### PR TITLE
Update name label logic

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -46,8 +46,9 @@ export class BattleSimulatorEngine {
      * @param {string} color - 이름표 배경색
      */
     _createNameLabels(sprites, units, color) {
-        sprites.forEach((sprite, idx) => {
-            const unit = units[idx];
+        sprites.forEach(sprite => {
+            const unitId = sprite.getData('unitId');
+            const unit = units.find(u => u.uniqueId === unitId);
             if (!unit) return;
 
             this.textEngine.createLabel(sprite, unit.instanceName || unit.name, color);


### PR DESCRIPTION
## Summary
- ensure `BattleSimulatorEngine` uses sprite's `unitId` data when creating name labels

## Testing
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687df63bb7988327933996c30eca59c1