### PR TITLE
Add debug token manager and tweak token system

### DIFF
--- a/src/game/debug/DebugTokenManager.js
+++ b/src/game/debug/DebugTokenManager.js
@@ -1,0 +1,41 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * \ud1a0\ud06c\ub4e0(\uc790\uc6d0)\uc758 \uc0dd\uc131, \uc18c\ubaa8, \ubcc0\ud654\ub97c \ucd94\ucd9c\ud558\uace0 \ub85c\uadf8\ub97c \ub0a8\uae30\ub294 \ub514\ubc84\uae08 \ub9e4\ub2c8\uc800
+ */
+class DebugTokenManager {
+    constructor() {
+        this.name = 'DebugToken';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * \ud2b9\uc815 \uc720\ub2c8\ud2b8\uc758 \ud1a0\ud06c \ubcc0\ud654 \uc0ac\ud56d\uc744 \ub85c\uadf8\ub85c \ub0a8\uae30\uace0 \ud45c\uc2dc\ud569\ub2c8\ub2e4.
+     * @param {number} unitId - \uc720\ub2c8\ud2b8\uc758 \uace0\uc720 ID
+     * @param {string} unitName - \uc720\ub2c8\ud2b8\uc758 \uc774\ub984
+     * @param {string} reason - \ubcc0\uacbd \uc0ac\uc720 (\uc608: '\ud130\ub110 \uc2dc\uc791', '\uc2a4\ud0a4 \uc0ac\uc6a9')
+     * @param {number} amount - \ubcc0\uacbd\ub41c \ud1a0\ud06c \uc758 \ub7a9 (+1 \ub610\ub294 -2 \ub4f1)
+     * @param {number} newTotal - \ubcc0\uacbd \ud6c4 \ucd5c\uc885 \ud1a0\ud06c \ub7a9
+     */
+    logTokenChange(unitId, unitName, reason, amount, newTotal) {
+        const sign = amount > 0 ? '+' : '';
+        console.groupCollapsed(
+            `%c[${this.name}]`,
+            `color: #f59e0b; font-weight: bold;`,
+            `${unitName}(ID:${unitId}) \ud1a0\ud06c \ubcc0\uacbd: ${reason}`
+        );
+        debugLogEngine.log(this.name, `\ubcc0\uacbd\ub7c9: ${sign}${amount}`);
+        debugLogEngine.log(this.name, `\ud604\uc7ac \ud1a0\ud06c: ${newTotal}`);
+        console.groupEnd();
+    }
+
+    /**
+     * \uc804\ud22c \uc2dc\uc791 \uc2dc \ud1a0\ud06c \ub370\uc774\ud130 \ucd08\uae30\ud654 \ub85c\uadf8\ub97c \ub0a8\uae30\uace0\uac8c \ud569\ub2c8\ub2e4.
+     * @param {number} unitCount - \ucd08\uae30\ud654\ub41c \uc720\ub2c8\ud2b8\uc758 \uc218
+     */
+    logInitialization(unitCount) {
+        debugLogEngine.log(this.name, `${unitCount}\uac1c \uc720\ub2c8\ud2b8\uc758 \ud1a0\ud06c \ub370\uc774\ud130\ub97c \ucd08\uae30\ud654\ud588\uc2b5\ub2c8\ub2e4.`);
+    }
+}
+
+export const debugTokenManager = new DebugTokenManager();

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -83,8 +83,8 @@ export class BattleSimulatorEngine {
         this.currentTurnIndex = 0;
         this.currentTurnNumber = 1; // 턴 번호 초기화
 
-        // --- ✨ 첫 턴 시작 시 토큰 지급 ---
-        tokenEngine.addTokensForNewTurn(this.currentTurnNumber);
+        // --- ✨ 첫 턴 시작 시 모든 유닛에게 토큰 1개 지급 ---
+        tokenEngine.addOneTokenPerTurn();
 
         // 첫 턴 시작 직후 모든 유닛의 토큰 UI를 업데이트합니다.
         allUnits.forEach(unit => this.vfxManager.updateTokenDisplay(unit.uniqueId));
@@ -113,10 +113,10 @@ export class BattleSimulatorEngine {
             unit.healthBar = healthBar;
 
             // --- ✨ 이름표 생성 후 토큰 UI 생성 ---
-            this.vfxManager.createTokenDisplay(unit.sprite, nameLabel);
+            const tokenContainer = this.vfxManager.createTokenDisplay(unit.sprite, nameLabel);
 
             // 바인딩은 가장 마지막에 수행
-            this.bindingManager.bind(unit.sprite, [nameLabel, healthBar.background, healthBar.foreground]);
+            this.bindingManager.bind(unit.sprite, [nameLabel, healthBar.background, healthBar.foreground, tokenContainer]);
         });
     }
 
