### PR TITLE
Prevent overlapping movement and simplify blood effect

### DIFF
--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -22,9 +22,13 @@ class MoveToTargetNode extends Node {
         const movePath = path.slice(0, movementRange);
         const destination = movePath[movePath.length - 1];
 
-        // 이동 애니메이션 실행 및 유닛 위치 업데이트
-        await this.formationEngine.moveUnitOnGrid(unit, destination, this.animationEngine);
-        
+        const moved = await this.formationEngine.moveUnitOnGrid(unit, destination, this.animationEngine);
+
+        if (!moved) {
+            debugAIManager.logNodeResult(NodeState.FAILURE);
+            return NodeState.FAILURE;
+        }
+
         debugAIManager.logNodeResult(NodeState.SUCCESS);
         return NodeState.SUCCESS;
     }

--- a/src/game/utils/FormationEngine.js
+++ b/src/game/utils/FormationEngine.js
@@ -152,10 +152,13 @@ class FormationEngine {
      * @returns {Promise<void>}
      */
     async moveUnitOnGrid(unit, newGridPos, animationEngine, bindingManager, duration = 500) {
-        if (!this.grid || !unit || !unit.sprite) return;
+        if (!this.grid || !unit || !unit.sprite) return false;
 
         const targetCell = this.grid.getCell(newGridPos.col, newGridPos.row);
-        if (!targetCell) return;
+        if (!targetCell || targetCell.isOccupied) {
+            debugLogEngine.log('FormationEngine', '목표 셀이 이미 점유되어 이동할 수 없습니다.');
+            return false;
+        }
 
         const targetPixelPos = { x: targetCell.x, y: targetCell.y };
 
@@ -173,6 +176,7 @@ class FormationEngine {
         targetCell.sprite = unit.sprite;
 
         debugLogEngine.log('FormationEngine', `유닛을 (${newGridPos.col}, ${newGridPos.row})로 이동 완료.`);
+        return true;
     }
 }
 

--- a/src/game/utils/VFXManager.js
+++ b/src/game/utils/VFXManager.js
@@ -61,22 +61,16 @@ export class VFXManager {
             g.destroy();
         }
 
-        const particles = this.scene.add.particles(textureKey);
-        const emitter = particles.createEmitter({
-            x,
-            y,
-            speed: { min: 50, max: 200 },
-            angle: { min: -120, max: -60 },
-            scale: { start: 1, end: 0 },
-            lifespan: 500,
-            gravityY: 300,
-            blendMode: 'ADD'
+        const circle = this.scene.add.circle(x, y, 3, 0xff0000).setDepth(10);
+        this.scene.tweens.add({
+            targets: circle,
+            alpha: 0,
+            scale: 2,
+            duration: 500,
+            ease: 'Cubic.easeOut',
+            onComplete: () => circle.destroy()
         });
-
-        emitter.explode(10, x, y);
-        debugLogEngine.log('VFXManager', '핏방울 파티클을 생성했습니다.');
-        // 파티클이 모두 소멸한 후 매니저를 정리합니다.
-        this.scene.time.delayedCall(600, () => particles.destroy());
+        debugLogEngine.log('VFXManager', '핏방울 효과를 생성했습니다.');
     }
 
     /**


### PR DESCRIPTION
## Summary
- block moves into occupied tiles
- update melee move node to account for failed moves
- replace particle blood effect with simple circle tween

## Testing
- `npm install`
- `npm run build-nolog`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687f8dc739388327a3158dfc9ad0e628