### PR TITLE
Implement warrior skill restrictions and UI tags

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -680,6 +680,7 @@ body {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
+    pointer-events: auto; /* ✨ 마우스 이벤트 활성화 */
 }
 
 #skill-list-panel { flex-basis: 20%; }
@@ -866,10 +867,25 @@ body {
     float: left;
     margin: 4px;
     cursor: grab;
+    position: relative; /* ✨ 태그 위치 기준 */
 }
 .skill-inventory-card:hover {
     border-color: #fff;
     transform: scale(1.05);
+}
+
+/* ✨ 스킬 클래스 태그 스타일 */
+.skill-class-tag {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: #ffc107;
+    font-size: 10px;
+    font-weight: bold;
+    padding: 1px 3px;
+    border-radius: 2px;
+    line-height: 1;
 }
 
 /* --- 스킬 툴팁 스타일 --- */

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -7,5 +7,6 @@ export const activeSkills = {
         cost: 2,
         description: '적에게 돌진하여 데미지를 주며 적을 2턴간 기절시킵니다.',
         illustrationPath: 'assets/images/skills/charge.png',
+        requiredClass: 'warrior', // ✨ 전사 전용 설정
     },
 };

--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -7,5 +7,6 @@ export const buffSkills = {
         cost: 1,
         description: '5턴간 자기 자신에게 데미지 감소 5%의 버프를 겁니다. 최대 중첩 25%',
         illustrationPath: 'assets/images/skills/ston-skin.png',
+        requiredClass: 'warrior', // ✨ 전사 전용 설정
     },
 };

--- a/src/game/data/skills/debuff.js
+++ b/src/game/data/skills/debuff.js
@@ -7,5 +7,6 @@ export const debuffSkills = {
         cost: 2,
         description: '적에게 5턴간 물리방어력 감소 5%의 디버프를 겁니다. 최대 중첩 25%',
         illustrationPath: 'assets/images/skills/shield-break.png',
+        requiredClass: 'warrior', // ✨ 전사 전용 설정
     },
 };

--- a/src/game/data/skills/passive.js
+++ b/src/game/data/skills/passive.js
@@ -7,5 +7,6 @@ export const passiveSkills = {
         cost: 0,
         description: '체력이 적을 수록 받는 데미지가 감소합니다. 최대 30%감소',
         illustrationPath: 'assets/images/skills/iron_will.png',
+        requiredClass: 'warrior', // ✨ 전사 전용 설정
     },
 };

--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -17,8 +17,8 @@ export class SkillManagementDOMEngine {
             document.getElementById('app').appendChild(this.container);
         }
 
-        // 선택된 용병의 ID를 추적
-        this.selectedMercenaryId = null;
+        // ✨ 선택된 용병의 전체 데이터를 저장
+        this.selectedMercenaryData = null;
 
         this.createView();
         this.populateSkillInventory();
@@ -95,7 +95,8 @@ export class SkillManagementDOMEngine {
     }
 
     selectMercenary(mercData) {
-        this.selectedMercenaryId = mercData.uniqueId;
+        // ✨ 선택된 용병 정보 저장
+        this.selectedMercenaryData = mercData;
         this.mercenaryDetailsContent.innerHTML = '';
 
         // --- ✨ 용병 초상화 ---
@@ -171,6 +172,15 @@ export class SkillManagementDOMEngine {
             cardElement.onmouseenter = (e) => SkillTooltipManager.show(skill.id, e);
             cardElement.onmouseleave = () => SkillTooltipManager.hide();
 
+            // ✨ 클래스 전용 태그 추가
+            if (skill.requiredClass) {
+                const tag = document.createElement('div');
+                tag.className = 'skill-class-tag';
+                const className = skill.requiredClass === 'warrior' ? '전사' : skill.requiredClass;
+                tag.textContent = `[${className}]`;
+                cardElement.appendChild(tag);
+            }
+
             this.skillInventoryContent.appendChild(cardElement);
         });
     }
@@ -182,9 +192,20 @@ export class SkillManagementDOMEngine {
         const slot = event.currentTarget;
         const slotType = slot.dataset.slotType;
 
+        if (!this.selectedMercenaryData) {
+            console.warn("스킬을 장착할 용병을 먼저 선택해주세요.");
+            return;
+        }
+
+        // ✨ 클래스 요구사항 확인
+        if (skillData.requiredClass && this.selectedMercenaryData.id !== skillData.requiredClass) {
+            alert(`[${skillData.name}] 스킬은 [${skillData.requiredClass}] 클래스 전용입니다.`);
+            return;
+        }
+
         // 스킬 타입이 슬롯 타입과 맞는지 확인
         if (skillData && skillData.type === slotType) {
-            const unitId = this.selectedMercenaryId;
+            const unitId = this.selectedMercenaryData.uniqueId;
             const slotIndex = parseInt(slot.dataset.slotIndex);
             
             // 스킬 장착 및 UI 업데이트


### PR DESCRIPTION
## Summary
- enable interaction inside skill management panels
- mark warrior-only skills across data files
- show class tags on skill cards in inventory
- restrict equipping skills to correct class in UI

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6880ccebbd448327b38923caca5cbca5