### PR TITLE
Add skill-based melee AI behavior

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -46,6 +46,10 @@ class AIManager {
         const data = this.unitData.get(unit.uniqueId);
         if (!data) return;
 
+        // 턴 시작 시 블랙보드 플래그 초기화
+        data.behaviorTree.blackboard.set('hasMovedThisTurn', false);
+        data.behaviorTree.blackboard.set('usedSkillsThisTurn', new Set());
+
         console.group(`[AIManager] --- ${data.instance.instanceName} (ID: ${unit.uniqueId}) 턴 시작 ---`);
 
         await data.behaviorTree.execute(unit, allUnits, enemyUnits);

--- a/src/ai/Blackboard.js
+++ b/src/ai/Blackboard.js
@@ -33,6 +33,11 @@ class Blackboard {
         // --- 이동 및 공격 관련 신규 정보 ---
         this.set('movementPath', null);
         this.set('isTargetInAttackRange', false);
+
+        // --- 턴 진행 플래그 ---
+        this.set('hasMovedThisTurn', false);
+        this.set('usedSkillsThisTurn', new Set());
+        this.set('currentTargetSkill', null);
     }
 
     set(key, value) {

--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -1,49 +1,83 @@
 import BehaviorTree from '../BehaviorTree.js';
 import SelectorNode from '../nodes/SelectorNode.js';
 import SequenceNode from '../nodes/SequenceNode.js';
-import FindTargetNode from '../nodes/FindTargetNode.js';
+import IsTargetValidNode from '../nodes/IsTargetValidNode.js';
+import FindPreferredTargetNode from '../nodes/FindPreferredTargetNode.js';
 import IsTargetInRangeNode from '../nodes/IsTargetInRangeNode.js';
 import AttackTargetNode from '../nodes/AttackTargetNode.js';
-import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
-import IsTargetValidNode from '../nodes/IsTargetValidNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
 import SuccessNode from '../nodes/SuccessNode.js';
 
-/**
- * 근접 유닛을 위한 범용 행동 트리를 생성합니다.
- * 수정된 행동 로직:
- * 1. 대상 확보: 유효한 타겟이 있는가? 없다면 새로 찾는다.
- * 2. 행동 실행:
- * - (우선) 현재 위치에서 공격을 시도한다.
- * - (차선) 공격이 안되면, 적에게 이동한 후 다시 공격을 시도한다.
- * - 둘 다 안되면 턴을 마친다.
- * @param {object} engines - AI 노드들이 사용할 엔진 및 매니저 모음
- * @returns {BehaviorTree}
- */
-function createMeleeAI(engines) {
+// 스킬 및 추가 이동을 위한 노드
+import FindBestSkillNode from '../nodes/FindBestSkillNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import CanExtraMoveNode from '../nodes/CanExtraMoveNode.js';
+import SpendTokenForExtraMoveNode from '../nodes/SpendTokenForExtraMoveNode.js';
+
+function createMeleeAI(engines = {}) {
     const rootNode = new SequenceNode([
-        // 단계 1: 타겟 확보 (현재 타겟이 유효한지 먼저 검사하고, 없으면 탐색)
+        // [1단계] 유효한 타겟 설정
         new SelectorNode([
             new IsTargetValidNode(),
-            new FindTargetNode(engines),
+            new FindPreferredTargetNode(engines),
         ]),
-        // 단계 2: 확보된 타겟에 대해 행동 결정 (더 유연한 구조로 변경)
+
+        // [2단계] 주 행동 페이즈
         new SelectorNode([
-            // 2a. (최우선) 사거리 내라면 즉시 공격
+            // (A) 제자리 스킬 사용
+            new SequenceNode([
+                new FindBestSkillNode(engines),
+                new IsSkillInRangeNode(engines),
+                new UseSkillNode(engines),
+            ]),
+            // (B) 이동 후 스킬 사용
+            new SequenceNode([
+                new FindBestSkillNode(engines),
+                new FindPathToSkillRangeNode(engines),
+                new MoveToTargetNode(engines),
+                new IsSkillInRangeNode(engines),
+                new UseSkillNode(engines),
+            ]),
+            // (C) 제자리 일반 공격
             new SequenceNode([
                 new IsTargetInRangeNode(),
                 new AttackTargetNode(engines),
             ]),
-            // 2b. (차선) 사거리 밖이라면 이동 후 반드시 공격
+            // (D) 이동 후 일반 공격
             new SequenceNode([
                 new FindPathToTargetNode(engines),
                 new MoveToTargetNode(engines),
-                // 이동 후 공격을 다시 시도합니다. 실패하면 이 행동 전체가 실패합니다.
-                new IsTargetInRangeNode(),
                 new AttackTargetNode(engines),
             ]),
-             // 2c. (대안) 공격도, 공격 위치로 이동도 할 수 없을 때
-             // 턴을 성공으로 처리하여 아무것도 하지 않고 턴을 넘김
+        ]),
+
+        // [3단계] 추가 행동 페이즈 (선택적)
+        new SelectorNode([
+            new SequenceNode([
+                new CanExtraMoveNode(engines),
+                new SpendTokenForExtraMoveNode(engines),
+                new SelectorNode([
+                    // (A) 아직 사용 안한 다른 스킬 사용
+                    new SequenceNode([
+                        new FindBestSkillNode(engines),
+                        new FindPathToSkillRangeNode(engines),
+                        new MoveToTargetNode(engines),
+                        new IsSkillInRangeNode(engines),
+                        new UseSkillNode(engines),
+                    ]),
+                    // (B) 일반 공격
+                    new SequenceNode([
+                        new FindPathToTargetNode(engines),
+                        new MoveToTargetNode(engines),
+                        new AttackTargetNode(engines),
+                    ]),
+                    // 이동만 하고 턴 종료
+                    new SuccessNode(),
+                ]),
+            ]),
             new SuccessNode(),
         ]),
     ]);

--- a/src/ai/nodes/CanExtraMoveNode.js
+++ b/src/ai/nodes/CanExtraMoveNode.js
@@ -1,0 +1,26 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { tokenEngine } from '../../game/utils/TokenEngine.js';
+
+class CanExtraMoveNode extends Node {
+    constructor(engines = {}) {
+        super();
+        this.tokenEngine = engines.tokenEngine || tokenEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+
+        const hasMoved = blackboard.get('hasMovedThisTurn');
+        const currentTokens = this.tokenEngine.getTokens(unit.uniqueId);
+
+        if (hasMoved && currentTokens >= 1) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `추가 이동 가능 (현재 토큰: ${currentTokens})`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, `추가 이동 불가 (이동 여부: ${hasMoved}, 토큰: ${currentTokens})`);
+        return NodeState.FAILURE;
+    }
+}
+export default CanExtraMoveNode;

--- a/src/ai/nodes/FindBestSkillNode.js
+++ b/src/ai/nodes/FindBestSkillNode.js
@@ -1,0 +1,37 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { ownedSkillsManager } from '../../game/utils/OwnedSkillsManager.js';
+import { skillInventoryManager } from '../../game/utils/SkillInventoryManager.js';
+import { skillEngine } from '../../game/utils/SkillEngine.js';
+
+class FindBestSkillNode extends Node {
+    constructor(engines = {}) {
+        super();
+        this.skillEngine = engines.skillEngine || skillEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+
+        const equippedSkillInstances = ownedSkillsManager.getEquippedSkills(unit.uniqueId);
+        const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
+
+        for (const instanceId of equippedSkillInstances) {
+            if (!instanceId || usedSkills.has(instanceId)) continue;
+
+            const skillId = skillInventoryManager.getSkillIdByInstance(instanceId);
+            const skillData = skillInventoryManager.getSkillData(skillId);
+
+            if (this.skillEngine.canUseSkill(unit, skillData)) {
+                blackboard.set('currentTargetSkill', { skillData, instanceId });
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `사용할 스킬 [${skillData.name}] 찾음`);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        blackboard.set('currentTargetSkill', null);
+        debugAIManager.logNodeResult(NodeState.FAILURE, '사용 가능한 스킬 없음');
+        return NodeState.FAILURE;
+    }
+}
+export default FindBestSkillNode;

--- a/src/ai/nodes/FindPathToSkillRangeNode.js
+++ b/src/ai/nodes/FindPathToSkillRangeNode.js
@@ -1,0 +1,74 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+class FindPathToSkillRangeNode extends Node {
+    constructor({ pathfinderEngine, formationEngine } = {}) {
+        super();
+        this.pathfinderEngine = pathfinderEngine;
+        this.formationEngine = formationEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const target = blackboard.get('currentTargetUnit');
+        const skillInfo = blackboard.get('currentTargetSkill');
+
+        if (!target || !skillInfo) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '타겟 또는 스킬 정보 없음');
+            return NodeState.FAILURE;
+        }
+
+        const skillData = skillInfo.skillData;
+        const skillRange = skillData.range || unit.finalStats.attackRange || 1;
+
+        const path = this._findPathToUnit(unit, target, skillRange);
+        if (path) {
+            blackboard.set('movementPath', path);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skillData.name}] 사용 위치로 경로 설정`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '스킬 사용 위치로의 경로 탐색 실패');
+        return NodeState.FAILURE;
+    }
+
+    _findPathToUnit(unit, target, range) {
+        const start = { col: unit.gridX, row: unit.gridY };
+        const targetPos = { col: target.gridX, row: target.gridY };
+
+        const distanceToTarget = Math.abs(start.col - targetPos.col) + Math.abs(start.row - targetPos.row);
+        if (distanceToTarget <= range) {
+            return [];
+        }
+
+        const potentialCells = [];
+        for (let r = 0; r < this.formationEngine.grid.rows; r++) {
+            for (let c = 0; c < this.formationEngine.grid.cols; c++) {
+                const distance = Math.abs(c - targetPos.col) + Math.abs(r - targetPos.row);
+                if (distance <= range) {
+                    const cell = this.formationEngine.grid.getCell(c, r);
+                    if (cell && (!cell.isOccupied || (c === start.col && r === start.row))) {
+                        potentialCells.push(cell);
+                    }
+                }
+            }
+        }
+
+        if (potentialCells.length === 0) return null;
+
+        potentialCells.sort((a, b) => {
+            const distA = Math.abs(a.col - start.col) + Math.abs(a.row - start.row);
+            const distB = Math.abs(b.col - start.col) + Math.abs(b.row - start.row);
+            return distA - distB;
+        });
+
+        for (const bestCell of potentialCells) {
+            const path = this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
+            if (path && path.length > 0) {
+                return path;
+            }
+        }
+        return null;
+    }
+}
+export default FindPathToSkillRangeNode;

--- a/src/ai/nodes/IsSkillInRangeNode.js
+++ b/src/ai/nodes/IsSkillInRangeNode.js
@@ -1,0 +1,28 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+class IsSkillInRangeNode extends Node {
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const target = blackboard.get('currentTargetUnit');
+        const skillInfo = blackboard.get('currentTargetSkill');
+
+        if (!target || !skillInfo) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '타겟 또는 스킬 정보 없음');
+            return NodeState.FAILURE;
+        }
+
+        const skillData = skillInfo.skillData;
+        const attackRange = skillData.range || unit.finalStats.attackRange || 1;
+        const distance = Math.abs(unit.gridX - target.gridX) + Math.abs(unit.gridY - target.gridY);
+
+        if (distance <= attackRange) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skillData.name}] 사거리 내`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, `스킬 [${skillData.name}] 사거리 밖`);
+        return NodeState.FAILURE;
+    }
+}
+export default IsSkillInRangeNode;