@@ -142,13 +142,16 @@ export class BattleSimulatorEngine {
                 this.currentTurnIndex = 0;
                 this.currentTurnNumber++; // 모든 유닛의 턴이 끝나면 전체 턴 수 증가
 
-                // 새로운 턴이 시작되었으므로 토큰을 지급합니다.
-                tokenEngine.addTokensForNewTurn(this.currentTurnNumber);
+                // 새로운 턴이 시작되었으므로 토큰을 1개씩 지급합니다.
+                tokenEngine.addOneTokenPerTurn();
             }
 
             // --- ✨ 매 행동 후 모든 유닛의 토큰 UI 업데이트 ---
-            // (spendTokens가 호출될 수 있으므로 매번 업데이트)
-            this.turnQueue.forEach(unit => this.vfxManager.updateTokenDisplay(unit.uniqueId));
+            this.turnQueue.forEach(unit => {
+                if (unit.sprite && unit.sprite.active) {
+                    this.vfxManager.updateTokenDisplay(unit.uniqueId);
+                }
+            });
 
             await delayEngine.hold(1000);
         }

--- a/src/game/utils/VFXManager.js
+++ b/src/game/utils/VFXManager.js
@@ -20,28 +20,31 @@ export class VFXManager {
      * 유닛의 이름표 위에 토큰 UI를 생성합니다.
      * @param {Phaser.GameObjects.Sprite} parentSprite - 토큰 UI가 따라다닐 유닛 스프라이트
      * @param {Phaser.GameObjects.Text} nameLabel - 위치의 기준이 될 이름표
+     * @returns {Phaser.GameObjects.Container} 생성된 토큰 컨테이너 (바인딩용)
      */
     createTokenDisplay(parentSprite, nameLabel) {
         const unitId = parentSprite.getData('unitId');
-        if (!unitId) return;
+        if (!unitId) return null;
 
-        // 토큰 아이콘들을 담을 컨테이너 생성
-        const container = this.scene.add.container(nameLabel.x, nameLabel.y - 10);
+        const container = this.scene.add.container(nameLabel.x, nameLabel.y - 12);
         this.vfxLayer.add(container);
 
         const tokenImages = [];
+        const tokenSpacing = 8;
+        const tokenScale = 0.05;
+
         for (let i = 0; i < tokenEngine.maxTokens; i++) {
-            const tokenImage = this.scene.add.image(i * 10, 0, 'token').setScale(0.5).setVisible(false);
+            const tokenImage = this.scene.add.image(i * tokenSpacing, 0, 'token').setScale(tokenScale).setVisible(false);
             container.add(tokenImage);
             tokenImages.push(tokenImage);
         }
 
-        // 컨테이너의 원점을 중앙 하단으로 설정하여 이름표 위에 정렬
-        container.setX(nameLabel.x - (tokenImages.length * 10 * 0.5) / 2);
-        container.setY(nameLabel.y - 12);
+        const totalWidth = (tokenEngine.maxTokens - 1) * tokenSpacing;
+        container.setX(nameLabel.x - totalWidth / 2);
 
         this.tokenDisplays.set(unitId, { container, tokenImages });
-        debugLogEngine.log('VFXManager', `유닛(ID:${unitId})의 토큰 UI 생성 완료.`);
+
+        return container;
     }
 
     /**


### PR DESCRIPTION
## Summary
- create `DebugTokenManager` for tracking token changes
- add per-turn token gain and logging to `TokenEngine`
- resize token icons and return container in `VFXManager`
- update `BattleSimulatorEngine` to bind token UI and use new token logic

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68809f9ffad483279b012b5095b356c5