### PR TITLE
Add behavior tree AI foundation

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -1,0 +1,50 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * 게임 내 모든 AI 유닛을 관리하고, 각 유닛의 행동 트리를 실행합니다.
+ */
+class AIManager {
+    constructor() {
+        // key: unit.uniqueId, value: { instance: unit, behaviorTree: tree }
+        this.unitData = new Map();
+        debugLogEngine.log('AIManager', 'AI 매니저가 초기화되었습니다.');
+    }
+
+    /**
+     * 새로운 AI 유닛과 해당 유닛이 사용할 행동 트리를 등록합니다.
+     * @param {object} unitInstance - AI에 의해 제어될 유닛
+     * @param {BehaviorTree} behaviorTree - 이 유닛이 사용할 BehaviorTree 인스턴스
+     */
+    registerUnit(unitInstance, behaviorTree) {
+        if (!unitInstance || !unitInstance.uniqueId || this.unitData.has(unitInstance.uniqueId)) {
+            debugLogEngine.warn('AIManager', '이미 등록되었거나 유효하지 않은 유닛입니다.');
+            return;
+        }
+
+        this.unitData.set(unitInstance.uniqueId, {
+            instance: unitInstance,
+            behaviorTree: behaviorTree,
+        });
+        debugLogEngine.log('AIManager', `유닛 ID ${unitInstance.uniqueId} (${unitInstance.instanceName}) 등록 완료.`);
+    }
+
+    /**
+     * 특정 유닛의 턴을 실행합니다.
+     * @param {object} unit - 턴을 실행할 유닛
+     * @param {Array<object>} allUnits - 전장의 모든 유닛
+     * @param {Array<object>} enemyUnits - 해당 유닛의 적 목록
+     */
+    async executeTurn(unit, allUnits, enemyUnits) {
+        const data = this.unitData.get(unit.uniqueId);
+        if (!data) return;
+
+        console.group(`[AIManager] --- ${data.instance.instanceName} (ID: ${unit.uniqueId}) 턴 시작 ---`);
+
+        await data.behaviorTree.execute(unit, allUnits, enemyUnits);
+
+        console.groupEnd();
+    }
+}
+
+// 싱글턴으로 관리
+export const aiManager = new AIManager();

--- a/src/ai/BehaviorTree.js
+++ b/src/ai/BehaviorTree.js
@@ -1,0 +1,33 @@
+import Blackboard from './Blackboard.js';
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * 행동 트리와 블랙보드를 함께 캡슐화하는 클래스입니다.
+ */
+class BehaviorTree {
+    /**
+     * @param {Node} rootNode - 행동 트리의 최상위 루트 노드
+     */
+    constructor(rootNode) {
+        this.root = rootNode;
+        this.blackboard = new Blackboard();
+        debugLogEngine.log('BehaviorTree', '새로운 행동 트리가 생성되었습니다.');
+    }
+
+    /**
+     * 이 행동 트리의 한 턴을 실행합니다.
+     * @param {object} unit - 이 트리를 실행하는 유닛
+     * @param {Array<object>} allUnits - 전장에 있는 모든 유닛 목록
+     * @param {Array<object>} enemyUnits - 적 유닛 목록
+     */
+    async execute(unit, allUnits, enemyUnits) {
+        // 매 턴 시작 시, 블랙보드에 최신 전장 정보를 업데이트합니다.
+        this.blackboard.set('allUnits', allUnits);
+        this.blackboard.set('enemyUnits', enemyUnits);
+
+        // 루트 노드부터 평가를 시작합니다.
+        await this.root.evaluate(unit, this.blackboard);
+    }
+}
+
+export default BehaviorTree;

