### PR TITLE
Implement scene and render management

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -11,41 +11,96 @@ import { SceneEngine } from './managers/SceneEngine.js';
 import { LogicManager } from './managers/LogicManager.js';
 import { UnitStatManager } from './managers/UnitStatManager.js';
 import { GameDataManager } from './managers/GameDataManager.js';
-import { GAME_EVENTS } from './constants.js'; // GAME_EVENTS 상수 임포트
+// GAME_EVENTS와 UI_STATES 상수를 사용합니다.
+import { GAME_EVENTS, UI_STATES } from './constants.js';
+
+// 장면과 전투에 필요한 다양한 매니저들을 불러옵니다.
+import { TerritoryManager } from './managers/TerritoryManager.js';
+import { BattleStageManager } from './managers/BattleStageManager.js';
+import { BattleGridManager } from './managers/BattleGridManager.js';
+import { BattleLogManager } from './managers/BattleLogManager.js';
+import { MercenaryPanelManager } from './managers/MercenaryPanelManager.js';
+import { CompatibilityManager } from './managers/CompatibilityManager.js';
 
 export class GameEngine {
     constructor(canvasId) {
         console.log("⚙️ GameEngine initializing...");
 
-        // 1. 핵심 동기 매니저 생성 (순서가 중요하지 않음)
+        // 1. 핵심 동기 매니저 생성
         this.eventManager = new EventManager();
         this.measureManager = new MeasureManager();
         this.ruleManager = new RuleManager();
+        this.sceneEngine = new SceneEngine();
+        this.logicManager = new LogicManager(this.measureManager, this.sceneEngine);
 
         // 2. 주요 엔진 생성
+        const mainCanvas = document.getElementById(canvasId);
         this.assetEngine = new AssetEngine(this.eventManager);
-        this.renderEngine = new RenderEngine(canvasId, this.eventManager, this.measureManager);
+        this.renderEngine = new RenderEngine(mainCanvas, this.eventManager, this.measureManager, this.logicManager, this.sceneEngine);
         this.battleEngine = new BattleEngine(this.eventManager, this.measureManager, this.assetEngine, this.renderEngine);
 
         // 3. 종속성을 가지는 나머지 매니저들 생성
         this.unitStatManager = new UnitStatManager(this.eventManager, this.battleEngine.getBattleSimulationManager());
-        this.sceneEngine = new SceneEngine();
-        this.logicManager = new LogicManager(this.measureManager, this.sceneEngine);
 
-        // ✨ UIEngine이 HeroManager 기능을 활용할 수 있도록 연결
-        this.renderEngine.uiEngine.heroManager = this.battleEngine.heroManager;
-        
+        // 장면 및 전투 관련 매니저들
+        this.territoryManager = new TerritoryManager();
+        this.battleStageManager = new BattleStageManager(this.assetEngine.getAssetLoaderManager());
+        this.battleGridManager = new BattleGridManager(this.measureManager, this.logicManager);
+
         // RenderEngine에 필요한 후반 종속성 주입
-        this.renderEngine.injectDependencies(this.battleEngine.getBattleSimulationManager(), this.logicManager, this.sceneEngine);
+        this.renderEngine.injectDependencies(this.getBattleSimulationManager(), this.battleEngine.heroManager);
 
         // 순환 참조 문제를 방지하기 위해 UIEngine 인스턴스를 ButtonEngine에도 전달
         this.renderEngine.inputManager.buttonEngine.uiEngine = this.renderEngine.uiEngine;
+
+        // MercenaryPanelManager를 생성하고 UIEngine과 연결
+        const battleSim = this.getBattleSimulationManager();
+        this.mercenaryPanelManager = new MercenaryPanelManager(this.measureManager, battleSim, this.logicManager, this.eventManager);
+        this.getUIEngine().mercenaryPanelManager = this.mercenaryPanelManager;
+
+        // BattleLogManager 생성 및 이벤트 리스너 설정
+        const combatLogCanvas = document.getElementById('combatLogCanvas');
+        if (combatLogCanvas) {
+            this.battleLogManager = new BattleLogManager(combatLogCanvas, this.eventManager, this.measureManager);
+            this.battleLogManager._setupEventListeners();
+        }
+
+        // 호환성 매니저 생성
+        this.compatibilityManager = new CompatibilityManager(
+            this.measureManager,
+            this.renderEngine.renderer,
+            this.getUIEngine(),
+            null,
+            this.logicManager,
+            this.mercenaryPanelManager,
+            this.battleLogManager
+        );
 
         // 4. 게임 루프 설정
         this.gameLoop = new GameLoop(this._update.bind(this), this._draw.bind(this));
 
         // 5. 비동기 초기화 실행
         this.initializeGame();
+    }
+
+    // SceneEngine과 RenderEngine의 레이어 구성을 설정합니다.
+    _registerScenesAndLayers() {
+        const battleSim = this.getBattleSimulationManager();
+
+        // 각 장면에 필요한 매니저들을 등록
+        this.sceneEngine.registerScene('territoryScene', [this.territoryManager]);
+        this.sceneEngine.registerScene('battleScene', [
+            this.battleStageManager,
+            this.battleGridManager,
+            battleSim,
+        ]);
+
+        const layerEngine = this.renderEngine.getLayerEngine();
+        layerEngine.registerLayer('sceneLayer', (ctx) => this.sceneEngine.draw(ctx), 10);
+        if (this.battleLogManager) {
+            layerEngine.registerLayer('battleLogLayer', (ctx) => this.battleLogManager.draw(ctx), 50);
+        }
+        layerEngine.registerLayer('uiLayer', (ctx) => this.getUIEngine().draw(ctx), 100);
     }
 
     /**
@@ -75,9 +130,22 @@ export class GameEngine {
             console.log("Initialization Step 3: Setting up battle units...");
             await this.battleEngine.setupBattle();
             console.log("✅ Battle setup complete.");
-            
-            // 단계 4 (예시): 다른 비동기 작업이 있다면 여기에 추가
-            // await this.loadSoundAssets();
+
+            // 단계 4: 장면과 레이어 등록
+            console.log("Initialization Step 4: Registering scenes and layers...");
+            this._registerScenesAndLayers();
+
+            // BATTLE_START 이벤트가 오면 전투 장면으로 전환합니다.
+            this.eventManager.subscribe(GAME_EVENTS.BATTLE_START, () => {
+                console.log("Battle Start event received by GameEngine. Changing scene...");
+                this.sceneEngine.setCurrentScene('battleScene');
+                this.getUIEngine().setUIState(UI_STATES.COMBAT_SCREEN);
+                this.battleEngine.startBattle();
+            });
+
+            this.sceneEngine.setCurrentScene('territoryScene');
+            this.getUIEngine().setUIState(UI_STATES.MAP_SCREEN);
+            console.log("✅ Scenes and layers registered. Initial scene set to 'territoryScene'.");
 
             console.log("--- ✅ All Initialization Steps Completed ---");
 
@@ -91,9 +159,11 @@ export class GameEngine {
     }
 
     _update(deltaTime) {
-        // 게임 루프는 초기화가 완료된 후 시작되므로 이 코드는 안전합니다.
-        this.battleEngine.update(deltaTime);
+        // 현재 활성화된 Scene의 매니저들만 업데이트하도록 구성
+        this.sceneEngine.update(deltaTime);
         this.renderEngine.update(deltaTime);
+        this.battleEngine.update(deltaTime);
+        this.getUIEngine().update(deltaTime);
     }
 
     _draw() {
@@ -117,4 +187,14 @@ export class GameEngine {
     getRenderEngine() { return this.renderEngine; }
     getBattleEngine() { return this.battleEngine; }
     getUnitStatManager() { return this.unitStatManager; }
+
+    // UIEngine 접근을 위한 편의 메서드
+    getUIEngine() {
+        return this.renderEngine.uiEngine;
+    }
+
+    // BattleSimulationManager 접근용 메서드
+    getBattleSimulationManager() {
+        return this.battleEngine.getBattleSimulationManager();
+    }
 }

--- a/js/engines/RenderEngine.js
+++ b/js/engines/RenderEngine.js
@@ -13,25 +13,39 @@ import { ButtonEngine } from '../managers/ButtonEngine.js';
  * 렌더링과 시각 효과를 담당하는 엔진입니다.
  */
 export class RenderEngine {
-    constructor(canvasId, eventManager, measureManager) {
-        console.log("\ud83c\udfa8 RenderEngine initialized.");
-        this.renderer = new Renderer(canvasId);
-        this.cameraEngine = new CameraEngine(this.renderer, null, null); // 논리 매니저는 추후 주입
+    // GameEngine에서 실제 Canvas DOM 요소를 전달받아 초기화합니다.
+    constructor(canvasElement, eventManager, measureManager, logicManager, sceneManager) {
+        console.log("🎨 RenderEngine initialized.");
+        // Renderer는 캔버스 ID를 사용해 초기화하므로 전달된 요소의 id를 사용합니다.
+        this.renderer = new Renderer(canvasElement.id);
+        // 생성 시점에 CameraEngine에 logicManager와 sceneManager를 주입합니다.
+        this.cameraEngine = new CameraEngine(this.renderer, logicManager, sceneManager);
         this.layerEngine = new LayerEngine(this.renderer, this.cameraEngine);
 
         this.particleEngine = new ParticleEngine(measureManager, this.cameraEngine, null);
         this.animationManager = new AnimationManager(measureManager, null, this.particleEngine);
 
         this.buttonEngine = new ButtonEngine();
+        // heroManager는 추후 GameEngine에서 주입됩니다.
         this.uiEngine = new UIEngine(this.renderer, measureManager, eventManager, null, this.buttonEngine, null);
         this.inputManager = new InputManager(this.renderer, this.cameraEngine, this.uiEngine, this.buttonEngine, eventManager);
+        // UIEngine과 ButtonEngine이 상호작용할 수 있도록 연결합니다.
+        this.inputManager.buttonEngine.uiEngine = this.uiEngine;
     }
 
-    injectDependencies(battleSim, logicManager, sceneManager) {
-        this.cameraEngine.logicManager = logicManager;
-        this.cameraEngine.sceneManager = sceneManager;
+    // 전투 관련 매니저와 영웅 매니저를 주입합니다.
+    injectDependencies(battleSim, heroManager) {
         this.particleEngine.battleSimulationManager = battleSim;
         this.animationManager.battleSimulationManager = battleSim;
+
+        if (this.uiEngine) {
+            this.uiEngine.heroManager = heroManager;
+        }
+
+        // BattleSimulationManager가 LogicManager에 접근할 수 있도록 주입합니다.
+        if (battleSim) {
+            battleSim.logicManager = this.cameraEngine.logicManager;
+        }
     }
 
     draw() {


### PR DESCRIPTION
## Summary
- expand GameEngine with additional managers and scene setup
- inject dependencies in RenderEngine and accept a canvas element
- update update loop to respect active scenes

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687885c3e9708327937dd4ca1067a8d4