### PR TITLE
Add skill slot system with dice engine

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -627,3 +627,17 @@ body {
     cursor: pointer;
     pointer-events: auto;
 }
+
+/* --- 스킬 슬롯 테두리 색상 스타일 --- */
+.skill-slot.active-slot {
+    border: 3px solid #FF8C00; /* 주황색 */
+}
+.skill-slot.buff-slot {
+    border: 3px solid #1E90FF; /* 파랑색 */
+}
+.skill-slot.debuff-slot {
+    border: 3px solid #DC143C; /* 빨강색 */
+}
+.skill-slot.passive-slot {
+    border: 3px solid #32CD32; /* 초록색 */
+}

--- a/src/game/debug/BirthReportManager.js
+++ b/src/game/debug/BirthReportManager.js
@@ -1,4 +1,6 @@
 import { debugLogEngine } from '../utils/DebugLogEngine.js';
+// 스킬 디버그 매니저를 import 합니다.
+import { debugSkillManager } from './DebugSkillManager.js';
 
 /**
  * 새로 생성된 모든 유닛(아군, 적군)의 데이터를 콘솔에 기록하는 매니저
@@ -30,6 +32,11 @@ class BirthReportManager {
         debugLogEngine.log(this.name, `이름: ${unitInstance.instanceName}`);
         debugLogEngine.log(this.name, `클래스: ${unitInstance.name}`);
         debugLogEngine.log(this.name, `레벨: ${unitInstance.level}`);
+
+        // 스킬 슬롯 정보를 로그로 남깁니다.
+        if (unitInstance.skillSlots) {
+            debugSkillManager.logSkillSlots(unitInstance.skillSlots);
+        }
 
         console.groupCollapsed(`%c[${this.name}] 최종 스탯 정보`, `color: #a855f7; font-weight: bold;`);
         console.table(unitInstance.finalStats);

--- a/src/game/debug/DebugSkillManager.js
+++ b/src/game/debug/DebugSkillManager.js
@@ -1,0 +1,28 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+import { SKILL_TYPES } from '../utils/SkillEngine.js';
+
+class DebugSkillManager {
+    constructor() {
+        this.name = 'DebugSkill';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 용병에게 부여된 스킬 슬롯 정보를 로그 그룹으로 출력합니다.
+     */
+    logSkillSlots(skillSlots = []) {
+        console.groupCollapsed(`%c[${this.name}]`, `color: #9333ea; font-weight: bold;`, '생성된 스킬 슬롯 정보');
+        
+        const styledSlots = skillSlots.map(slotKey => {
+            const skillInfo = SKILL_TYPES[slotKey];
+            return `%c${skillInfo.name}`;
+        }).join(' - ');
+
+        const styles = skillSlots.map(slotKey => `color: ${SKILL_TYPES[slotKey].color}; font-weight: bold;`);
+        
+        console.log(styledSlots, ...styles);
+        console.groupEnd();
+    }
+}
+
+export const debugSkillManager = new DebugSkillManager();

--- a/src/game/dom/PartyDOMEngine.js
+++ b/src/game/dom/PartyDOMEngine.js
@@ -1,5 +1,7 @@
 import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 import { statEngine } from '../utils/StatEngine.js';
