### PR TITLE
Fix battle formation placement and camera focus

### DIFF
--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -47,13 +47,6 @@ export class CursedForestBattleScene extends Scene {
         // BattleSimulatorEngine을 통해 전투를 시작합니다.
         this.battleSimulator.start(partyUnits, monsters);
 
-        // 약간의 지연 후 첫 번째 아군 유닛을 따라가 보며 카메라 이동을 테스트합니다.
-        this.time.delayedCall(2000, () => {
-            const firstAlly = this.partyUnits.find(u => u.sprite);
-            if (firstAlly && firstAlly.sprite) {
-                this.cameraControl.panTo(firstAlly.sprite.x, firstAlly.sprite.y);
-            }
-        });
 
         this.events.on('shutdown', () => {
             ['dungeon-container', 'territory-container'].forEach(id => {

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -53,8 +53,12 @@ export class BattleSimulatorEngine {
         allies.forEach(u => u.team = 'ally');
         enemies.forEach(u => u.team = 'enemy');
 
-        formationEngine.placeUnits(this.scene, allies, 0, 7);
-        formationEngine.placeUnits(this.scene, enemies, 8, 15);
+        formationEngine.applyFormation(this.scene, allies, 0, 7);
+        const unplaced = allies.filter(u => !u.sprite);
+        if (unplaced.length > 0) {
+            formationEngine.placeUnits(this.scene, unplaced, 0, 7);
+        }
+        formationEngine.placeMonsters(this.scene, enemies, 8);
 
         this._setupUnits(allUnits);
 


### PR DESCRIPTION
## Summary
- respect saved formation when starting battles
- fallback to random placement when formation info is missing
- remove leftover camera pan test that interfered with first turn

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687fa5e9a6308327985e168cd561ff31