### PR TITLE
Add sprite engine and dynamic unit sprites

### DIFF
--- a/src/ai/nodes/AttackTargetNode.js
+++ b/src/ai/nodes/AttackTargetNode.js
@@ -1,5 +1,6 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { spriteEngine } from '../../game/utils/SpriteEngine.js';
 
 class AttackTargetNode extends Node {
     constructor({ combatCalculationEngine, vfxManager, animationEngine, delayEngine, terminationManager }) {
@@ -19,8 +20,17 @@ class AttackTargetNode extends Node {
             return NodeState.FAILURE;
         }
 
+        // 공격 스프라이트로 일시 변경
+        if (unit.sprite.scene && !spriteEngine.scene) {
+            spriteEngine.setScene(unit.sprite.scene);
+        }
+        spriteEngine.changeSpriteForDuration(unit, 'attack', 400);
+
         // 공격 애니메이션
         await this.animationEngine.attack(unit.sprite, target.sprite);
+
+        // 피격 스프라이트로 변경
+        spriteEngine.changeSpriteForDuration(target, 'hitted', 300);
 
         // 데미지 계산 및 적용
         const damage = this.combatEngine.calculateDamage(unit, target);

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -4,8 +4,13 @@ export const mercenaryData = {
         name: '전사',
         hireImage: 'assets/images/territory/warrior-hire.png',
         uiImage: 'assets/images/territory/warrior-ui.png',
-        battleSprite: 'assets/images/unit/warrior.png',
-        spriteKey: 'warrior',
+        battleSprite: 'warrior',
+        // 유닛의 행동별 스프라이트 키를 정의합니다.
+        sprites: {
+            idle: 'warrior',
+            attack: 'warrior-attack',
+            hitted: 'warrior-hitted',
+        },
         description: '"그는 단 한 사람을 지키기 위해 검을 든다."',
         baseStats: {
             hp: 120, valor: 10, strength: 15, endurance: 12,
@@ -17,8 +22,12 @@ export const mercenaryData = {
         name: '거너',
         hireImage: 'assets/images/territory/gunner-hire.png',
         uiImage: 'assets/images/territory/gunner-ui.png',
-        battleSprite: 'assets/images/unit/gunner.png',
-        spriteKey: 'gunner',
+        battleSprite: 'gunner',
+        sprites: {
+            idle: 'gunner',
+            attack: 'gunner-attack',
+            hitted: 'gunner-hitted',
+        },
         description: '"한 발, 한 발. 신중하게, 그리고 차갑게."',
         baseStats: {
             hp: 80, valor: 5, strength: 7, endurance: 6,

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -61,6 +61,14 @@ export class Preloader extends Scene
         this.load.image('warrior', 'images/unit/warrior.png');
         this.load.image('gunner', 'images/unit/gunner.png');
 
+        // --- 전사의 행동별 스프라이트 로드 ---
+        this.load.image('warrior-attack', 'images/unit/warrior-attack.png');
+        this.load.image('warrior-hitted', 'images/unit/warrior-hitted.png');
+
+        // --- 거너의 행동별 스프라이트 로드 ---
+        this.load.image('gunner-attack', 'images/unit/gunner-attack.png');
+        this.load.image('gunner-hitted', 'images/unit/gunner-hitted.png');
+
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
 

--- a/src/game/utils/SpriteEngine.js
+++ b/src/game/utils/SpriteEngine.js
@@ -1,0 +1,54 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 유닛의 행동에 따라 스프라이트 텍스처를 동적으로 변경하는 엔진
+ */
+class SpriteEngine {
+    constructor() {
+        debugLogEngine.log('SpriteEngine', '스프라이트 엔진이 초기화되었습니다.');
+    }
+
+    /**
+     * 유닛의 스프라이트를 지정된 행동 타입의 이미지로 변경하고,
+     * 일정 시간 후 원래대로 되돌립니다.
+     * @param {object} unit - 대상 유닛 객체 (sprite와 sprites 데이터 포함)
+     * @param {string} actionType - 행동 타입 ('attack', 'hitted' 등)
+     * @param {number} duration - 이미지가 변경된 상태로 유지될 시간 (ms)
+     */
+    changeSpriteForDuration(unit, actionType, duration = 500) {
+        if (!unit || !unit.sprite || !unit.sprites) return;
+
+        const originalTexture = unit.sprites.idle || unit.battleSprite;
+        const actionTexture = unit.sprites[actionType];
+
+        if (!actionTexture || !this.scene.textures.exists(actionTexture)) {
+            debugLogEngine.warn('SpriteEngine', `${actionType}\uC5D0 \uD574\uB2F9\uD558\uB294 \uC2A4\uD504\uB77C\uC774\uD2B8 \uD0A4 '${actionTexture}'\uB97C \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.`);
+            return;
+        }
+
+        // 1. 행동에 맞는 텍스처로 즉시 변경
+        unit.sprite.setTexture(actionTexture);
+        debugLogEngine.log('SpriteEngine', `${unit.instanceName}\uC758 \uC2A4\uD504\uB77C\uC774\uD2B8\uB97C '${actionType}'\uC73C\uB85C \uBCC0\uACBD.`);
+
+        // 2. 지정된 시간(duration)이 지난 후 원래 텍스처로 복귀
+        if (unit.sprite.scene) {
+            unit.sprite.scene.time.delayedCall(duration, () => {
+                if (unit.sprite && unit.sprite.active) {
+                    unit.sprite.setTexture(originalTexture);
+                    debugLogEngine.log('SpriteEngine', `${unit.instanceName}\uC758 \uC2A4\uD504\uB77C\uC774\uD2B8\uB97C 'idle'\uB85C \uBCF5\uAD6C.`);
+                }
+            });
+        }
+    }
+
+    /**
+     * 스프라이트 엔진이 씬 컨텍스트에 접근할 수 있도록 설정합니다.
+     * @param {Phaser.Scene} scene
+     */
+    setScene(scene) {
+        this.scene = scene;
+    }
+}
+
+export const spriteEngine = new SpriteEngine();
+


### PR DESCRIPTION
## Summary
- add sprite engine utility
- extend mercenary data with sprite mapping
- preload additional sprite textures
- show attack and hit sprites during combat

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687fab09ca788327958eb64fc93a8da0