### PR TITLE
Add target validation node to melee AI

### DIFF
--- a/src/ai/nodes/IsTargetValidNode.js
+++ b/src/ai/nodes/IsTargetValidNode.js
@@ -1,0 +1,21 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+class IsTargetValidNode extends Node {
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const target = blackboard.get('currentTargetUnit');
+
+        // 대상이 존재하고 현재 HP가 0보다 큰지 확인
+        if (target && target.currentHp > 0) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS);
+            return NodeState.SUCCESS;
+        }
+
+        // 대상이 없거나 쓰러졌다면 블랙보드에서 제거
+        blackboard.set('currentTargetUnit', null);
+        debugAIManager.logNodeResult(NodeState.FAILURE);
+        return NodeState.FAILURE;
+    }
+}
+export default IsTargetValidNode;


### PR DESCRIPTION
## Summary
- add `IsTargetValidNode` to check if stored target is alive
- redesign `MeleeAI` behavior tree to validate or find targets before acting

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687f9045fb04832791a7db6122812480