### PR TITLE
Implement skill management scene

### DIFF
--- a/src/game/config/UIConfig.js
+++ b/src/game/config/UIConfig.js
@@ -1,0 +1,23 @@
+export const uiConfig = {
+    skillManagementScene: {
+        mercenaryListPanel: {
+            x: 20,
+            y: 50,
+            width: 300,
+            height: 500,
+        },
+        mercenaryDetailsPanel: {
+            x: 340,
+            y: 50,
+            width: 400,
+            height: 500,
+        },
+        skillInventoryPanel: {
+            x: 760,
+            y: 50,
+            width: 500,
+            height: 500,
+        },
+    },
+};
+

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -29,6 +29,8 @@ export class TerritoryDOMEngine {
         this.addExpeditionButton(2, 0);
         // --- 진형 관리 버튼 추가 ---
         this.addFormationButton(0, 1);
+        // --- 스킬 관리 버튼 추가 ---
+        this.addSkillManagementButton(1, 1);
     }
 
     createGrid() {
@@ -113,6 +115,21 @@ export class TerritoryDOMEngine {
         button.addEventListener('click', () => {
             this.container.style.display = 'none';
             this.scene.scene.start('FormationScene');
+        });
+        this.grid.appendChild(button);
+    }
+
+    addSkillManagementButton(col, row) {
+        const button = document.createElement('div');
+        button.className = 'building-icon';
+        button.style.backgroundImage = `url(assets/images/territory/skills-icon.png)`;
+        button.style.gridColumnStart = col + 1;
+        button.style.gridRowStart = row + 1;
+        button.addEventListener('mouseover', (event) => this.domEngine.showTooltip(event.clientX, event.clientY, '[스킬 관리]'));
+        button.addEventListener('mouseout', () => this.domEngine.hideTooltip());
+        button.addEventListener('click', () => {
+            this.container.style.display = 'none';
+            this.scene.scene.start('SkillManagementScene');
         });
         this.grid.appendChild(button);
     }

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -12,6 +12,7 @@ import { PartyScene } from './PartyScene.js';
 import { DungeonScene } from './DungeonScene.js';
 import { FormationScene } from './FormationScene.js';
 import { CursedForestBattleScene } from './CursedForestBattleScene.js';
+import { SkillManagementScene } from './SkillManagementScene.js';
 
 export class Boot extends Scene
 {
@@ -40,6 +41,7 @@ export class Boot extends Scene
         this.scene.add('DungeonScene', DungeonScene);
         this.scene.add('FormationScene', FormationScene);
         this.scene.add('CursedForestBattle', CursedForestBattleScene);
+        this.scene.add('SkillManagementScene', SkillManagementScene);
 
         this.scene.start('Preloader');
     }

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -86,6 +86,11 @@ export class Preloader extends Scene
         this.load.image('dungeon-scene', 'images/territory/dungeon-scene.png');
         this.load.image('cursed-forest', 'images/territory/cursed-forest.png');
         this.load.image('formation-icon', 'images/territory/formation-icon.png');
+        // --- 스킬 관리 아이콘 및 씬 배경 로드 ---
+        this.load.image('skills-icon', 'images/territory/skills-icon.png');
+        this.load.image('skills-scene-background', 'images/territory/skills-scene.png');
+        // 공통 패널 배경 이미지
+        this.load.image('panel-background', 'images/ui-panel.png');
         this.load.image('battle-stage-arena', 'images/battle/battle-stage-arena.png');
         this.load.image('battle-stage-cursed-forest', 'images/battle/battle-stage-cursed-forest.png');
 

--- a/src/game/scenes/SkillManagementScene.js
+++ b/src/game/scenes/SkillManagementScene.js
@@ -1,0 +1,68 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { uiConfig } from '../config/UIConfig.js';
+import { partyEngine } from '../utils/PartyEngine.js';
+import { SKILL_TYPES } from '../utils/SkillEngine.js';
+
+export class SkillManagementScene extends Scene {
+    constructor() {
+        super('SkillManagementScene');
+    }
+
+    preload() {
+        this.load.image('skills-scene-background', 'assets/images/territory/skills-scene.png');
+        this.load.image('panel-background', 'assets/images/ui-panel.png');
+    }
+
+    create() {
+        this.add.image(0, 0, 'skills-scene-background').setOrigin(0);
+
+        const listCfg = uiConfig.skillManagementScene.mercenaryListPanel;
+        const listBg = this.add.image(listCfg.x, listCfg.y, 'panel-background').setOrigin(0).setDisplaySize(listCfg.width, listCfg.height);
+        this.add.text(listCfg.x + 10, listCfg.y + 10, '출정 중인 용병', { fontSize: '20px', color: '#fff' });
+
+        const deployed = partyEngine.getDeployedMercenaries();
+        deployed.forEach((merc, idx) => {
+            const y = listCfg.y + 40 + idx * 30;
+            const text = this.add.text(listCfg.x + 20, y, merc.instanceName, { fontSize: '16px', color: '#ddd' }).setInteractive();
+            text.setData('mercenaryId', merc.uniqueId);
+            text.on('pointerdown', this.showMercenaryDetails, this);
+        });
+
+        const detailsCfg = uiConfig.skillManagementScene.mercenaryDetailsPanel;
+        this.add.image(detailsCfg.x, detailsCfg.y, 'panel-background').setOrigin(0).setDisplaySize(detailsCfg.width, detailsCfg.height);
+        this.detailsTitleText = this.add.text(detailsCfg.x + 10, detailsCfg.y + 10, '용병 상세 정보', { fontSize: '20px', color: '#fff' });
+        this.skillSlotsContainer = this.add.container(detailsCfg.x + 20, detailsCfg.y + 50);
+
+        const invCfg = uiConfig.skillManagementScene.skillInventoryPanel;
+        this.add.image(invCfg.x, invCfg.y, 'panel-background').setOrigin(0).setDisplaySize(invCfg.width, invCfg.height);
+        this.add.text(invCfg.x + 10, invCfg.y + 10, '스킬 카드 인벤토리', { fontSize: '20px', color: '#fff' });
+        this.skillCardGridContainer = this.add.container(invCfg.x + 20, invCfg.y + 40);
+    }
+
+    showMercenaryDetails(pointer) {
+        const mercId = pointer.gameObject.getData('mercenaryId');
+        const mercenary = partyEngine.getMercenaryById(mercId);
+
+        if (mercenary) {
+            this.detailsTitleText.setText(`${mercenary.instanceName} 상세 정보`);
+            this.skillSlotsContainer.removeAll(true);
+
+            const spacing = 100;
+            mercenary.skillSlots.forEach((slotType, index) => {
+                const x = index * spacing;
+                const container = this.add.container(x, 0);
+
+                const g = this.add.graphics();
+                g.lineStyle(3, SKILL_TYPES[slotType].color);
+                g.strokeRect(0, 0, 80, 100);
+                container.add(g);
+
+                const typeText = this.add.text(40, 85, SKILL_TYPES[slotType].name, { fontSize: '12px', color: '#eee' }).setOrigin(0.5, 0);
+                const empty = this.add.text(40, 35, '[빈 슬롯]', { fontSize: '14px', color: '#999' }).setOrigin(0.5);
+                container.add([empty, typeText]);
+                this.skillSlotsContainer.add(container);
+            });
+        }
+    }
+}
+

--- a/src/game/utils/PartyEngine.js
+++ b/src/game/utils/PartyEngine.js
@@ -1,6 +1,8 @@
 /**
  * 플레이어의 파티를 관리하는 엔진 (싱글턴)
  */
+import { mercenaryEngine } from './MercenaryEngine.js';
+
 class PartyEngine {
     constructor() {
         this.maxPartySize = 12;
@@ -57,6 +59,17 @@ class PartyEngine {
      */
     getPartyMembers() {
         return [...this.partyMembers];
+    }
+
+    getDeployedMercenaries() {
+        return this.getPartyMembers()
+            .filter(id => id !== undefined)
+            .map(id => mercenaryEngine.getMercenaryById(id, 'ally'))
+            .filter(m => m);
+    }
+
+    getMercenaryById(id) {
+        return mercenaryEngine.getMercenaryById(id, 'ally');
     }
 }
 


### PR DESCRIPTION
## Summary
- add UI config constants for the new scene layout
- load new skill management assets during preload
- register SkillManagementScene in boot
- implement the SkillManagementScene with panels for mercenary list, detail and inventory
- extend PartyEngine to access deployed mercenaries
- add skill management button to territory

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6880b563b8e48327861480e296cd7b75