### PR TITLE
Implement ranged AI with kiting behavior

### DIFF
--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -1,0 +1,63 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import IsTargetValidNode from '../nodes/IsTargetValidNode.js';
+import FindLowestHealthEnemyNode from '../nodes/FindLowestHealthEnemyNode.js';
+import IsTargetInRangeNode from '../nodes/IsTargetInRangeNode.js';
+import AttackTargetNode from '../nodes/AttackTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import IsTargetTooCloseNode from '../nodes/IsTargetTooCloseNode.js';
+import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
+import SuccessNode from '../nodes/SuccessNode.js';
+
+/**
+ * 원거리 유닛(거너)을 위한 카이팅 행동 트리를 생성합니다.
+ * 행동 로직:
+ * 1. 생존: 적이 너무 가까우면 뒤로 물러난다.
+ * 2. 타겟팅: 체력이 가장 낮은 적을 노린다.
+ * 3. 공격: 사거리 내에 있으면 공격, 아니면 접근 후 공격.
+ * @param {object} engines - AI 노드들이 사용할 엔진 및 매니저 모음
+ * @returns {BehaviorTree}
+ */
+function createRangedAI(engines) {
+    const rootNode = new SequenceNode([
+        // 단계 1: 유효한 타겟 설정 (체력이 가장 낮은 적 우선)
+        new SelectorNode([
+            new IsTargetValidNode(),
+            new FindLowestHealthEnemyNode(engines),
+        ]),
+        // 단계 2: 상황에 따른 행동 결정
+        new SelectorNode([
+            // 2a. (최우선) 생존: 적이 너무 가까우면 카이팅 위치로 이동
+            new SequenceNode([
+                new IsTargetTooCloseNode({ dangerZone: 1 }),
+                new FindKitingPositionNode(engines),
+                new MoveToTargetNode(engines),
+            ]),
+            // 2b. 공격: 사거리 내에 있으면 즉시 공격
+            new SequenceNode([
+                new IsTargetInRangeNode(),
+                new AttackTargetNode(engines),
+            ]),
+            // 2c. 이동 후 공격: 사거리 밖이면 적절한 위치로 이동 후 공격
+            new SequenceNode([
+                new FindPathToTargetNode(engines),
+                new MoveToTargetNode(engines),
+                new SelectorNode([
+                    new SequenceNode([
+                        new IsTargetInRangeNode(),
+                        new AttackTargetNode(engines),
+                    ]),
+                    new SuccessNode(),
+                ]),
+            ]),
+            // 2d. 어떤 행동도 할 수 없을 때
+            new SuccessNode(),
+        ]),
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createRangedAI };

--- a/src/ai/nodes/FindKitingPositionNode.js
+++ b/src/ai/nodes/FindKitingPositionNode.js
@@ -1,0 +1,58 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+// 최적의 카이팅(거리두기) 위치를 찾는 노드
+class FindKitingPositionNode extends Node {
+    constructor({ formationEngine, pathfinderEngine }) {
+        super();
+        this.formationEngine = formationEngine;
+        this.pathfinderEngine = pathfinderEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const target = blackboard.get('currentTargetUnit');
+        if (!target) return NodeState.FAILURE;
+
+        const safeRange = unit.finalStats.attackRange || 3;
+        const start = { col: unit.gridX, row: unit.gridY };
+        const targetPos = { col: target.gridX, row: target.gridY };
+
+        // 1. 이동 가능한 모든 빈 셀 찾기
+        const availableCells = this.formationEngine.grid.gridCells.filter(cell => !cell.isOccupied || (cell.col === start.col && cell.row === start.row));
+
+        // 2. 각 셀의 "안전 점수" 계산
+        let bestCell = null;
+        let maxScore = -Infinity;
+
+        availableCells.forEach(cell => {
+            const distanceToTarget = Math.abs(cell.col - targetPos.col) + Math.abs(cell.row - targetPos.row);
+            // 점수 = (목표와의 거리 - 목표 사거리) -> 목표로부터 멀수록, 사거리 안에 있을수록 점수 높음
+            let score = distanceToTarget - safeRange;
+
+            // 이동 불가능한 셀은 점수 대폭 하락
+            if (this.pathfinderEngine.findPath(start, cell) === null) {
+                score = -Infinity;
+            }
+
+            if (score > maxScore) {
+                maxScore = score;
+                bestCell = cell;
+            }
+        });
+        
+        // 3. 가장 좋은 위치로의 경로 탐색
+        if (bestCell) {
+            const path = this.pathfinderEngine.findPath(start, { col: bestCell.col, row: bestCell.row });
+            if (path && path.length > 0) {
+                blackboard.set('movementPath', path);
+                debugAIManager.logNodeResult(NodeState.SUCCESS);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE);
+        return NodeState.FAILURE;
+    }
+}
+export default FindKitingPositionNode;

--- a/src/ai/nodes/FindLowestHealthEnemyNode.js
+++ b/src/ai/nodes/FindLowestHealthEnemyNode.js
@@ -1,0 +1,26 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+// 체력이 가장 낮은 적을 찾는 노드
+class FindLowestHealthEnemyNode extends Node {
+    constructor({ targetManager }) {
+        super();
+        this.targetManager = targetManager;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const enemyUnits = blackboard.get('enemyUnits');
+        const target = this.targetManager.findLowestHealthEnemy(enemyUnits);
+
+        if (target) {
+            blackboard.set('currentTargetUnit', target);
+            debugAIManager.logNodeResult(NodeState.SUCCESS);
+            return NodeState.SUCCESS;
+        }
+        
+        debugAIManager.logNodeResult(NodeState.FAILURE);
+        return NodeState.FAILURE;
+    }
+}
+export default FindLowestHealthEnemyNode;

--- a/src/ai/nodes/IsTargetTooCloseNode.js
+++ b/src/ai/nodes/IsTargetTooCloseNode.js
@@ -1,0 +1,30 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+// 타겟이 너무 가까운지(위험 지역 내에 있는지) 확인하는 노드
+class IsTargetTooCloseNode extends Node {
+    constructor({ dangerZone = 1 }) {
+        super();
+        this.dangerZone = dangerZone;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const target = blackboard.get('currentTargetUnit');
+        if (!target) {
+            debugAIManager.logNodeResult(NodeState.FAILURE);
+            return NodeState.FAILURE;
+        }
+
+        const distance = Math.abs(unit.gridX - target.gridX) + Math.abs(unit.gridY - target.gridY);
+
+        if (distance <= this.dangerZone) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS);
+            return NodeState.SUCCESS; // 너무 가까움!
+        }
+        
+        debugAIManager.logNodeResult(NodeState.FAILURE);
+        return NodeState.FAILURE; // 안전함
+    }
+}
+export default IsTargetTooCloseNode;

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -31,7 +31,8 @@ export const mercenaryData = {
         description: '"한 발, 한 발. 신중하게, 그리고 차갑게."',
         baseStats: {
             hp: 80, valor: 5, strength: 7, endurance: 6,
-            agility: 15, intelligence: 8, wisdom: 10, luck: 12
+            agility: 15, intelligence: 8, wisdom: 10, luck: 12,
+            attackRange: 3
         }
     }
 };

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -7,6 +7,7 @@ import { TerminationManager } from './TerminationManager.js';
 
 import { aiManager } from '../../ai/AIManager.js';
 import { createMeleeAI } from '../../ai/behaviors/MeleeAI.js';
