### PR TITLE
Show unit names under sprites

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -605,6 +605,16 @@ body {
     text-align: center;
 }
 
+/* --- 전투 이름표 스타일 --- */
+.battle-name-tag {
+    font-size: 12px;
+    color: #fff;
+    border-radius: 2px;
+    padding: 2px 4px;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
 #formation-back-button {
     position: absolute;
     top: 20px;

--- a/src/game/utils/DOMEngine.js
+++ b/src/game/utils/DOMEngine.js
@@ -42,6 +42,20 @@ export class DOMEngine {
     }
 
     /**
+     * 임의의 DOM 요소를 게임 오브젝트와 동기화합니다.
+     * @param {Phaser.GameObjects.GameObject} target - DOM 요소가 따라다닐 게임 오브젝트
+     * @param {HTMLElement} element - 동기화할 DOM 요소
+     * @returns {HTMLElement} 동기화된 DOM 요소
+     */
+    syncElement(target, element) {
+        element.style.position = 'absolute';
+        this.uiContainer.appendChild(element);
+        const sync = new DomSync(this.scene, target, element);
+        this.activeSyncs.push(sync);
+        return element;
+    }
+
+    /**
      * 툴팁을 표시합니다.
      * @param {number} x - 툴팁의 기준 x 좌표
      * @param {number} y - 툴팁의 기준 y 좌표

--- a/src/game/utils/FormationEngine.js
+++ b/src/game/utils/FormationEngine.js
@@ -26,7 +26,8 @@ class FormationEngine {
      * @param {Array<object>} units 유닛 데이터 배열
      */
     applyFormation(scene, units) {
-        if (!this.grid) return;
+        if (!this.grid) return [];
+        const sprites = [];
         units.forEach(unit => {
             const index = this.getPosition(unit.uniqueId);
             const cell = this.grid.gridCells[index];
@@ -44,7 +45,9 @@ class FormationEngine {
             } else {
                 sprite.setDisplaySize(cell.width, cell.height);
             }
+            sprites.push(sprite);
         });
+        return sprites;
     }
 
     /**
@@ -54,8 +57,9 @@ class FormationEngine {
      * @param {number} startCol 적군 배치가 시작될 최소 열
      */
     placeMonsters(scene, monsters, startCol = 8) {
-        if (!this.grid) return;
+        if (!this.grid) return [];
         const cells = this.grid.gridCells.filter(c => c.col >= startCol && !c.isOccupied);
+        const sprites = [];
         monsters.forEach(mon => {
             const cell = cells.splice(Math.floor(Math.random() * cells.length), 1)[0];
             if (!cell) return;
@@ -73,7 +77,9 @@ class FormationEngine {
             } else {
                 sprite.setDisplaySize(cell.width, cell.height);
             }
+            sprites.push(sprite);
         });
+        return sprites;
     }
 }
 

--- a/src/game/utils/NameLabelFactory.js
+++ b/src/game/utils/NameLabelFactory.js
@@ -1,0 +1,22 @@
+export function createNameLabelCanvas(text = '', bgColor = 'rgba(0,0,0,0.7)') {
+    const fontSize = 12;
+    const scale = 2;
+    const padding = 2;
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    ctx.font = `${fontSize * scale}px sans-serif`;
+    const textWidth = ctx.measureText(text).width;
+    canvas.width = textWidth + padding * 2 * scale;
+    canvas.height = fontSize * scale + padding * 2 * scale;
+    ctx.fillStyle = bgColor;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = '#ffffff';
+    ctx.textBaseline = 'top';
+    ctx.font = `${fontSize * scale}px sans-serif`;
+    ctx.fillText(text, padding * scale, padding * scale);
+    canvas.style.width = canvas.width / scale + 'px';
+    canvas.style.height = canvas.height / scale + 'px';
+    canvas.style.pointerEvents = 'none';
+    canvas.className = 'battle-name-tag';
+    return canvas;
+}


### PR DESCRIPTION
## Summary
- add `syncElement` helper to DOMEngine for general DOM/GameObject pairing
- implement crisp name label creation via `NameLabelFactory`
- return created sprites from FormationEngine
- overlay ally and enemy nameplates in battle scene
- style `.battle-name-tag` for nameplates

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687dcb3c14588327bc18179aaf3d2798