### PR TITLE
Fix mercenary image path for formation UI

### DIFF
--- a/src/game/dom/FormationDOMEngine.js
+++ b/src/game/dom/FormationDOMEngine.js
@@ -80,7 +80,9 @@ export class FormationDOMEngine {
             const unitDiv = document.createElement('div');
             unitDiv.className = 'formation-unit';
             unitDiv.dataset.unitId = id;
-            unitDiv.style.backgroundImage = `url(${unit.battleSprite})`;
+            // Use the mercenary id to build an explicit path so images load
+            // correctly regardless of sprite key configuration.
+            unitDiv.style.backgroundImage = `url(assets/images/unit/${unit.id}.png)`;
             unitDiv.draggable = true;
             unitDiv.addEventListener('dragstart', (e) => {
                 e.dataTransfer.setData('unit-id', id);


### PR DESCRIPTION
## Summary
- load mercenary icons in formation screen using their id-based filenames

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687fb247f3708327aae36862bfff2ff6