### PR TITLE
Implement skill inventory display

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -443,16 +443,38 @@ body {
 .unit-skills {
     flex-grow: 1;
 }
-.skill-grid {
+.unit-skills .skill-grid {
     display: flex;
     gap: 10px;
+    margin-top: 10px;
 }
-.skill-slot {
-    flex: 1;
+.unit-skills .skill-slot {
+    width: 60px;
     height: 60px;
-    background-color: rgba(0,0,0,0.3);
-    border: 1px solid #444;
-    border-radius: 4px;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    border: 2px solid transparent;
+}
+.unit-skills .skill-slot.active-slot { border-color: #FF8C00; }
+.unit-skills .skill-slot.buff-slot { border-color: #1E90FF; }
+.unit-skills .skill-slot.debuff-slot { border-color: #DC143C; }
+.unit-skills .skill-slot.passive-slot { border-color: #32CD32; }
+
+.skill-slot .slot-rank {
+    position: absolute;
+    bottom: -15px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 10px;
+    color: #aaa;
+    background-color: rgba(0, 0, 0, 0.7);
+    padding: 2px 5px;
+    border-radius: 3px;
 }
 
 /* --- 용병 고용 모달에 버튼 스타일 추가 --- */
@@ -628,19 +650,6 @@ body {
     pointer-events: auto;
 }
 
-/* --- 스킬 슬롯 테두리 색상 스타일 --- */
-.skill-slot.active-slot {
-    border: 3px solid #FF8C00; /* 주황색 */
-}
-.skill-slot.buff-slot {
-    border: 3px solid #1E90FF; /* 파랑색 */
-}
-.skill-slot.debuff-slot {
-    border: 3px solid #DC143C; /* 빨강색 */
-}
-.skill-slot.passive-slot {
-    border: 3px solid #32CD32; /* 초록색 */
-}
 
 /* --- 스킬 관리 씬 스타일 --- */
 #skill-management-container {
@@ -799,4 +808,22 @@ body {
 .skill-description {
     margin-top: 4px;
     flex-grow: 1;
+}
+
+/* --- 스킬 카드 추가 스타일 --- */
+.skill-card.active-card { border-top: 5px solid #FF8C00; }
+.skill-card.buff-card { border-top: 5px solid #1E90FF; }
+.skill-card.debuff-card { border-top: 5px solid #DC143C; }
+.skill-card.passive-card { border-top: 5px solid #32CD32; }
+
+.skill-cost-container {
+    display: flex;
+    align-items: center;
+    margin-top: 2px;
+}
+
+.token-icon {
+    width: 12px;
+    height: 12px;
+    margin-right: 2px;
 }

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -1,2 +1,11 @@
-// 이곳에 '액티브' 스킬 데이터가 정의될 예정입니다.
-export const activeSkills = {};
+// 액티브 스킬 데이터 정의
+export const activeSkills = {
+    charge: {
+        id: 'charge',
+        name: '차지',
+        type: 'ACTIVE',
+        cost: 2,
+        description: '적에게 돌진하여 데미지를 주며 적을 2턴간 기절시킵니다.',
+        illustrationPath: 'assets/images/skills/charge.png',
+    },
+};

--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -1,2 +1,11 @@
-// 이곳에 '버프' 스킬 데이터가 정의될 예정입니다.
-export const buffSkills = {};
+// 버프 스킬 데이터 정의
+export const buffSkills = {
+    stoneSkin: {
+        id: 'stoneSkin',
+        name: '스톤 스킨',
+        type: 'BUFF',
+        cost: 1,
+        description: '5턴간 자기 자신에게 데미지 감소 5%의 버프를 겁니다. 최대 중첩 25%',
+        illustrationPath: 'assets/images/skills/ston-skin.png',
+    },
+};

--- a/src/game/data/skills/debuff.js
+++ b/src/game/data/skills/debuff.js
@@ -1,2 +1,11 @@
-// 이곳에 '디버프' 스킬 데이터가 정의될 예정입니다.
-export const debuffSkills = {};
+// 디버프 스킬 데이터 정의
+export const debuffSkills = {
+    shieldBreak: {
+        id: 'shieldBreak',
+        name: '쉴드 브레이크',
+        type: 'DEBUFF',
+        cost: 2,
+        description: '적에게 5턴간 물리방어력 감소 5%의 디버프를 겁니다. 최대 중첩 25%',
+        illustrationPath: 'assets/images/skills/shield-break.png',
+    },
+};

--- a/src/game/data/skills/passive.js
+++ b/src/game/data/skills/passive.js
@@ -1,2 +1,11 @@
-// 이곳에 '패시브' 스킬 데이터가 정의될 예정입니다.
-export const passiveSkills = {};
+// 패시브 스킬 데이터 정의
+export const passiveSkills = {
+    ironWill: {
+        id: 'ironWill',
+        name: '아이언 윌',
+        type: 'PASSIVE',
+        cost: 0,
+        description: '체력이 적을 수록 받는 데미지가 감소합니다. 최대 30%감소',
+        illustrationPath: 'assets/images/skills/iron_will.png',
+    },
+};

--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -1,6 +1,8 @@
 import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 import { partyEngine } from '../utils/PartyEngine.js';
 import { SKILL_TYPES } from '../utils/SkillEngine.js';
+import { SkillCardManager } from './SkillCardManager.js';
+import { skillInventoryManager } from '../utils/SkillInventoryManager.js';
 
 export class SkillManagementDOMEngine {
     constructor(scene) {
@@ -16,6 +18,7 @@ export class SkillManagementDOMEngine {
         this.selectedMercenaryId = null;
 
         this.createView();
+        this.populateSkillInventory();
     }
 
     createView() {
@@ -43,7 +46,6 @@ export class SkillManagementDOMEngine {
         this.skillInventoryContent = inventoryPanel.querySelector('.panel-content');
 
         this.populateMercenaryList();
-        this.createSkillInventoryGrid();
 
         // 뒤로가기 버튼 추가
         const backButton = document.createElement('div');
@@ -120,6 +122,30 @@ export class SkillManagementDOMEngine {
             cell.className = 'skill-inventory-cell';
             this.skillInventoryContent.appendChild(cell);
         }
+    }
+
+    populateSkillInventory() {
+        this.skillInventoryContent.innerHTML = '';
+        const inventory = skillInventoryManager.getInventory();
+        inventory.forEach(skill => {
+            const cardElement = SkillCardManager.createCardElement(skill);
+
+            // 스킬 종류에 따라 테두리 색상 적용 (CSS 클래스 활용)
+            cardElement.classList.add(`${skill.type.toLowerCase()}-card`);
+
+            // 소모 토큰 표시
+            const costContainer = document.createElement('div');
+            costContainer.className = 'skill-cost-container';
+            for (let i = 0; i < skill.cost; i++) {
+                const tokenIcon = document.createElement('img');
+                tokenIcon.src = 'assets/images/battle/token.png';
+                tokenIcon.className = 'token-icon';
+                costContainer.appendChild(tokenIcon);
+            }
+            cardElement.querySelector('.skill-info').appendChild(costContainer);
+
+            this.skillInventoryContent.appendChild(cardElement);
+        });
     }
 
     destroy() {

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -68,13 +68,16 @@ export class UnitDetailDOM {
                 <div class="skill-grid">`;
 
         if (unitData.skillSlots && unitData.skillSlots.length > 0) {
-            unitData.skillSlots.forEach(slotType => {
+            unitData.skillSlots.forEach((slotType, index) => {
                 const typeClass = `${slotType.toLowerCase()}-slot`;
-                skillsHTML += `<div class="skill-slot ${typeClass}" style="background-image: url(assets/images/skills/skill-slot.png);"></div>`;
+                skillsHTML += `
+                    <div class="skill-slot ${typeClass}" style="background-image: url(assets/images/skills/skill-slot.png);">
+                        <span class="slot-rank">${index + 1} 순위</span>
+                    </div>`;
             });
         } else {
             for(let i = 0; i < 3; i++) {
-                skillsHTML += `<div class="skill-slot" style="background-image: url(assets/images/skills/skill-slot.png);"></div>`;
+                skillsHTML += `<div class="skill-slot" style="background-image: url(assets/images/skills/skill-slot.png);"><span class="slot-rank">${i + 1} 순위</span></div>`;
             }
         }
         

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -1,13 +1,41 @@
 import { debugLogEngine } from './DebugLogEngine.js';
+import { activeSkills } from '../data/skills/active.js';
+import { buffSkills } from '../data/skills/buff.js';
+import { debuffSkills } from '../data/skills/debuff.js';
+import { passiveSkills } from '../data/skills/passive.js';
 
 /**
  * 플레이어가 획득한 모든 스킬 카드의 인벤토리를 관리하는 엔진
  */
 class SkillInventoryManager {
     constructor() {
-        // key: skillId, value: { details, count: number }
         this.skillInventory = new Map();
         debugLogEngine.log('SkillInventoryManager', '스킬 인벤토리 매니저가 초기화되었습니다.');
+        this.initializeSkillCards();
+    }
+
+    initializeSkillCards() {
+        this.addSkillCards(activeSkills);
+        this.addSkillCards(buffSkills);
+        this.addSkillCards(debuffSkills);
+        this.addSkillCards(passiveSkills);
+    }
+
+    addSkillCards(skillObject) {
+        for (const skillId in skillObject) {
+            if (skillObject.hasOwnProperty(skillId)) {
+                const skillData = skillObject[skillId];
+                this.skillInventory.set(
+                    skillId,
+                    { details: skillData, count: (this.skillInventory.get(skillId)?.count || 0) + 1 }
+                );
+            }
+        }
+        debugLogEngine.log('SkillInventoryManager', '초기 스킬 카드 로드 완료.');
+    }
+
+    getInventory() {
+        return Array.from(this.skillInventory.values()).map(item => item.details);
     }
 
     // 향후 여기에 스킬 획득/폐기/조회 관련 메서드가 추가될 것입니다.


### PR DESCRIPTION
## Summary
- add sample skill data for each category
- load initial skill cards in inventory manager
- show inventory cards in SkillManagementDOMEngine
- show skill slot ranks and adjust slot styles
- style skill cards by type and show token cost

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880c1fe08548327b22ecf73a4b080b0