### PR TITLE
Refine melee AI movement

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -34,20 +34,13 @@ function createMeleeAI(engines) {
                 new IsTargetInRangeNode(),
                 new AttackTargetNode(engines),
             ]),
-            // 2b. (차선) 사거리 밖이라면 이동 후 다시 공격 시도
+            // 2b. (차선) 사거리 밖이라면 이동 후 반드시 공격
             new SequenceNode([
                 new FindPathToTargetNode(engines),
                 new MoveToTargetNode(engines),
-                // 이동 후, 다시 사거리 체크 후 공격
-                new SelectorNode([
-                    new SequenceNode([
-                        new IsTargetInRangeNode(),
-                        new AttackTargetNode(engines),
-                    ]),
-                    // 이동은 했지만 공격은 실패한 경우 (예: 적이 그 사이 이동)
-                    // 턴을 성공으로 간주하여 AI가 멈추지 않게 함
-                    new SuccessNode(),
-                ]),
+                // 이동 후 공격을 다시 시도합니다. 실패하면 이 행동 전체가 실패합니다.
+                new IsTargetInRangeNode(),
+                new AttackTargetNode(engines),
             ]),
              // 2c. (대안) 공격도, 공격 위치로 이동도 할 수 없을 때
              // 턴을 성공으로 처리하여 아무것도 하지 않고 턴을 넘김

--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -1,10 +1,10 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { formationEngine } from '../../game/utils/FormationEngine.js';
 
 class MoveToTargetNode extends Node {
-    constructor({ formationEngine, animationEngine }) {
+    constructor({ animationEngine }) {
         super();
-        this.formationEngine = formationEngine;
         this.animationEngine = animationEngine;
     }
 
@@ -17,16 +17,36 @@ class MoveToTargetNode extends Node {
             debugAIManager.logNodeResult(NodeState.FAILURE);
             return NodeState.FAILURE;
         }
-        
-        // 이동력만큼만 경로를 잘라냄
+
+        // 이동력만큼만 경로를 잘라냅니다.
         const movePath = path.slice(0, movementRange);
+        if (movePath.length === 0) {
+            return NodeState.SUCCESS;
+        }
+
+        // 현재 위치의 점유 상태를 해제합니다.
+        const originalCell = formationEngine.grid.getCell(unit.gridX, unit.gridY);
+        if (originalCell) {
+            originalCell.isOccupied = false;
+            originalCell.sprite = null;
+        }
+
+        // 경로를 따라 한 칸씩 이동합니다.
+        for (const step of movePath) {
+            const targetCell = formationEngine.grid.getCell(step.col, step.row);
+            if (targetCell) {
+                await this.animationEngine.moveTo(unit.sprite, targetCell.x, targetCell.y, 200);
+                unit.gridX = step.col;
+                unit.gridY = step.row;
+            }
+        }
+
+        // 최종 위치의 점유 상태를 갱신합니다.
         const destination = movePath[movePath.length - 1];
-
-        const moved = await this.formationEngine.moveUnitOnGrid(unit, destination, this.animationEngine);
-
-        if (!moved) {
-            debugAIManager.logNodeResult(NodeState.FAILURE);
-            return NodeState.FAILURE;
+        const finalCell = formationEngine.grid.getCell(destination.col, destination.row);
+        if (finalCell) {
+            finalCell.isOccupied = true;
+            finalCell.sprite = unit.sprite;
         }
 
         debugAIManager.logNodeResult(NodeState.SUCCESS);


### PR DESCRIPTION
## Summary
- update `MoveToTargetNode` to step through the calculated path
- simplify move-and-attack logic in `createMeleeAI`

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`
- `npm run build-nolog`

------
https://chatgpt.com/codex/tasks/task_e_688063042ed08327a9551351355c1f5d