--- a/src/ai/Blackboard.js
+++ b/src/ai/Blackboard.js
@@ -1,0 +1,51 @@
+/**
+ * AI 유닛의 의사결정에 필요한 모든 데이터를 저장하고 관리하는 중앙 데이터 저장소입니다.
+ * 각 AI 유닛은 자신만의 블랙보드 인스턴스를 가집니다.
+ */
+class Blackboard {
+    constructor() {
+        this.data = new Map();
+        this.initializeDataKeys();
+    }
+
+    /**
+     * 블랙보드에서 사용할 모든 데이터 키를 초기 상태로 설정합니다.
+     */
+    initializeDataKeys() {
+        // --- 🎯 타겟팅 및 위치 관련 정보 ---
+        this.set('nearestEnemy', null);
+        this.set('lowestHealthEnemy', null);
+        this.set('currentTargetUnit', null);
+        this.set('optimalAttackPosition', null);
+        this.set('safestRetreatPosition', null);
+        this.set('enemiesInAttackRange', []);
+
+        // --- ⚔️ 전술적 상황 판단 정보 ---
+        this.set('isThreatened', false);
+        this.set('squadAdvantage', 0);
+        this.set('enemyHealerUnit', null);
+
+        // --- 🤖 AI 자신의 상태 정보 ---
+        this.set('canUseSkill_1', false);
+        this.set('canUseSkill_2', false);
+        this.set('canUseSkill_3', false);
+
+        // --- 이동 및 공격 관련 신규 정보 ---
+        this.set('movementPath', null);
+        this.set('isTargetInAttackRange', false);
+    }
+
+    set(key, value) {
+        this.data.set(key, value);
+    }
+
+    get(key) {
+        return this.data.get(key);
+    }
+
+    has(key) {
+        return this.data.has(key);
+    }
+}
+
+export default Blackboard;

--- a/src/ai/nodes/Node.js
+++ b/src/ai/nodes/Node.js
@@ -1,0 +1,25 @@
+/**
+ * 모든 노드 상태를 정의하는 열거형(Enum) 객체입니다.
+ */
+export const NodeState = Object.freeze({
+    SUCCESS: 'SUCCESS', // 행동 성공
+    FAILURE: 'FAILURE', // 행동 실패
+    RUNNING: 'RUNNING', // 행동 진행 중 (예: 이동 중)
+});
+
+/**
+ * 행동 트리의 모든 노드의 기반이 되는 추상 클래스입니다.
+ */
+class Node {
+    /**
+     * 이 노드의 로직을 평가하고 실행합니다.
+     * @param {object} unit - 이 트리를 실행하는 유닛의 인스턴스
+     * @param {Blackboard} blackboard - 해당 유닛의 블랙보드
+     * @returns {Promise<NodeState>} - 행동의 결과 상태
+     */
+    async evaluate(unit, blackboard) {
+        throw new Error("evaluate() 메서드는 반드시 자식 클래스에서 구현되어야 합니다.");
+    }
+}
+
+export default Node;

--- a/src/ai/nodes/SelectorNode.js
+++ b/src/ai/nodes/SelectorNode.js
@@ -1,0 +1,23 @@
+import Node, { NodeState } from './Node.js';
+
+/**
+ * 자식 노드 중 하나라도 성공할 때까지 왼쪽에서 오른쪽으로 실행합니다. (OR 논리)
+ */
+class SelectorNode extends Node {
+    constructor(children) {
+        super();
+        this.children = children;
+    }
+
+    async evaluate(unit, blackboard) {
+        for (const child of this.children) {
+            const result = await child.evaluate(unit, blackboard);
+            if (result !== NodeState.FAILURE) {
+                return result; // 하나라도 실패하지 않았다면(성공 또는 실행 중) 즉시 반환
+            }
+        }
+        return NodeState.FAILURE; // 모두 실패했을 경우에만 실패 반환
+    }
+}
+
+export default SelectorNode;

--- a/src/ai/nodes/SequenceNode.js
+++ b/src/ai/nodes/SequenceNode.js
@@ -1,0 +1,23 @@
+import Node, { NodeState } from './Node.js';
+
+/**
+ * 모든 자식 노드가 성공해야만 성공합니다. 하나라도 실패하면 즉시 실패합니다. (AND 논리)
+ */
+class SequenceNode extends Node {
+    constructor(children) {
+        super();
+        this.children = children;
+    }
+
+    async evaluate(unit, blackboard) {
+        for (const child of this.children) {
+            const result = await child.evaluate(unit, blackboard);
+            if (result !== NodeState.SUCCESS) {
+                return result; // 하나라도 성공하지 못하면 즉시 해당 상태를 반환
+            }
+        }
+        return NodeState.SUCCESS; // 모두 성공했을 경우에만 성공 반환
+    }
+}
+
+export default SequenceNode;


### PR DESCRIPTION
## Summary
- implement `Blackboard` for AI data storage
- add core behavior tree nodes
- introduce `BehaviorTree` wrapper for root node and blackboard
- implement `AIManager` for running behavior trees

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687f7c8c652c8327baf69e7156876864