### PR TITLE
Implement skill instance system

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -721,14 +721,20 @@ body {
 .merc-skill-slot {
     width: 80px;
     height: 80px;
-    background-size: contain;
-    background-repeat: no-repeat;
+    background-size: cover;
     background-position: center;
+    border: 3px solid #888;
+    border-radius: 5px;
     position: relative;
     display: flex;
     align-items: flex-end;
     justify-content: center;
+    cursor: pointer;
 }
+.merc-skill-slot.active-slot { border-color: #FF8C00; }
+.merc-skill-slot.buff-slot { border-color: #1E90FF; }
+.merc-skill-slot.debuff-slot { border-color: #DC143C; }
+.merc-skill-slot.passive-slot { border-color: #32CD32; }
 .merc-skill-slot span {
     background-color: rgba(0,0,0,0.7);
     width: 100%;
@@ -850,11 +856,6 @@ body {
     padding-top: 10px;
 }
 
-.merc-skill-slot {
-    width: 80px;
-    height: 80px; /* 정사각형 */
-    /* ... 나머지 스타일은 기존과 유사 */
-}
 
 /* --- 스킬 인벤토리 카드 --- */
 .skill-inventory-card {
@@ -862,17 +863,22 @@ body {
     height: 60px;
     background-size: cover;
     background-position: center;
-    border: 2px solid #555;
+    border: 3px solid #555;
     border-radius: 4px;
     float: left;
     margin: 4px;
     cursor: grab;
-    position: relative; /* ✨ 태그 위치 기준 */
+    position: relative;
+    box-sizing: border-box;
 }
 .skill-inventory-card:hover {
     border-color: #fff;
     transform: scale(1.05);
 }
+.skill-inventory-card.active-card { border-color: #FF8C00; }
+.skill-inventory-card.buff-card { border-color: #1E90FF; }
+.skill-inventory-card.debuff-card { border-color: #DC143C; }
+.skill-inventory-card.passive-card { border-color: #32CD32; }
 
 /* ✨ 스킬 클래스 태그 스타일 */
 .skill-class-tag {
@@ -918,3 +924,14 @@ body {
 .skill-info-large { padding: 8px; /* ... */ }
 .skill-name-large { font-size: 18px; /* ... */ }
 /* ... 나머지 툴팁 내부 스타일 ... */
+.skill-cost-container-large {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 2px;
+}
+
+.token-icon-large {
+    width: 12px;
+    height: 12px;
+}

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -76,10 +76,11 @@ export class UnitDetailDOM {
         if (unitData.skillSlots && unitData.skillSlots.length > 0) {
             unitData.skillSlots.forEach((slotType, index) => {
                 const typeClass = `${slotType.toLowerCase()}-slot`;
-                const equippedSkillId = equippedSkills[index];
+                const instanceId = equippedSkills[index];
                 let bgImage = 'url(assets/images/skills/skill-slot.png)';
-                if (equippedSkillId) {
-                    const skillData = skillInventoryManager.getSkillData(equippedSkillId);
+                if (instanceId) {
+                    const skillId = skillInventoryManager.getSkillIdByInstance(instanceId);
+                    const skillData = skillInventoryManager.getSkillData(skillId);
                     if (skillData) bgImage = `url(${skillData.illustrationPath})`;
                 }
                 skillsHTML += `

--- a/src/game/utils/OwnedSkillsManager.js
+++ b/src/game/utils/OwnedSkillsManager.js
@@ -2,18 +2,15 @@ import { debugLogEngine } from './DebugLogEngine.js';
 
 /**
  * 각 용병이 장착한 스킬을 관리하는 매니저
+ * 스킬 인스턴스 ID를 저장합니다.
  */
 class OwnedSkillsManager {
     constructor() {
-        // key: unit.uniqueId, value: an array of 3 elements [skillId | null, skillId | null, skillId | null]
+        // key: unitId => [instanceId|null, ...]
         this.equippedSkills = new Map();
         debugLogEngine.log('OwnedSkillsManager', '보유 스킬 매니저가 초기화되었습니다.');
     }
 
-    /**
-     * 특정 용병의 스킬 슬롯 정보를 초기화합니다.
-     * @param {number} unitId - 용병의 고유 ID
-     */
     initializeSlots(unitId) {
         if (!this.equippedSkills.has(unitId)) {
             this.equippedSkills.set(unitId, [null, null, null]);
@@ -21,26 +18,33 @@ class OwnedSkillsManager {
     }
 
     /**
-     * 용병의 특정 슬롯에 스킬을 장착합니다.
-     * @param {number} unitId - 용병의 고유 ID
-     * @param {number} slotIndex - 장착할 슬롯 인덱스 (0, 1, 2)
-     * @param {string} skillId - 장착할 스킬의 ID
-     * @returns {string|null} - 원래 장착되어 있던 스킬 ID (스왑용)
+     * 용병의 특정 슬롯에 스킬 인스턴스를 장착합니다.
+     * @param {number} unitId
+     * @param {number} slotIndex
+     * @param {number} instanceId
+     * @returns {number|null} 기존 인스턴스 ID
      */
-    equipSkill(unitId, slotIndex, skillId) {
+    equipSkill(unitId, slotIndex, instanceId) {
         this.initializeSlots(unitId);
         const slots = this.equippedSkills.get(unitId);
-        const previousSkillId = slots[slotIndex];
-        slots[slotIndex] = skillId;
-        console.log(`[OwnedSkillsManager] 유닛 ${unitId}의 ${slotIndex}번 슬롯에 ${skillId} 장착. 이전 스킬: ${previousSkillId}`);
-        return previousSkillId;
+        const prev = slots[slotIndex];
+        slots[slotIndex] = instanceId;
+        console.log(`[OwnedSkillsManager] 유닛 ${unitId}의 ${slotIndex}번 슬롯에 스킬 인스턴스 ${instanceId} 장착. 이전 스킬: ${prev}`);
+        return prev;
     }
 
     /**
-     * 특정 용병이 장착한 스킬 목록을 반환합니다.
-     * @param {number} unitId - 용병의 고유 ID
-     * @returns {Array<string|null>}
+     * 장착 해제
      */
+    unequipSkill(unitId, slotIndex) {
+        if (!this.equippedSkills.has(unitId)) return null;
+        const slots = this.equippedSkills.get(unitId);
+        const removed = slots[slotIndex];
+        slots[slotIndex] = null;
+        console.log(`[OwnedSkillsManager] 유닛 ${unitId}의 ${slotIndex}번 슬롯에서 스킬 인스턴스 ${removed} 해제.`);
+        return removed;
+    }
+
     getEquippedSkills(unitId) {
         this.initializeSlots(unitId);
         return this.equippedSkills.get(unitId);

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -3,43 +3,64 @@ import { skillCardDatabase } from '../data/skills/SkillCardDatabase.js';
 
 /**
  * 플레이어가 획득한 모든 스킬 카드의 인벤토리를 관리하는 엔진
+ * 각 스킬 카드는 고유 instanceId로 관리됩니다.
  */
 class SkillInventoryManager {
     constructor() {
-        this.skillInventory = new Map();
+        /** 인벤토리 안에 있는 스킬 인스턴스 목록 */
+        this.skillInventory = [];
+        /** 모든 인스턴스의 매핑을 보존 */
+        this.instanceMap = new Map();
+        this.nextInstanceId = 1;
         debugLogEngine.log('SkillInventoryManager', '스킬 인벤토리 매니저가 초기화되었습니다.');
         this.initializeSkillCards();
     }
 
+    /**
+     * 게임 시작 시 기본 스킬 카드를 지급합니다.
+     */
     initializeSkillCards() {
-        this.addSkillCards(skillCardDatabase);
-    }
-
-    addSkillCards(skillObject) {
-        for (const skillId in skillObject) {
-            if (skillObject.hasOwnProperty(skillId)) {
-                const skillData = skillObject[skillId];
-                this.skillInventory.set(
-                    skillId,
-                    { details: skillData, count: (this.skillInventory.get(skillId)?.count || 0) + 1 }
-                );
+        for (const skillId in skillCardDatabase) {
+            if (skillCardDatabase.hasOwnProperty(skillId)) {
+                this.addSkillById(skillId);
+                this.addSkillById(skillId);
             }
         }
-        debugLogEngine.log('SkillInventoryManager', '초기 스킬 카드 로드 완료.');
+        debugLogEngine.log('SkillInventoryManager', `초기 스킬 카드 ${this.skillInventory.length}장 생성 완료.`);
     }
 
-    getInventory() {
-        return Array.from(this.skillInventory.keys()).map(id => skillCardDatabase[id]);
-    }
-    
     /**
-     * ✨ [추가] 스킬 ID로 스킬 데이터를 반환하는 헬퍼 메서드
+     * 스킬 ID를 기반으로 새로운 스킬 인스턴스를 생성해 인벤토리에 추가합니다.
+     * @param {string} skillId
      */
+    addSkillById(skillId) {
+        const instance = { instanceId: this.nextInstanceId++, skillId };
+        this.skillInventory.push(instance);
+        this.instanceMap.set(instance.instanceId, skillId);
+    }
+
+    /**
+     * 인벤토리에서 특정 인스턴스를 제거합니다.
+     * @param {number} instanceId
+     */
+    removeSkillByInstanceId(instanceId) {
+        this.skillInventory = this.skillInventory.filter(s => s.instanceId !== instanceId);
+    }
+
+    /** 현재 인벤토리에 있는 스킬 인스턴스 배열을 반환 */
+    getInventory() {
+        return this.skillInventory;
+    }
+
+    /** 스킬 ID로 스킬 데이터 조회 */
     getSkillData(skillId) {
         return skillCardDatabase[skillId];
     }
 
-    // 향후 여기에 스킬 획득/폐기/조회 관련 메서드가 추가될 것입니다.
+    /** 인스턴스 ID로 스킬 ID 조회 */
+    getSkillIdByInstance(instanceId) {
+        return this.instanceMap.get(instanceId);
+    }
 }
 
 export const skillInventoryManager = new SkillInventoryManager();


### PR DESCRIPTION
## Summary
- support skill slot UI styling
- track skill cards as unique instances
- manage equipped skills via instance IDs
- rework skill management UI to handle new inventory system
- update unit detail view to map instance IDs to skills

## Testing
- `npm run build-nolog`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6880d50419748327ae7df3773ce1bbeb