### PR TITLE
Fix game initialization by passing ResolutionEngine

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -83,7 +83,12 @@ export class GameEngine {
         this.sceneEngine = new SceneEngine();
 
         // LogicManager 초기화
-        this.logicManager = new LogicManager(this.measureManager, this.sceneEngine);
+        // ResolutionEngine을 함께 전달하여 화면 크기 계산에 사용합니다.
+        this.logicManager = new LogicManager(
+            this.measureManager,
+            this.sceneEngine,
+            this.resolutionEngine
+        );
 
         // IdManager 및 AssetLoaderManager 초기화
         this.idManager = new IdManager();


### PR DESCRIPTION
## Summary
- ensure LogicManager receives the ResolutionEngine

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20` *(404 expected)*
- `curl http://localhost:8000/index.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6873f85c81188327a845497b2a7c108c