### PR TITLE
Implement status effect system

### DIFF
--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -1,6 +1,7 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
 import { skillEngine } from '../../game/utils/SkillEngine.js';
+import { statusEffectManager } from '../../game/utils/StatusEffectManager.js';
 
 class UseSkillNode extends Node {
     constructor({ vfxManager, animationEngine, delayEngine, terminationManager, skillEngine: se } = {}) {
@@ -29,6 +30,10 @@ class UseSkillNode extends Node {
         blackboard.set('usedSkillsThisTurn', usedSkills);
 
         await this.animationEngine.attack(unit.sprite, target.sprite);
+
+        if (skillData.effect) {
+            statusEffectManager.addEffect(target, skillData);
+        }
 
         console.log(`[AI] ${unit.instanceName}이(가) ${target.instanceName}에게 스킬 [${skillData.name}] 사용!`);
 

--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -1,3 +1,5 @@
+import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
+
 // 버프 스킬 데이터 정의
 export const buffSkills = {
     stoneSkin: {
@@ -8,5 +10,14 @@ export const buffSkills = {
         description: '5턴간 자기 자신에게 데미지 감소 5%의 버프를 겁니다. 최대 중첩 25%',
         illustrationPath: 'assets/images/skills/ston-skin.png',
         requiredClass: 'warrior', // ✨ 전사 전용 설정
+        effect: {
+            type: EFFECT_TYPES.BUFF,
+            duration: 5,
+            modifiers: {
+                stat: 'damageReduction',
+                type: 'percentage',
+                value: 0.05
+            }
+        }
     },
 };

--- a/src/game/debug/DebugCombatLogManager.js
+++ b/src/game/debug/DebugCombatLogManager.js
@@ -15,14 +15,23 @@ class DebugCombatLogManager {
      * @param {number} finalDamage - 최종 데미지
      */
     logAttackCalculation(attacker, defender, baseDamage, finalDamage) {
-        console.groupCollapsed(`%c[${this.name}]`, `color: #d946ef; font-weight: bold;`, `${attacker.name}이(가) ${defender.name}을(를) 공격!`);
-        
+        const atkName = attacker.instanceName || attacker.name || 'unknown';
+        const defName = defender.instanceName || defender.name || 'unknown';
+        const atkValue = attacker.finalStats?.physicalAttack ?? attacker.atk;
+        const defValue = defender.finalStats?.physicalDefense ?? defender.def;
+
+        console.groupCollapsed(
+            `%c[${this.name}]`,
+            `color: #d946ef; font-weight: bold;`,
+            `${atkName}이(가) ${defName}을(를) 공격!`
+        );
+
         debugLogEngine.log(this.name, '--- 공격 상세 계산 ---');
-        debugLogEngine.log(this.name, `공격자: ${attacker.name} (공격력: ${attacker.atk})`);
-        debugLogEngine.log(this.name, `방어자: ${defender.name} (방어력: ${defender.def})`);
+        debugLogEngine.log(this.name, `공격자: ${atkName} (공격력: ${atkValue})`);
+        debugLogEngine.log(this.name, `방어자: ${defName} (방어력: ${defValue})`);
         debugLogEngine.log(this.name, `기본 데미지: ${baseDamage}`);
         debugLogEngine.log(this.name, `데미지 공식: 기본 데미지 - 방어자 방어력`);
-        debugLogEngine.log(this.name, `계산: ${baseDamage} - ${defender.def} = ${finalDamage}`);
+        debugLogEngine.log(this.name, `계산: ${baseDamage} - ${defValue} = ${finalDamage}`);
         debugLogEngine.log(this.name, `최종 적용 데미지: ${finalDamage}`);
         
         console.groupEnd();

--- a/src/game/debug/DebugStatusEffectManager.js
+++ b/src/game/debug/DebugStatusEffectManager.js
@@ -1,0 +1,44 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+import { EFFECT_TYPES } from '../utils/StatusEffectManager.js';
+
+class DebugStatusEffectManager {
+    constructor() {
+        this.name = 'DebugStatusEffect';
+        debugLogEngine.register(this);
+    }
+
+    logEffectApplied(unit, effect) {
+        const color = effect.type === EFFECT_TYPES.BUFF ? '#22c55e' : '#ef4444';
+        console.groupCollapsed(
+            `%c[${this.name}]`, `color: #a78bfa; font-weight: bold;`,
+            `%c[${effect.type}]`, `color: ${color}; font-weight: bold;`,
+            `${unit.instanceName}에게 [${effect.sourceSkillName}] 효과 적용 (${effect.duration}턴)`
+        );
+        console.table(effect.modifiers);
+        console.groupEnd();
+    }
+
+    logEffectExpired(unitId, effect) {
+        debugLogEngine.log(this.name, `유닛(ID:${unitId})의 [${effect.sourceSkillName}] 효과 만료됨.`);
+    }
+
+    /**
+     * 데미지 계산 과정에서 상태 효과가 어떻게 영향을 미쳤는지 로그로 남깁니다.
+     * @param {object} unit - 효과를 받는 유닛
+     * @param {number} originalDamage - 원래 데미지
+     * @param {number} modifiedDamage - 효과 적용 후 데미지
+     * @param {Array<object>} effects - 적용된 효과 목록
+     */
+    logDamageModification(unit, originalDamage, modifiedDamage, effects) {
+         const effectNames = effects.map(e => e.sourceSkillName).join(', ');
+         console.groupCollapsed(
+            `%c[${this.name}]`, `color: #a78bfa; font-weight: bold;`,
+            `${unit.instanceName}의 [${effectNames}] 효과로 피해량 변경`
+        );
+        debugLogEngine.log(this.name, `원래 피해량: ${originalDamage.toFixed(2)}`);
+        debugLogEngine.log(this.name, `최종 피해량: %c${modifiedDamage.toFixed(2)}`, `color: #ef4444; font-weight:bold;`);
+        console.groupEnd();
+    }
+}
+
+export const debugStatusEffectManager = new DebugStatusEffectManager();

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -18,6 +18,7 @@ import { delayEngine } from './DelayEngine.js';
 // --- ✨ TokenEngine을 import 합니다. ---
 import { tokenEngine } from './TokenEngine.js';
 import { skillEngine } from './SkillEngine.js';
+import { statusEffectManager } from './StatusEffectManager.js';
 
 
 export class BattleSimulatorEngine {
@@ -145,9 +146,8 @@ export class BattleSimulatorEngine {
                 this.currentTurnIndex = 0;
                 this.currentTurnNumber++; // 모든 유닛의 턴이 끝나면 전체 턴 수 증가
 
-                // 새로운 턴이 시작되었으므로 토큰을 1개씩 지급합니다.
+                statusEffectManager.onTurnEnd();
                 tokenEngine.addOneTokenPerTurn();
-                // 스킬 사용 기록 초기화
                 skillEngine.resetTurnActions();
             }
 

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -1,4 +1,6 @@
 import { debugCombatLogManager } from '../debug/DebugCombatLogManager.js';
+import { statusEffectManager } from './StatusEffectManager.js';
+import { debugStatusEffectManager } from '../debug/DebugStatusEffectManager.js';
 
 /**
  * 실제 전투 데미지 계산을 담당하는 엔진
@@ -11,10 +13,22 @@ class CombatCalculationEngine {
      * @returns {number} 최종 적용될 데미지
      */
     calculateDamage(attacker = {}, defender = {}) {
-        const base = attacker.finalStats?.physicalAttack || 0;
-        const def = defender.finalStats?.physicalDefense || 0;
-        const finalDamage = Math.max(1, base - def);
-        debugCombatLogManager.logAttackCalculation(attacker, defender, base, finalDamage);
+        const baseAttack = attacker.finalStats?.physicalAttack || 0;
+        const baseDefense = defender.finalStats?.physicalDefense || 0;
+
+        const initialDamage = Math.max(1, baseAttack - baseDefense);
+
+        const damageReductionPercent = statusEffectManager.getModifierValue(defender, 'damageReduction');
+
+        const finalDamage = initialDamage * (1 - damageReductionPercent);
+
+        if (damageReductionPercent > 0) {
+            const effects = (statusEffectManager.activeEffects.get(defender.uniqueId) || [])
+                .filter(e => e.modifiers.stat === 'damageReduction');
+            debugStatusEffectManager.logDamageModification(defender, initialDamage, finalDamage, effects);
+        }
+
+        debugCombatLogManager.logAttackCalculation(attacker, defender, baseAttack, finalDamage);
         return finalDamage;
     }
 }

--- a/src/game/utils/StatusEffectManager.js
+++ b/src/game/utils/StatusEffectManager.js
@@ -1,0 +1,86 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+import { debugStatusEffectManager } from '../debug/DebugStatusEffectManager.js';
+
+// 효과의 종류를 명확히 구분하기 위한 상수
+export const EFFECT_TYPES = {
+    BUFF: 'BUFF',
+    DEBUFF: 'DEBUFF',
+    STATUS_EFFECT: 'STATUS_EFFECT', // 기절, 빙결 등 행동을 제어하는 효과
+};
+
+/**
+ * 게임 내 모든 상태 효과(버프, 디버프, 상태이상)를 관리하는 중앙 엔진
+ */
+class StatusEffectManager {
+    constructor() {
+        // key: unitId, value: Array of active effects
+        this.activeEffects = new Map();
+        this.nextEffectInstanceId = 1;
+        debugLogEngine.log('StatusEffectManager', '상태 효과 매니저가 초기화되었습니다.');
+    }
+
+    /**
+     * 턴 종료 시 모든 활성 효과의 지속시간을 감소시키고 만료된 효과를 제거합니다.
+     */
+    onTurnEnd() {
+        for (const [unitId, effects] of this.activeEffects.entries()) {
+            const remainingEffects = [];
+            for (const effect of effects) {
+                effect.duration--;
+                if (effect.duration > 0) {
+                    remainingEffects.push(effect);
+                } else {
+                    debugStatusEffectManager.logEffectExpired(unitId, effect);
+                }
+            }
+            this.activeEffects.set(unitId, remainingEffects);
+        }
+    }
+
+    /**
+     * 대상 유닛에게 새로운 상태 효과를 적용합니다.
+     * @param {object} targetUnit - 효과를 받을 유닛
+     * @param {object} sourceSkill - 효과를 발생시킨 스킬 데이터
+     */
+    addEffect(targetUnit, sourceSkill) {
+        if (!sourceSkill.effect) return;
+
+        const newEffect = {
+            instanceId: this.nextEffectInstanceId++,
+            ...sourceSkill.effect,
+            sourceSkillName: sourceSkill.name,
+        };
+
+        if (!this.activeEffects.has(targetUnit.uniqueId)) {
+            this.activeEffects.set(targetUnit.uniqueId, []);
+        }
+        this.activeEffects.get(targetUnit.uniqueId).push(newEffect);
+
+        debugStatusEffectManager.logEffectApplied(targetUnit, newEffect);
+    }
+
+    /**
+     * 특정 유닛의 특정 보정치 타입 값을 합산합니다.
+     * @param {object} unit - 대상 유닛
+     * @param {string} modifierType - 계산할 보정치 타입 (예: 'physicalDefense', 'damageReduction')
+     * @returns {number} - 해당 타입의 모든 효과 값을 합산한 결과
+     */
+    getModifierValue(unit, modifierType) {
+        const effects = this.activeEffects.get(unit.uniqueId) || [];
+        let totalValue = 0;
+
+        const relevantEffects = [];
+
+        for (const effect of effects) {
+            if (effect.modifiers && effect.modifiers.stat === modifierType) {
+                totalValue += effect.modifiers.value;
+                relevantEffects.push(effect);
+            }
+        }
+
+        // 값의 변화 로그는 CombatCalculationEngine에서 처리합니다.
+        return totalValue;
+    }
+}
+
+export const statusEffectManager = new StatusEffectManager();


### PR DESCRIPTION
## Summary
- add StatusEffectManager for buff/debuff management
- add DebugStatusEffectManager for effect logging
- update Stone Skin buff to apply damage reduction
- apply status effects in combat calculations and skill usage
- handle effect expiration each round
- improve combat debug log details

## Testing
- `npm run build-nolog`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6880edcc75bc8327b3920ba213c5e1a2