### PR TITLE
Implement BattleSimulatorEngine and refactor battle scene

### DIFF
--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -1,14 +1,12 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { BattleStageManager } from '../utils/BattleStageManager.js';
 import { CameraControlEngine } from '../utils/CameraControlEngine.js';
-import { formationEngine } from '../utils/FormationEngine.js';
 import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 import { partyEngine } from '../utils/PartyEngine.js';
 import { monsterEngine } from '../utils/MonsterEngine.js';
 import { getMonsterBase } from '../data/monster.js';
 import { DOMEngine } from '../utils/DOMEngine.js';
-import { createNameLabelCanvas } from '../utils/NameLabelFactory.js';
-import { debugCoordinateManager } from '../debug/DebugCoordinateManager.js';
+import { BattleSimulatorEngine } from '../utils/BattleSimulatorEngine.js';
 
 export class CursedForestBattleScene extends Scene {
     constructor() {
@@ -16,6 +14,8 @@ export class CursedForestBattleScene extends Scene {
         this.stageManager = null;
         this.cameraControl = null;
         this.domEngine = null;
+        // BattleSimulatorEngine 인스턴스를 보관할 속성
+        this.battleSimulator = null;
     }
 
     create() {
@@ -30,80 +30,22 @@ export class CursedForestBattleScene extends Scene {
         this.cameraControl = new CameraControlEngine(this);
         this.domEngine = new DOMEngine(this);
 
-        // 아군 배치
+        // BattleSimulatorEngine 사용
+        this.battleSimulator = new BattleSimulatorEngine(this, this.domEngine);
+
+        // 파티 유닛과 몬스터 데이터를 준비합니다.
         const partyIds = partyEngine.getPartyMembers().filter(id => id !== undefined);
         const allMercs = mercenaryEngine.getAllAlliedMercenaries();
         const partyUnits = allMercs.filter(m => partyIds.includes(m.uniqueId));
-        const allySprites = formationEngine.applyFormation(this, partyUnits);
 
-        // 적 몬스터 생성 및 배치
         const monsters = [];
         const zombieBase = getMonsterBase('zombie');
         for (let i = 0; i < 5; i++) {
             monsters.push(monsterEngine.spawnMonster(zombieBase, 'enemy'));
         }
-        const enemySprites = formationEngine.placeMonsters(this, monsters, 8);
 
-        // 이름표 생성
-        allySprites.forEach((sprite, idx) => {
-            const unit = partyUnits[idx];
-            const label = createNameLabelCanvas(
-                unit.instanceName || unit.name,
-                'rgba(0,0,255,0.7)'
-            );
-
-            // 이름표 위치 보정 및 디버그 로그 추가
-            const labelWidth = parseFloat(label.style.width) || 0;
-            const labelHeight = parseFloat(label.style.height) || 0;
-            label.style.marginLeft = `-${labelWidth / 2}px`;
-            label.style.marginTop = `${sprite.displayHeight / 2 - labelHeight}px`;
-
-            const syncedElement = this.domEngine.syncElement(sprite, label);
-
-            // 디버그: 좌표 기록
-            const imageCoord = { x: sprite.x, y: sprite.y };
-            const labelRect = syncedElement.getBoundingClientRect();
-            const gameRect = this.sys.game.canvas.getBoundingClientRect();
-            const labelCoord = {
-                x: labelRect.left - gameRect.left,
-                y: labelRect.top - gameRect.top
-            };
-            debugCoordinateManager.logCoordinates(
-                unit.instanceName || unit.name,
-                imageCoord,
-                labelCoord
-            );
-        });
-
-        enemySprites.forEach((sprite, idx) => {
-            const mon = monsters[idx];
-            const label = createNameLabelCanvas(
-                mon.instanceName || mon.name,
-                'rgba(255,0,0,0.7)'
-            );
-
-            // 이름표 위치 보정 및 디버그 로그 추가
-            const labelWidth = parseFloat(label.style.width) || 0;
-            const labelHeight = parseFloat(label.style.height) || 0;
-            label.style.marginLeft = `-${labelWidth / 2}px`;
-            label.style.marginTop = `${sprite.displayHeight / 2 - labelHeight}px`;
-
-            const syncedElement = this.domEngine.syncElement(sprite, label);
-
-            // 디버그: 좌표 기록
-            const imageCoord = { x: sprite.x, y: sprite.y };
-            const labelRect = syncedElement.getBoundingClientRect();
-            const gameRect = this.sys.game.canvas.getBoundingClientRect();
-            const labelCoord = {
-                x: labelRect.left - gameRect.left,
-                y: labelRect.top - gameRect.top
-            };
-            debugCoordinateManager.logCoordinates(
-                mon.instanceName || mon.name,
-                imageCoord,
-                labelCoord
-            );
-        });
+        // BattleSimulatorEngine을 통해 전투를 시작합니다.
+        this.battleSimulator.start(partyUnits, monsters);
 
         this.events.on('shutdown', () => {
             ['dungeon-container', 'territory-container'].forEach(id => {
@@ -119,6 +61,9 @@ export class CursedForestBattleScene extends Scene {
             }
             if (this.domEngine) {
                 this.domEngine.shutdown();
+            }
+            if (this.battleSimulator) {
+                this.battleSimulator.shutdown();
             }
         });
     }

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -1,0 +1,78 @@
+import { formationEngine } from './FormationEngine.js';
+import { createNameLabelCanvas } from './NameLabelFactory.js';
+import { debugCoordinateManager } from '../debug/DebugCoordinateManager.js';
+
+/**
+ * 전투의 전체 과정을 시뮬레이션하고 관리하는 엔진입니다.
+ * 이 엔진은 특정 씬에 종속되지 않으며, 어떤 씬에서든 전투를 시작할 수 있습니다.
+ */
+export class BattleSimulatorEngine {
+    /**
+     * @param {Phaser.Scene} scene - 전투가 벌어질 Phaser 씬
+     * @param {DOMEngine} domEngine - 이름표 등 DOM 요소를 관리할 DOM 엔진
+     */
+    constructor(scene, domEngine) {
+        this.scene = scene;
+        this.domEngine = domEngine;
+        this.allySprites = [];
+        this.enemySprites = [];
+    }
+
+    /**
+     * 지정된 아군 및 적군 유닛으로 전투를 시작합니다.
+     * @param {Array<object>} allies - 아군 유닛 데이터 배열
+     * @param {Array<object>} enemies - 적군 유닛 데이터 배열
+     */
+    start(allies, enemies) {
+        // 1. 아군을 진형에 맞춰 배치합니다.
+        this.allySprites = formationEngine.applyFormation(this.scene, allies);
+
+        // 2. 적군을 무작위 위치에 배치합니다.
+        this.enemySprites = formationEngine.placeMonsters(this.scene, enemies, 8); // 8번 열부터 적군 지역
+
+        // 3. 모든 유닛에 대해 이름표를 생성하고 디버그 로그를 기록합니다.
+        this._createNameLabels(this.allySprites, allies, 'rgba(0,0,255,0.7)');
+        this._createNameLabels(this.enemySprites, enemies, 'rgba(255,0,0,0.7)');
+    }
+
+    /**
+     * 유닛 스프라이트에 이름표를 생성하고 부착합니다.
+     * @private
+     * @param {Array<Phaser.GameObjects.Image>} sprites - 대상 스프라이트 배열
+     * @param {Array<object>} units - 유닛 데이터 배열
+     * @param {string} color - 이름표 배경색
+     */
+    _createNameLabels(sprites, units, color) {
+        sprites.forEach((sprite, idx) => {
+            const unit = units[idx];
+            if (!unit) return;
+
+            const label = createNameLabelCanvas(unit.instanceName || unit.name, color);
+
+            const labelWidth = parseFloat(label.style.width) || 0;
+            const labelHeight = parseFloat(label.style.height) || 0;
+            label.style.marginLeft = `-${labelWidth / 2}px`;
+            label.style.marginTop = `${sprite.displayHeight / 2 - labelHeight}px`;
+
+            const syncedElement = this.domEngine.syncElement(sprite, label);
+
+            // 디버그 좌표 기록
+            const imageCoord = { x: sprite.x, y: sprite.y };
+            const labelRect = syncedElement.getBoundingClientRect();
+            const gameRect = this.scene.sys.game.canvas.getBoundingClientRect();
+            const labelCoord = {
+                x: labelRect.left - gameRect.left,
+                y: labelRect.top - gameRect.top,
+            };
+            debugCoordinateManager.logCoordinates(unit.instanceName || unit.name, imageCoord, labelCoord);
+        });
+    }
+
+    /**
+     * 전투와 관련된 모든 리소스를 정리합니다.
+     */
+    shutdown() {
+        // 나중에 전투 관련 객체들이 추가되면 여기서 정리합니다.
+        console.log('BattleSimulatorEngine이 종료되었습니다.');
+    }
+}


### PR DESCRIPTION
## Summary
- add `BattleSimulatorEngine` to centralize unit setup and name tag creation
- refactor `CursedForestBattleScene` to use the new simulator and clean up imports

## Testing
- `python3 -m http.server 8000 &> /tmp/http.log &`
- `curl http://localhost:8000/debug.html | head -n 20`
- `kill %1`


------
https://chatgpt.com/codex/tasks/task_e_687df05b65d8832791d8c4f677da8593