### PR TITLE
Improve ranged unit kiting AI

### DIFF
--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -2,7 +2,7 @@ import BehaviorTree from '../BehaviorTree.js';
 import SelectorNode from '../nodes/SelectorNode.js';
 import SequenceNode from '../nodes/SequenceNode.js';
 import IsTargetValidNode from '../nodes/IsTargetValidNode.js';
-import FindLowestHealthEnemyNode from '../nodes/FindLowestHealthEnemyNode.js';
+import FindPreferredTargetNode from '../nodes/FindPreferredTargetNode.js';
 import IsTargetInRangeNode from '../nodes/IsTargetInRangeNode.js';
 import AttackTargetNode from '../nodes/AttackTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
@@ -14,26 +14,33 @@ import SuccessNode from '../nodes/SuccessNode.js';
 /**
  * 원거리 유닛(거너)을 위한 카이팅 행동 트리를 생성합니다.
  * 행동 로직:
- * 1. 생존: 가장 가까운 적이 너무 가까우면 뒤로 물러난다. (수정됨)
- * 2. 타겟팅: 체력이 가장 낮은 적을 노린다.
- * 3. 공격: 사거리 내에 있으면 공격, 아니면 최대 사거리를 유지하는 위치로 이동 후 공격. (수정됨)
+ * 1. 생존: 가장 가까운 적이 위험 거리 안에 있으면 카이팅 위치로 후퇴 후 가능하다면 공격한다.
+ * 2. 타겟팅: 사거리 내의 적 중 체력이 가장 낮은 대상을 우선 삼고, 없다면 가장 가까운 적을 선택한다.
+ * 3. 공격: 사거리 내에 있으면 즉시 공격하고, 사거리 밖이면 이동 후 공격을 시도한다.
  * @param {object} engines - AI 노드들이 사용할 엔진 및 매니저 모음
  * @returns {BehaviorTree}
  */
 function createRangedAI(engines) {
     const rootNode = new SequenceNode([
-        // 단계 1: 유효한 타겟 설정 (체력이 가장 낮은 적 우선)
+        // 단계 1: 유효한 타겟 설정 (사거리 내의 체력이 낮은 적을 우선)
         new SelectorNode([
             new IsTargetValidNode(),
-            new FindLowestHealthEnemyNode(engines),
+            new FindPreferredTargetNode(engines),
         ]),
         // 단계 2: 상황에 따른 행동 결정
         new SelectorNode([
             // 2a. (최우선) 생존: "가장 가까운 적"이 너무 가까우면 카이팅 위치로 이동
             new SequenceNode([
-                new IsTargetTooCloseNode({ ...engines, dangerZone: 2 }), // 위험 거리 2로 상향
+                new IsTargetTooCloseNode({ ...engines, dangerZone: 2 }),
                 new FindKitingPositionNode(engines),
                 new MoveToTargetNode(engines),
+                new SelectorNode([
+                    new SequenceNode([
+                        new IsTargetInRangeNode(),
+                        new AttackTargetNode(engines),
+                    ]),
+                    new SuccessNode(),
+                ]),
             ]),
             // 2b. 공격: 사거리 내에 있으면 즉시 공격
             new SequenceNode([

--- a/src/ai/nodes/FindPreferredTargetNode.js
+++ b/src/ai/nodes/FindPreferredTargetNode.js
@@ -1,0 +1,42 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+// 공격 사거리 내에 있는 적 중 체력이 가장 낮은 적을 우선적으로 찾고,
+// 없다면 가장 가까운 적을 타겟으로 삼는 노드
+class FindPreferredTargetNode extends Node {
+    constructor({ targetManager }) {
+        super();
+        this.targetManager = targetManager;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const enemyUnits = blackboard.get('enemyUnits');
+        if (!enemyUnits || enemyUnits.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE);
+            return NodeState.FAILURE;
+        }
+
+        const attackRange = unit.finalStats.attackRange || 1;
+        const inRange = enemyUnits.filter(e => e.currentHp > 0 &&
+            Math.abs(unit.gridX - e.gridX) + Math.abs(unit.gridY - e.gridY) <= attackRange);
+
+        let target = null;
+        if (inRange.length > 0) {
+            target = inRange.sort((a, b) => a.currentHp - b.currentHp)[0];
+        } else {
+            target = this.targetManager.findNearestEnemy(unit, enemyUnits);
+        }
+
+        if (target) {
+            blackboard.set('currentTargetUnit', target);
+            debugAIManager.logNodeResult(NodeState.SUCCESS);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE);
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindPreferredTargetNode;


### PR DESCRIPTION
## Summary
- add new `FindPreferredTargetNode` that picks low HP enemies in range before chasing far targets
- update ranged AI to use the new node and attack right after kiting move
- document new behavior

## Testing
- `npm install`
- `npm run build-nolog`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687fd5f94de08327a525c9761901a794