### PR TITLE
Add skill data placeholders and SkillCardManager

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -746,3 +746,57 @@ body {
     cursor: pointer;
     pointer-events: auto;
 }
+
+/* --- 스킬 카드 스타일 --- */
+.skill-card {
+    width: 100px;
+    height: 140px;
+    background-color: #333;
+    border: 1px solid #777;
+    border-radius: 5px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    cursor: pointer;
+}
+.skill-card:hover {
+    border-color: #fff;
+}
+
+.skill-illustration {
+    width: 100%;
+    height: 60px; /* 정사각형에 가까운 비율 */
+    background-color: #222; /* 임시 배경색 */
+    background-size: cover;
+    background-position: center;
+}
+
+.skill-info {
+    padding: 4px;
+    font-size: 10px;
+    color: #eee;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.skill-name {
+    font-weight: bold;
+    font-size: 12px;
+    text-align: center;
+    border-bottom: 1px solid #555;
+    margin-bottom: 2px;
+    padding-bottom: 2px;
+}
+
+.skill-type-cost {
+    display: flex;
+    justify-content: space-between;
+    font-size: 9px;
+    color: #ccc;
+}
+
+.skill-description {
+    margin-top: 4px;
+    flex-grow: 1;
+}

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -1,0 +1,2 @@
+// 이곳에 '액티브' 스킬 데이터가 정의될 예정입니다.
+export const activeSkills = {};

--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -1,0 +1,2 @@
+// 이곳에 '버프' 스킬 데이터가 정의될 예정입니다.
+export const buffSkills = {};

--- a/src/game/data/skills/debuff.js
+++ b/src/game/data/skills/debuff.js
@@ -1,0 +1,2 @@
+// 이곳에 '디버프' 스킬 데이터가 정의될 예정입니다.
+export const debuffSkills = {};

--- a/src/game/data/skills/passive.js
+++ b/src/game/data/skills/passive.js
@@ -1,0 +1,2 @@
+// 이곳에 '패시브' 스킬 데이터가 정의될 예정입니다.
+export const passiveSkills = {};

--- a/src/game/dom/SkillCardManager.js
+++ b/src/game/dom/SkillCardManager.js
@@ -1,0 +1,50 @@
+import { SKILL_TYPES } from '../utils/SkillEngine.js';
+
+/**
+ * 스킬 카드 DOM 요소를 생성하는 것을 전담하는 매니저
+ */
+export class SkillCardManager {
+    /**
+     * 스킬 데이터를 기반으로 스킬 카드 HTML 요소를 생성합니다.
+     * @param {object} skillData - 카드를 만들 스킬의 정보
+     * @returns {HTMLElement} - 생성된 스킬 카드 DOM 요소
+     */
+    static createCardElement(skillData) {
+        const card = document.createElement('div');
+        card.className = 'skill-card';
+        card.dataset.skillId = skillData.id;
+
+        // 1. 스킬 일러스트
+        const illustration = document.createElement('div');
+        illustration.className = 'skill-illustration';
+        // illustration.style.backgroundImage = `url(${skillData.illustrationPath})`;
+        card.appendChild(illustration);
+
+        // 2. 스킬 정보 텍스트 창
+        const infoContainer = document.createElement('div');
+        infoContainer.className = 'skill-info';
+        
+        const name = document.createElement('div');
+        name.className = 'skill-name';
+        name.innerText = skillData.name || '스킬 이름';
+        infoContainer.appendChild(name);
+
+        const typeAndCost = document.createElement('div');
+        typeAndCost.className = 'skill-type-cost';
+        const skillTypeInfo = SKILL_TYPES[skillData.type];
+        typeAndCost.innerHTML = `
+            <span style="color: ${skillTypeInfo.color};">[${skillTypeInfo.name}]</span>
+            <span>토큰 ${skillData.cost || 0}</span>
+        `;
+        infoContainer.appendChild(typeAndCost);
+
+        const description = document.createElement('div');
+        description.className = 'skill-description';
+        description.innerText = skillData.description || '스킬에 대한 설명이 여기에 표시됩니다.';
+        infoContainer.appendChild(description);
+        
+        card.appendChild(infoContainer);
+
+        return card;
+    }
+}


### PR DESCRIPTION
## Summary
- prepare empty skill datasets by type
- implement `SkillCardManager` for DOM-based skill cards
- style the skill card component

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6880bb7b543483279d36f3299bc6dabf