### PR TITLE
Add debug coordinate manager and use in battle scene

### DIFF
--- a/src/game/debug/DebugCoordinateManager.js
+++ b/src/game/debug/DebugCoordinateManager.js
@@ -1,0 +1,29 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+class DebugCoordinateManager {
+    constructor() {
+        this.name = 'DebugCoordinate';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 유닛 이미지와 이름표의 좌표 정보를 로그로 남깁니다.
+     * @param {string} unitName - 유닛의 이름
+     * @param {object} imageCoord - 이미지의 x, y 좌표 {x, y}
+     * @param {object} labelCoord - 이름표의 x, y 좌표 {x, y}
+     */
+    logCoordinates(unitName, imageCoord, labelCoord) {
+        console.groupCollapsed(
+            `%c[${this.name}]`,
+            `color: #f59e0b; font-weight: bold;`,
+            `'${unitName}' 좌표 정보`
+        );
+
+        debugLogEngine.log(this.name, `유닛 이미지 좌표: x=${imageCoord.x.toFixed(2)}, y=${imageCoord.y.toFixed(2)}`);
+        debugLogEngine.log(this.name, `이름표 실제 좌표: x=${labelCoord.x.toFixed(2)}, y=${labelCoord.y.toFixed(2)}`);
+
+        console.groupEnd();
+    }
+}
+
+export const debugCoordinateManager = new DebugCoordinateManager();

--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -8,6 +8,7 @@ import { monsterEngine } from '../utils/MonsterEngine.js';
 import { getMonsterBase } from '../data/monster.js';
 import { DOMEngine } from '../utils/DOMEngine.js';
 import { createNameLabelCanvas } from '../utils/NameLabelFactory.js';
+import { debugCoordinateManager } from '../debug/DebugCoordinateManager.js';
 
 export class CursedForestBattleScene extends Scene {
     constructor() {
@@ -46,20 +47,62 @@ export class CursedForestBattleScene extends Scene {
         // 이름표 생성
         allySprites.forEach((sprite, idx) => {
             const unit = partyUnits[idx];
-            const label = createNameLabelCanvas(unit.instanceName || unit.name, 'rgba(0,0,255,0.7)');
-            const width = parseFloat(label.style.width) || 0;
-            label.style.marginLeft = -(width / 2) + 'px';
-            label.style.marginTop = sprite.displayHeight / 2 + 'px';
-            this.domEngine.syncElement(sprite, label);
+            const label = createNameLabelCanvas(
+                unit.instanceName || unit.name,
+                'rgba(0,0,255,0.7)'
+            );
+
+            // 이름표 위치 보정 및 디버그 로그 추가
+            const labelWidth = parseFloat(label.style.width) || 0;
+            const labelHeight = parseFloat(label.style.height) || 0;
+            label.style.marginLeft = `-${labelWidth / 2}px`;
+            label.style.marginTop = `${sprite.displayHeight / 2 - labelHeight}px`;
+
+            const syncedElement = this.domEngine.syncElement(sprite, label);
+
+            // 디버그: 좌표 기록
+            const imageCoord = { x: sprite.x, y: sprite.y };
+            const labelRect = syncedElement.getBoundingClientRect();
+            const gameRect = this.sys.game.canvas.getBoundingClientRect();
+            const labelCoord = {
+                x: labelRect.left - gameRect.left,
+                y: labelRect.top - gameRect.top
+            };
+            debugCoordinateManager.logCoordinates(
+                unit.instanceName || unit.name,
+                imageCoord,
+                labelCoord
+            );
         });
 
         enemySprites.forEach((sprite, idx) => {
             const mon = monsters[idx];
-            const label = createNameLabelCanvas(mon.instanceName || mon.name, 'rgba(255,0,0,0.7)');
-            const width = parseFloat(label.style.width) || 0;
-            label.style.marginLeft = -(width / 2) + 'px';
-            label.style.marginTop = sprite.displayHeight / 2 + 'px';
-            this.domEngine.syncElement(sprite, label);
+            const label = createNameLabelCanvas(
+                mon.instanceName || mon.name,
+                'rgba(255,0,0,0.7)'
+            );
+
+            // 이름표 위치 보정 및 디버그 로그 추가
+            const labelWidth = parseFloat(label.style.width) || 0;
+            const labelHeight = parseFloat(label.style.height) || 0;
+            label.style.marginLeft = `-${labelWidth / 2}px`;
+            label.style.marginTop = `${sprite.displayHeight / 2 - labelHeight}px`;
+
+            const syncedElement = this.domEngine.syncElement(sprite, label);
+
+            // 디버그: 좌표 기록
+            const imageCoord = { x: sprite.x, y: sprite.y };
+            const labelRect = syncedElement.getBoundingClientRect();
+            const gameRect = this.sys.game.canvas.getBoundingClientRect();
+            const labelCoord = {
+                x: labelRect.left - gameRect.left,
+                y: labelRect.top - gameRect.top
+            };
+            debugCoordinateManager.logCoordinates(
+                mon.instanceName || mon.name,
+                imageCoord,
+                labelCoord
+            );
         });
 
         this.events.on('shutdown', () => {


### PR DESCRIPTION
## Summary
- add `DebugCoordinateManager` for logging name label coordinates
- display name labels at corrected positions in the Cursed Forest scene
- log unit image and label coordinates on creation

## Testing
- `python3 -m http.server 8000 &> /tmp/server.log &`
- `curl http://localhost:8000/debug.html | head -n 20`
- `kill %1`


------
https://chatgpt.com/codex/tasks/task_e_687decf62ac48327b715f58aff674af3