--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -49,6 +49,9 @@ class MoveToTargetNode extends Node {
             finalCell.sprite = unit.sprite;
         }
 
+        // 이동 완료 플래그 설정
+        blackboard.set('hasMovedThisTurn', true);
+
         debugAIManager.logNodeResult(NodeState.SUCCESS);
         return NodeState.SUCCESS;
     }

--- a/src/ai/nodes/SpendTokenForExtraMoveNode.js
+++ b/src/ai/nodes/SpendTokenForExtraMoveNode.js
@@ -1,0 +1,24 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { tokenEngine } from '../../game/utils/TokenEngine.js';
+
+class SpendTokenForExtraMoveNode extends Node {
+    constructor(engines = {}) {
+        super();
+        this.tokenEngine = engines.tokenEngine || tokenEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const success = this.tokenEngine.spendTokens(unit.uniqueId, 1);
+
+        if (success) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, '추가 이동을 위해 토큰 1개 소모');
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '토큰 소모 실패');
+        return NodeState.FAILURE;
+    }
+}
+export default SpendTokenForExtraMoveNode;

--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -1,0 +1,43 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { skillEngine } from '../../game/utils/SkillEngine.js';
+
+class UseSkillNode extends Node {
+    constructor({ vfxManager, animationEngine, delayEngine, terminationManager, skillEngine: se } = {}) {
+        super();
+        this.animationEngine = animationEngine;
+        this.delayEngine = delayEngine;
+        this.skillEngine = se || skillEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const target = blackboard.get('currentTargetUnit');
+        const skillInfo = blackboard.get('currentTargetSkill');
+
+        if (!target || !skillInfo) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '스킬 대상 또는 스킬 정보 없음');
+            return NodeState.FAILURE;
+        }
+
+        const { skillData, instanceId } = skillInfo;
+
+        this.skillEngine.recordSkillUse(unit, skillData);
+
+        const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
+        usedSkills.add(instanceId);
+        blackboard.set('usedSkillsThisTurn', usedSkills);
+
+        await this.animationEngine.attack(unit.sprite, target.sprite);
+
+        console.log(`[AI] ${unit.instanceName}이(가) ${target.instanceName}에게 스킬 [${skillData.name}] 사용!`);
+
+        blackboard.set('currentTargetSkill', null);
+
+        await this.delayEngine.hold(200);
+
+        debugAIManager.logNodeResult(NodeState.SUCCESS);
+        return NodeState.SUCCESS;
+    }
+}
+export default UseSkillNode;


### PR DESCRIPTION
## Summary
- extend `Blackboard` with per-turn flags for movement and skill use
- reset new flags each turn in `AIManager`
- mark units as moved in `MoveToTargetNode`
- implement skill-related behaviour nodes
- rebuild melee behaviour tree to use skills and extra move logic
- ensure skills are only cast if still in range after moving

## Testing
- `npm run build-nolog`
- `python3 -m http.server 8000 &` and `curl -s http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6880e7c5ab208327937caeeb43626565