### PR TITLE
Add debugging and utility managers for combat and movement

### DIFF
--- a/src/game/debug/DebugAIManager.js
+++ b/src/game/debug/DebugAIManager.js
@@ -1,0 +1,43 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * AI의 의사결정 과정을 추적하고 로그로 남기는 디버그 매니저
+ */
+class DebugAIManager {
+    constructor() {
+        this.name = 'DebugAI';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 특정 노드의 평가 시작을 로그로 남깁니다.
+     * @param {object} node - 평가를 시작하는 노드
+     * @param {object} unit - 해당 AI 유닛
+     */
+    logNodeEvaluation(node, unit) {
+        const nodeName = node.constructor?.name || 'Unknown';
+        console.groupCollapsed(`%c[${this.name}]`, `color: #f59e0b; font-weight: bold;`, `${unit.instanceName} - 노드 평가: ${nodeName}`);
+    }
+
+    /**
+     * 노드 평가 결과를 로그로 남깁니다.
+     * @param {string} result - 노드의 평가 결과 (SUCCESS, FAILURE, RUNNING)
+     */
+    logNodeResult(result) {
+        const color = result === 'SUCCESS' ? '#22c55e' : (result === 'FAILURE' ? '#ef4444' : '#3b82f6');
+        debugLogEngine.log(this.name, `%c결과: ${result}`, `color: ${color}; font-weight: bold;`);
+        console.groupEnd();
+    }
+
+    /**
+     * 블랙보드에 저장된 주요 정보를 로그로 남깁니다.
+     * @param {object} blackboard
+     */
+    logBlackboardState(blackboard) {
+        const target = blackboard.get('currentTargetUnit');
+        const targetName = target ? target.instanceName : '없음';
+        debugLogEngine.log(this.name, `현재 타겟: ${targetName}, 사거리 내 존재: ${blackboard.get('isTargetInAttackRange')}`);
+    }
+}
+
+export const debugAIManager = new DebugAIManager();

--- a/src/game/debug/DebugCombatCalculationManager.js
+++ b/src/game/debug/DebugCombatCalculationManager.js
@@ -1,0 +1,37 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * 전투 데미지 계산의 모든 단계를 로그로 기록하는 디버그 매니저
+ */
+class DebugCombatCalculationManager {
+    constructor() {
+        this.name = 'DebugCombatCalc';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 공격의 상세 계산식을 콘솔에 그룹화하여 출력합니다.
+     * @param {object} attacker - 공격자 정보
+     * @param {object} defender - 방어자 정보
+     * @param {number} baseDamage - 기본 데미지
+     * @param {number} finalDamage - 최종 적용 데미지
+     */
+    logAttackCalculation(attacker, defender, baseDamage, finalDamage) {
+        console.groupCollapsed(`%c[${this.name}]`, `color: #d946ef; font-weight: bold;`, `${attacker.instanceName} -> ${defender.instanceName} 피해량 계산`);
+        
+        debugLogEngine.log(this.name, `--- 공격자: ${attacker.instanceName} ---`);
+        debugLogEngine.log(this.name, `기본 공격력: ${attacker.finalStats.physicalAttack}`);
+
+        debugLogEngine.log(this.name, `--- 방어자: ${defender.instanceName} ---`);
+        debugLogEngine.log(this.name, `기본 방어력: ${defender.finalStats.physicalDefense}`);
+        
+        debugLogEngine.log(this.name, `--- 최종 계산 ---`);
+        debugLogEngine.log(this.name, `공식: (기본 공격력 - 기본 방어력), 최소 1`);
+        debugLogEngine.log(this.name, `계산: ${baseDamage} - ${defender.finalStats.physicalDefense} = ${baseDamage - defender.finalStats.physicalDefense}`);
+        debugLogEngine.log(this.name, `최종 피해량: ${finalDamage}`);
+        
+        console.groupEnd();
+    }
+}
+
+export const debugCombatCalculationManager = new DebugCombatCalculationManager();

--- a/src/game/utils/PathfinderEngine.js
+++ b/src/game/utils/PathfinderEngine.js
@@ -1,0 +1,42 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 유닛의 이동 경로를 계산하는 엔진 (현재는 단순화된 버전)
+ */
+class PathfinderEngine {
+    constructor() {
+        debugLogEngine.log('PathfinderEngine', '경로 탐색 엔진이 초기화되었습니다.');
+    }
+
+    /**
+     * 시작 좌표에서 목표 좌표까지의 경로를 찾습니다.
+     * (A* 알고리즘 대신, 장애물을 무시하는 직선 경로를 반환하는 단순화된 버전입니다.)
+     * @param {object} startPos - 시작 그리드 좌표 { col, row }
+     * @param {object} endPos - 목표 그리드 좌표 { col, row }
+     * @returns {Array<object>|null} - 경로 좌표 배열 또는 null
+     */
+    findPath(startPos, endPos) {
+        const path = [];
+        let currentPos = { ...startPos };
+
+        while (currentPos.col !== endPos.col || currentPos.row !== endPos.row) {
+            const dx = endPos.col - currentPos.col;
+            const dy = endPos.row - currentPos.row;
+
+            if (Math.abs(dx) > Math.abs(dy)) {
+                currentPos.col += Math.sign(dx);
+            } else {
+                currentPos.row += Math.sign(dy);
+            }
+            path.push({ ...currentPos });
+        }
+        
+        if (path.length > 0) {
+            debugLogEngine.log('PathfinderEngine', `경로 탐색 완료: ${path.length}개의 이동 경로 발견.`);
+            return path;
+        }
+        return null;
+    }
+}
+
+export const pathfinderEngine = new PathfinderEngine();

--- a/src/game/utils/TerminationManager.js
+++ b/src/game/utils/TerminationManager.js
@@ -1,0 +1,35 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 유닛 사망 등 특정 로직의 '종료'와 관련된 후처리를 담당하는 매니저
+ */
+class TerminationManager {
+    constructor(scene) {
+        this.scene = scene;
+        debugLogEngine.log('TerminationManager', '종료 매니저가 초기화되었습니다.');
+    }
+
+    /**
+     * 유닛의 사망 처리를 수행합니다.
+     * @param {object} deadUnit - 사망한 유닛
+     */
+    handleUnitDeath(deadUnit) {
+        if (!deadUnit || !deadUnit.sprite) return;
+
+        debugLogEngine.log('TerminationManager', `${deadUnit.instanceName}의 사망 처리를 시작합니다.`);
+        
+        // 유닛 스프라이트를 서서히 투명하게 만들어 사라지게 합니다.
+        this.scene.tweens.add({
+            targets: deadUnit.sprite,
+            alpha: 0,
+            duration: 1000,
+            ease: 'Power2'
+        });
+
+        // 바인딩된 다른 요소들(체력바, 그림자 등)도 함께 사라지게 합니다.
+        // (BindingManager에서 active가 false인 주 오브젝트의 요소들을 숨기도록 수정 필요)
+    }
+}
+
+// 이 엔진은 Scene에 종속적이므로, new 키워드를 통해 생성하여 사용합니다.
+export { TerminationManager };

--- a/src/game/utils/TurnOrderManager.js
+++ b/src/game/utils/TurnOrderManager.js
@@ -1,0 +1,40 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 유닛의 스탯에 따라 전투의 턴 순서를 결정하고 관리하는 매니저
+ */
+class TurnOrderManager {
+    constructor() {
+        debugLogEngine.log('TurnOrderManager', '턴 순서 매니저가 초기화되었습니다.');
+    }
+
+    /**
+     * 유닛 목록을 받아 무게(weight)가 낮은 순서대로 정렬하여 턴 큐를 생성합니다.
+     * @param {Array<object>} allUnits - 전투에 참여하는 모든 유닛 목록
+     * @returns {Array<object>} - 턴 순서에 따라 정렬된 유닛 배열
+     */
+    createTurnQueue(allUnits) {
+        // 임의의 무게(weight)를 각 유닛의 finalStats에 추가합니다.
+        // 실제 게임에서는 StatEngine이 이 값을 계산해야 합니다.
+        allUnits.forEach(unit => {
+            if (!unit.finalStats) unit.finalStats = {};
+            // 전사는 10, 좀비는 15로 설정하여 전사가 항상 선공하도록 합니다.
+            if (unit.name === '전사') {
+                unit.finalStats.weight = 10;
+            } else if (unit.name === '좀비') {
+                unit.finalStats.weight = 15;
+            } else {
+                unit.finalStats.weight = 20; // 기타
+            }
+        });
+
+        const turnQueue = [...allUnits].sort((a, b) => a.finalStats.weight - b.finalStats.weight);
+        
+        const turnOrderNames = turnQueue.map(u => `${u.instanceName}(w:${u.finalStats.weight})`).join(' -> ');
+        debugLogEngine.log('TurnOrderManager', `턴 순서 결정: ${turnOrderNames}`);
+
+        return turnQueue;
+    }
+}
+
+export const turnOrderManager = new TurnOrderManager();

--- a/src/game/utils/VFXManager.js
+++ b/src/game/utils/VFXManager.js
@@ -47,6 +47,55 @@ export class VFXManager {
     }
 
     /**
+     * 지정된 위치에 핏방울 파티클 효과를 생성합니다.
+     * @param {number} x - 파티클이 생성될 x 좌표
+     * @param {number} y - 파티클이 생성될 y 좌표
+     */
+    createBloodSplatter(x, y) {
+        const textureKey = 'red-pixel';
+        if (!this.scene.textures.exists(textureKey)) {
+            const g = this.scene.add.graphics();
+            g.fillStyle(0xff0000, 1);
+            g.fillRect(0, 0, 2, 2);
+            g.generateTexture(textureKey, 2, 2);
+            g.destroy();
+        }
+
+        const particles = this.scene.add.particles(textureKey);
+        const emitter = particles.createEmitter({
+            x,
+            y,
+            speed: { min: 50, max: 200 },
+            angle: { min: -120, max: -60 },
+            scale: { start: 1, end: 0 },
+            lifespan: 500,
+            gravityY: 300,
+            blendMode: 'ADD'
+        });
+
+        emitter.explode(10, x, y);
+        debugLogEngine.log('VFXManager', '핏방울 파티클을 생성했습니다.');
+        // 파티클이 모두 소멸한 후 매니저를 정리합니다.
+        this.scene.time.delayedCall(600, () => particles.destroy());
+    }
+
+    /**
+     * 유닛의 체력바를 갱신합니다.
+     * @param {object} healthBar - 갱신할 체력바 객체 { background, foreground }
+     * @param {number} currentHp - 현재 체력
+     * @param {number} maxHp - 최대 체력
+     */
+    updateHealthBar(healthBar, currentHp, maxHp) {
+        const percentage = Math.max(0, currentHp / maxHp);
+        this.scene.tweens.add({
+            targets: healthBar.foreground,
+            width: healthBar.background.width * percentage,
+            duration: 200,
+            ease: 'Linear'
+        });
+    }
+
+    /**
      * 매니저와 관련된 모든 리소스를 정리합니다.
      */
     shutdown() {


### PR DESCRIPTION
## Summary
- add `DebugAIManager` for behavior tree debugging
- add `DebugCombatCalculationManager` for detailed damage logs
- add `PathfinderEngine` with a simple straight-line pathfinding
- add `TurnOrderManager` to determine action order based on weight
- add `TerminationManager` to handle unit death effects
- expand `VFXManager` with blood splatter particles and health bar updates

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687f808ae2f48327849f4176dd58a136