+import { createRangedAI } from '../../ai/behaviors/RangedAI.js';
 
 import { targetManager } from './TargetManager.js';
 import { pathfinderEngine } from './PathfinderEngine.js';
@@ -63,7 +64,9 @@ export class BattleSimulatorEngine {
         this._setupUnits(allUnits);
 
         allUnits.forEach(unit => {
-            if (unit.name === '전사' || unit.name === '좀비') {
+            if (unit.name === '거너') {
+                aiManager.registerUnit(unit, createRangedAI(this.aiEngines));
+            } else if (unit.name === '전사' || unit.name === '좀비') {
                 aiManager.registerUnit(unit, createMeleeAI(this.aiEngines));
             }
         });

--- a/src/game/utils/StatEngine.js
+++ b/src/game/utils/StatEngine.js
@@ -98,6 +98,7 @@ class StatEngine {
             intelligence: baseStats.intelligence || 0,
             wisdom: baseStats.wisdom || 0,
             luck: baseStats.luck || 0,
+            attackRange: baseStats.attackRange || 1,
         });
 
         // 2. \uC804\uBB38 \uC5D4\uC9C4\uC744 \uD1B5\uD574 \uD30C\uC9C0 \uC2A4\uD0EF\uC744 \uACC4\uC0B0\uD569\uB2C8\uB2E4.


### PR DESCRIPTION
## Summary
- introduce `RangedAI` behavior tree for ranged units
- add nodes for selecting lowest health target and kiting logic
- include attack range stat on gunner mercenary
- ensure `StatEngine` copies `attackRange`
- register gunner units with the new AI

## Testing
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687fc3dd003083279893d35d5b56e6a0