### PR TITLE
Implement token engine for battle UI

### DIFF
--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -91,6 +91,9 @@ export class Preloader extends Scene
 
         // 몬스터 스프라이트 로드
         this.load.image('zombie', 'images/unit/zombie.png');
+
+        // --- 추가된 토큰 이미지 로드 ---
+        this.load.image('token', 'images/battle/token.png');
     }
 
     create ()

--- a/src/game/utils/TokenEngine.js
+++ b/src/game/utils/TokenEngine.js
@@ -1,0 +1,66 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 전투 중 유닛의 토큰(자원)을 관리하는 엔진 (싱글턴)
+ */
+class TokenEngine {
+    constructor() {
+        this.tokenData = new Map();
+        this.maxTokens = 9; // 최대 토큰 보유량
+        debugLogEngine.log('TokenEngine', '토큰 엔진이 초기화되었습니다.');
+    }
+
+    /**
+     * 전투 시작 시 모든 유닛의 토큰 정보를 등록하고 초기화합니다.
+     * @param {Array<object>} units - 전투에 참여하는 모든 유닛
+     */
+    initializeUnits(units) {
+        this.tokenData.clear();
+        units.forEach(unit => {
+            this.tokenData.set(unit.uniqueId, { currentTokens: 0 });
+        });
+        debugLogEngine.log('TokenEngine', `${units.length}명의 유닛 토큰 정보 초기화 완료.`);
+    }
+
+    /**
+     * 새로운 턴이 시작될 때 모든 유닛에게 토큰을 지급합니다.
+     * @param {number} turnNumber - 현재 턴 번호 (1턴부터 시작)
+     */
+    addTokensForNewTurn(turnNumber) {
+        if (turnNumber <= 0) return;
+
+        for (const [unitId, data] of this.tokenData.entries()) {
+            const newTokens = Math.min(this.maxTokens, data.currentTokens + turnNumber);
+            this.tokenData.set(unitId, { currentTokens: newTokens });
+        }
+        debugLogEngine.log('TokenEngine', `${turnNumber}턴 시작: 모든 유닛에게 ${turnNumber}개의 토큰 지급 시도.`);
+    }
+
+    /**
+     * 특정 유닛의 토큰을 사용합니다.
+     * @param {number} unitId - 토큰을 사용할 유닛의 고유 ID
+     * @param {number} amount - 소모할 토큰의 양
+     * @returns {boolean} - 토큰 소모 성공 여부
+     */
+    spendTokens(unitId, amount) {
+        const data = this.tokenData.get(unitId);
+        if (data && data.currentTokens >= amount) {
+            data.currentTokens -= amount;
+            debugLogEngine.log('TokenEngine', `유닛(ID:${unitId})이 토큰 ${amount}개를 사용. 남은 토큰: ${data.currentTokens}`);
+            return true;
+        }
+        debugLogEngine.warn('TokenEngine', `유닛(ID:${unitId}) 토큰 부족으로 ${amount}개 사용 실패.`);
+        return false;
+    }
+
+    /**
+     * 특정 유닛의 현재 토큰 개수를 반환합니다.
+     * @param {number} unitId - 조회할 유닛의 고유 ID
+     * @returns {number} - 현재 토큰 개수
+     */
+    getTokens(unitId) {
+        return this.tokenData.get(unitId)?.currentTokens || 0;
+    }
+}
+
+export const tokenEngine = new TokenEngine();


### PR DESCRIPTION
## Summary
- load token image in Preloader
- add TokenEngine singleton to track unit tokens
- extend VFXManager to show token icons above units
- integrate token logic into BattleSimulatorEngine

## Testing
- `python3 -m http.server 8000 &>/tmp/http.log &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68809a7b0cec8327a4d096aa95f2582c