### PR TITLE
Add A* pathfinding with team awareness

### DIFF
--- a/src/ai/nodes/FindKitingPositionNode.js
+++ b/src/ai/nodes/FindKitingPositionNode.js
@@ -65,7 +65,7 @@ class FindKitingPositionNode extends Node {
         });
 
         if (bestCell) {
-            const path = this.pathfinderEngine.findPath(start, { col: bestCell.col, row: bestCell.row });
+            const path = this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
             if (path && path.length > 0) {
                 blackboard.set('movementPath', path);
                 debugAIManager.logNodeResult(NodeState.SUCCESS, `최적 카이팅 위치 (${bestCell.col}, ${bestCell.row})로 경로 설정`);

--- a/src/ai/nodes/FindPathToTargetNode.js
+++ b/src/ai/nodes/FindPathToTargetNode.js
@@ -49,7 +49,7 @@ class FindPathToTargetNode extends Node {
 
         // 3. 해당 셀까지의 경로 탐색
         for (const bestCell of potentialAttackCells) {
-            const path = this.pathfinderEngine.findPath(start, { col: bestCell.col, row: bestCell.row });
+            const path = this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
             if (path && path.length > 0) {
                 // 경로가 존재하면 해당 경로를 사용
                 blackboard.set('movementPath', path);

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -83,6 +83,9 @@ export class BattleSimulatorEngine {
         units.forEach(unit => {
             if (!unit.sprite) return;
 
+            // 유닛 스프라이트에 팀 정보를 명시적으로 저장합니다.
+            unit.sprite.setData('team', unit.team);
+
             unit.currentHp = unit.finalStats.hp;
             const cell = formationEngine.getCellFromSprite(unit.sprite);
             if (cell) {

--- a/src/game/utils/PathfinderEngine.js
+++ b/src/game/utils/PathfinderEngine.js
@@ -1,42 +1,121 @@
 import { debugLogEngine } from './DebugLogEngine.js';
+import { formationEngine } from './FormationEngine.js';
 
 /**
- * 유닛의 이동 경로를 계산하는 엔진 (현재는 단순화된 버전)
+ * A* 알고리즘을 사용하여 유닛의 이동 경로를 계산하는 엔진
  */
 class PathfinderEngine {
     constructor() {
-        debugLogEngine.log('PathfinderEngine', '경로 탐색 엔진이 초기화되었습니다.');
+        debugLogEngine.log('PathfinderEngine', 'A* 경로 탐색 엔진이 초기화되었습니다.');
     }
 
     /**
-     * 시작 좌표에서 목표 좌표까지의 경로를 찾습니다.
-     * (A* 알고리즘 대신, 장애물을 무시하는 직선 경로를 반환하는 단순화된 버전입니다.)
+     * A* 알고리즘을 사용하여 시작 좌표에서 목표 좌표까지의 경로를 찾습니다.
+     * @param {object} unit - 경로를 찾는 주체 유닛 (아군/적군 판단용)
      * @param {object} startPos - 시작 그리드 좌표 { col, row }
      * @param {object} endPos - 목표 그리드 좌표 { col, row }
-     * @returns {Array<object>|null} - 경로 좌표 배열 또는 null
+     * @returns {Array<object>|null} - 경로 좌표 배열 또는 null (경로 없음)
      */
-    findPath(startPos, endPos) {
-        const path = [];
-        let currentPos = { ...startPos };
+    findPath(unit, startPos, endPos) {
+        const grid = formationEngine.grid;
+        if (!grid) return null;
 
-        while (currentPos.col !== endPos.col || currentPos.row !== endPos.row) {
-            const dx = endPos.col - currentPos.col;
-            const dy = endPos.row - currentPos.row;
+        const openSet = [];
+        const closedSet = new Set();
 
-            if (Math.abs(dx) > Math.abs(dy)) {
-                currentPos.col += Math.sign(dx);
-            } else {
-                currentPos.row += Math.sign(dy);
+        const startNode = this._getNodeFromGrid(startPos.col, startPos.row);
+        const endNode = this._getNodeFromGrid(endPos.col, endPos.row);
+        if (!startNode || !endNode) return null;
+
+        startNode.gCost = 0;
+        startNode.hCost = this._getDistance(startNode, endNode);
+        startNode.fCost = startNode.hCost;
+        openSet.push(startNode);
+
+        while (openSet.length > 0) {
+            const currentNode = openSet.reduce((a, b) =>
+                a.fCost === b.fCost ? (a.hCost < b.hCost ? a : b) : (a.fCost < b.fCost ? a : b)
+            );
+
+            openSet.splice(openSet.indexOf(currentNode), 1);
+            closedSet.add(`${currentNode.col},${currentNode.row}`);
+
+            if (currentNode.col === endNode.col && currentNode.row === endNode.row) {
+                return this._retracePath(startNode, currentNode);
             }
-            path.push({ ...currentPos });
+
+            this._getNeighbors(currentNode).forEach(neighbor => {
+                const key = `${neighbor.col},${neighbor.row}`;
+                const cell = grid.getCell(neighbor.col, neighbor.row);
+                const isOccupiedByEnemy = cell && cell.isOccupied && cell.sprite?.getData('team') !== unit.team;
+
+                if (closedSet.has(key) || isOccupiedByEnemy) {
+                    return;
+                }
+
+                const newCost = currentNode.gCost + this._getDistance(currentNode, neighbor);
+                const existing = openSet.find(n => n.col === neighbor.col && n.row === neighbor.row);
+
+                if (!existing || newCost < neighbor.gCost) {
+                    neighbor.gCost = newCost;
+                    neighbor.hCost = this._getDistance(neighbor, endNode);
+                    neighbor.fCost = neighbor.gCost + neighbor.hCost;
+                    neighbor.parent = currentNode;
+
+                    if (!existing) {
+                        openSet.push(neighbor);
+                    }
+                }
+            });
         }
-        
-        if (path.length > 0) {
-            debugLogEngine.log('PathfinderEngine', `경로 탐색 완료: ${path.length}개의 이동 경로 발견.`);
-            return path;
-        }
+
+        debugLogEngine.warn('PathfinderEngine', `경로를 찾을 수 없습니다: (${startPos.col},${startPos.row}) -> (${endPos.col},${endPos.row})`);
         return null;
+    }
+
+    _retracePath(startNode, endNode) {
+        const path = [];
+        let currentNode = endNode;
+        while (currentNode && currentNode !== startNode) {
+            path.push({ col: currentNode.col, row: currentNode.row });
+            currentNode = currentNode.parent;
+        }
+        const reversedPath = path.reverse();
+        debugLogEngine.log('PathfinderEngine', `A* 경로 탐색 완료: ${reversedPath.length}개의 이동 경로 발견.`);
+        return reversedPath;
+    }
+
+    _getNodeFromGrid(col, row) {
+        const cell = formationEngine.grid.getCell(col, row);
+        if (!cell) return null;
+        return { col: cell.col, row: cell.row, gCost: Infinity, hCost: Infinity, fCost: Infinity, parent: null };
+    }
+
+    _getNeighbors(node) {
+        const neighbors = [];
+        const { col, row } = node;
+
+        for (let x = -1; x <= 1; x++) {
+            for (let y = -1; y <= 1; y++) {
+                if (x === 0 && y === 0) continue;
+                const checkCol = col + x;
+                const checkRow = row + y;
+
+                const neighborNode = this._getNodeFromGrid(checkCol, checkRow);
+                if (neighborNode) {
+                    neighbors.push(neighborNode);
+                }
+            }
+        }
+        return neighbors;
+    }
+
+    _getDistance(nodeA, nodeB) {
+        const dstX = Math.abs(nodeA.col - nodeB.col);
+        const dstY = Math.abs(nodeA.row - nodeB.row);
+        return 14 * Math.min(dstX, dstY) + 10 * Math.abs(dstX - dstY);
     }
 }
 
 export const pathfinderEngine = new PathfinderEngine();
+


### PR DESCRIPTION
## Summary
- implement A* search in `PathfinderEngine`
- send acting unit to pathfinder so allies/enemies are considered
- mark each sprite with its team in `BattleSimulatorEngine`

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687fdfd1369883279e7d554a8331b13e