### PR TITLE
Add damage number VFX

### DIFF
--- a/src/ai/nodes/AttackTargetNode.js
+++ b/src/ai/nodes/AttackTargetNode.js
@@ -29,6 +29,7 @@ class AttackTargetNode extends Node {
         // 시각 효과
         this.vfxManager.updateHealthBar(target.healthBar, target.currentHp, target.finalStats.hp);
         this.vfxManager.createBloodSplatter(target.sprite.x, target.sprite.y);
+        this.vfxManager.createDamageNumber(target.sprite.x, target.sprite.y, damage);
 
         // 딜레이
         await this.delayEngine.hold(200);

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -26,6 +26,13 @@ const config = {
         mode: Phaser.Scale.FIT,
         autoCenter: Phaser.Scale.CENTER_BOTH
     },
+    physics: {
+        default: 'arcade',
+        arcade: {
+            gravity: { y: 0 },
+            debug: false
+        }
+    },
     render: {
         pixelArt: false,
         antialias: true, // 안티에일리어싱을 활성화하여 이미지를 부드럽게 표현합니다.

--- a/src/game/utils/VFXManager.js
+++ b/src/game/utils/VFXManager.js
@@ -82,6 +82,44 @@ export class VFXManager {
     }
 
     /**
+     * 물리 효과가 적용된 데미지 숫자를 생성합니다.
+     * @param {number} x - 생성 위치 x
+     * @param {number} y - 생성 위치 y
+     * @param {number|string} damage - 표시할 데미지 숫자
+     */
+    createDamageNumber(x, y, damage) {
+        const style = {
+            fontFamily: '"Arial Black", Arial, sans-serif',
+            fontSize: '32px',
+            color: '#ff4d4d',
+            stroke: '#000000',
+            strokeThickness: 4,
+        };
+
+        const damageText = this.scene.physics.add
+            .text(x, y, damage.toString(), style)
+            .setOrigin(0.5, 0.5);
+
+        const randomX = Math.random() * 200 - 100; // -100 ~ 100
+        const randomY = -(Math.random() * 150 + 150); // -150 ~ -300
+        damageText.setVelocity(randomX, randomY);
+        damageText.setGravityY(400);
+        damageText.setAngularVelocity(Math.random() * 200 - 100);
+
+        this.scene.tweens.add({
+            targets: damageText,
+            alpha: 0,
+            duration: 800,
+            ease: 'Cubic.easeIn',
+            onComplete: () => {
+                damageText.destroy();
+            },
+        });
+
+        debugLogEngine.log('VFXManager', `${damage} 데미지 숫자를 생성했습니다.`);
+    }
+
+    /**
      * 유닛의 체력바를 갱신합니다.
      * @param {object} healthBar - 갱신할 체력바 객체 { background, foreground }
      * @param {number} currentHp - 현재 체력


### PR DESCRIPTION
## Summary
- enable Arcade Physics in Phaser game config
- add `createDamageNumber` to `VFXManager` using physics for velocity, gravity, and fade-out
- show damage numbers after each attack

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687f9ae864d88327baa43990a752a0dc