+// SKILL_TYPES를 import하여 색상 정보를 사용합니다.
+import { SKILL_TYPES } from '../utils/SkillEngine.js';
 
 /**
  * 파티 관리 화면의 DOM 요소를 생성하고 관리하는 엔진
@@ -191,24 +193,31 @@ export class PartyDOMEngine {
 
         const rightSection = document.createElement('div');
         rightSection.className = 'detail-section right';
-        rightSection.innerHTML = `
+
+        let skillsHTML = `
             <div class="equipment-grid">
                 <div class="section-title">장비</div>
-                <div class="equip-slot"></div>
-                <div class="equip-slot"></div>
-                <div class="equip-slot"></div>
-                <div class="equip-slot"></div>
-                <div class="equip-slot"></div>
+                <div class="equip-slot"></div><div class="equip-slot"></div><div class="equip-slot"></div><div class="equip-slot"></div><div class="equip-slot"></div>
             </div>
             <div class="unit-skills">
                 <div class="section-title">스킬</div>
                 <div class="skill-grid">
-                    <div class="skill-slot"></div>
-                    <div class="skill-slot"></div>
-                    <div class="skill-slot"></div>
+        `;
+
+        if (unitData.skillSlots && unitData.skillSlots.length > 0) {
+            unitData.skillSlots.forEach(slotType => {
+                const typeClass = `${slotType.toLowerCase()}-slot`;
+                skillsHTML += `<div class="skill-slot ${typeClass}"></div>`;
+            });
+        } else {
+            skillsHTML += `<div class="skill-slot"></div><div class="skill-slot"></div><div class="skill-slot"></div>`;
+        }
+
+        skillsHTML += `
                 </div>
             </div>
         `;
+        rightSection.innerHTML = skillsHTML;
 
         detailContent.appendChild(leftSection);
         detailContent.appendChild(rightSection);

--- a/src/game/utils/DiceEngine.js
+++ b/src/game/utils/DiceEngine.js
@@ -1,0 +1,25 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 게임 내 모든 무작위 요소를 관장하는 중앙 주사위 엔진 (싱글턴)
+ */
+class DiceEngine {
+    constructor() {
+        debugLogEngine.log('DiceEngine', '다이스 엔진이 초기화되었습니다.');
+    }
+
+    /**
+     * 주어진 배열에서 무작위 요소를 하나 선택하여 반환합니다.
+     * @param {Array<*>} array - 요소를 선택할 배열
+     * @returns {*|undefined} - 무작위로 선택된 요소
+     */
+    getRandomElement(array) {
+        if (!array || array.length === 0) {
+            return undefined;
+        }
+        const index = Math.floor(Math.random() * array.length);
+        return array[index];
+    }
+}
+
+export const diceEngine = new DiceEngine();

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -3,6 +3,8 @@ import { birthReportManager } from '../debug/BirthReportManager.js';
 // PartyEngine을 불러옵니다.
 import { partyEngine } from './PartyEngine.js';
 import { uniqueIDManager } from './UniqueIDManager.js';
+// 스킬 엔진을 불러옵니다.
+import { skillEngine } from './SkillEngine.js';
 
 /**
  * 용병의 생성, 저장, 관리를 전담하는 엔진 (싱글턴)
@@ -31,7 +33,9 @@ class MercenaryEngine {
             instanceName: randomName,
             level: 1,
             exp: 0,
-            equippedItems: []
+            equippedItems: [],
+            // 무작위 스킬 슬롯을 생성하여 저장합니다.
+            skillSlots: skillEngine.generateRandomSkillSlots()
         };
         
         newInstance.finalStats = statEngine.calculateStats(newInstance, newInstance.baseStats, newInstance.equippedItems);

--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -1,0 +1,35 @@
+import { diceEngine } from './DiceEngine.js';
+import { debugLogEngine } from './DebugLogEngine.js';
+
+// 스킬 종류와 해당 색상, 이름을 상수로 정의합니다.
+export const SKILL_TYPES = {
+    ACTIVE: { name: '액티브', color: '#FF8C00' }, // 주황색
+    BUFF:   { name: '버프',   color: '#1E90FF' }, // 파랑색
+    DEBUFF: { name: '디버프', color: '#DC143C' }, // 빨강색
+    PASSIVE:{ name: '패시브', color: '#32CD32' }  // 초록색
+};
+
+/**
+ * 용병의 스킬 슬롯 생성 등 스킬 관련 로직을 총괄하는 엔진
+ */
+class SkillEngine {
+    constructor() {
+        this.skillTypes = Object.keys(SKILL_TYPES);
+        debugLogEngine.log('SkillEngine', '스킬 엔진이 초기화되었습니다.');
+    }
+
+    /**
+     * 3개의 무작위 스킬 슬롯 타입을 생성하여 반환합니다.
+     * @returns {Array<string>} - 3개의 스킬 타입 문자열 배열 (예: ['ACTIVE', 'PASSIVE', 'BUFF'])
+     */
+    generateRandomSkillSlots() {
+        const slots = [];
+        for (let i = 0; i < 3; i++) {
+            const randomType = diceEngine.getRandomElement(this.skillTypes);
+            slots.push(randomType);
+        }
+        return slots;
+    }
+}
+
+export const skillEngine = new SkillEngine();


### PR DESCRIPTION
## Summary
- implement `DiceEngine` for random selections
- introduce `SkillEngine` to assign random skill slots
- add `DebugSkillManager` to log generated slots
- integrate skill slots into mercenary creation and birth report
- display skill slots in party details
- style skill slots by type

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6880b2ee655883278398eef56fbac75c