### PR TITLE
Add status effect icon manager and casting VFX

### DIFF
--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -1,11 +1,13 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
-import { skillEngine } from '../../game/utils/SkillEngine.js';
+import { skillEngine, SKILL_TYPES } from '../../game/utils/SkillEngine.js';
 import { statusEffectManager } from '../../game/utils/StatusEffectManager.js';
+import { spriteEngine } from '../../game/utils/SpriteEngine.js';
 
 class UseSkillNode extends Node {
     constructor({ vfxManager, animationEngine, delayEngine, terminationManager, skillEngine: se } = {}) {
         super();
+        this.vfxManager = vfxManager;
         this.animationEngine = animationEngine;
         this.delayEngine = delayEngine;
         this.skillEngine = se || skillEngine;
@@ -40,9 +42,12 @@ class UseSkillNode extends Node {
         usedSkills.add(instanceId);
         blackboard.set('usedSkillsThisTurn', usedSkills);
 
-        if (skillData.targetType === 'self') {
-            // 자신에게 사용하는 모션이 존재한다면 여기서 처리 가능
-            // await this.animationEngine.cast(unit.sprite);
+        // 스킬 이름 표시
+        const skillColor = SKILL_TYPES[skillData.type].color;
+        this.vfxManager.showSkillName(unit.sprite, skillData.name, skillColor);
+
+        if (skillData.type === 'BUFF' || skillData.type === 'DEBUFF') {
+            spriteEngine.changeSpriteForDuration(unit, 'cast', 600);
         } else {
             await this.animationEngine.attack(unit.sprite, skillTarget.sprite);
         }
@@ -55,7 +60,7 @@ class UseSkillNode extends Node {
 
         blackboard.set('currentTargetSkill', null);
 
-        await this.delayEngine.hold(200);
+        await this.delayEngine.hold(500);
 
         debugAIManager.logNodeResult(NodeState.SUCCESS);
         return NodeState.SUCCESS;

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -10,6 +10,7 @@ export const mercenaryData = {
             idle: 'warrior',
             attack: 'warrior-attack',
             hitted: 'warrior-hitted',
+            cast: 'warrior-cast',
         },
         description: '"그는 단 한 사람을 지키기 위해 검을 든다."',
         baseStats: {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -64,6 +64,7 @@ export class Preloader extends Scene
         // --- 전사의 행동별 스프라이트 로드 ---
         this.load.image('warrior-attack', 'images/unit/warrior-attack.png');
         this.load.image('warrior-hitted', 'images/unit/warrior-hitted.png');
+        this.load.image('warrior-cast', 'images/unit/warrior-cast.png');
 
         // --- 거너의 행동별 스프라이트 로드 ---
         this.load.image('gunner-attack', 'images/unit/gunner-attack.png');

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -30,7 +30,7 @@ export class BattleSimulatorEngine {
         this.animationEngine = new AnimationEngine(scene);
         this.textEngine = new OffscreenTextEngine(scene);
         this.bindingManager = new BindingManager(scene);
-        this.vfxManager = new VFXManager(scene);
+        this.vfxManager = new VFXManager(scene, this.textEngine, this.bindingManager);
         this.terminationManager = new TerminationManager(scene);
         
         // AI 노드에 주입할 엔진 패키지
@@ -111,16 +111,7 @@ export class BattleSimulatorEngine {
                 unit.gridY = cell.row;
             }
 
-            const color = (unit.team === 'ally') ? '#63b1ff' : '#ff6363';
-            const nameLabel = this.textEngine.createLabel(unit.sprite, unit.instanceName, color);
-            const healthBar = this.vfxManager.createHealthBar(unit.sprite);
-            unit.healthBar = healthBar;
-
-            // --- ✨ 이름표 생성 후 토큰 UI 생성 ---
-            const tokenContainer = this.vfxManager.createTokenDisplay(unit.sprite, nameLabel);
-
-            // 바인딩은 가장 마지막에 수행
-            this.bindingManager.bind(unit.sprite, [nameLabel, healthBar.background, healthBar.foreground, tokenContainer]);
+            this.vfxManager.setupUnitVFX(unit);
         });
     }
 
@@ -157,6 +148,7 @@ export class BattleSimulatorEngine {
                     this.vfxManager.updateTokenDisplay(unit.uniqueId);
                 }
             });
+            this.vfxManager.updateAllStatusIcons();
 
             await delayEngine.hold(1000);
         }

--- a/src/game/utils/IconManager.js
+++ b/src/game/utils/IconManager.js
@@ -1,0 +1,111 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+import { statusEffectManager } from './StatusEffectManager.js';
+import { skillCardDatabase } from '../data/skills/SkillCardDatabase.js';
+
+/**
+ * 상태 효과 아이콘을 생성하고 관리하는 엔진
+ */
+export class IconManager {
+    constructor(scene, vfxLayer) {
+        this.scene = scene;
+        this.vfxLayer = vfxLayer;
+        // key: unitId, value: { container: Container, icons: Map<effectInstanceId, {icon, text}> }
+        this.activeIconDisplays = new Map();
+        debugLogEngine.log('IconManager', '아이콘 매니저가 초기화되었습니다.');
+    }
+
+    /**
+     * 특정 유닛의 아이콘 표시 컨테이너를 생성합니다.
+     * @param {Phaser.GameObjects.Sprite} parentSprite - 아이콘이 따라다닐 유닛
+     * @param {object} healthBar - 위치 기준이 될 체력바
+     */
+    createIconDisplay(parentSprite, healthBar) {
+        const unitId = parentSprite.getData('unitId');
+        if (!unitId || this.activeIconDisplays.has(unitId)) return;
+
+        const container = this.scene.add.container(healthBar.background.x, healthBar.background.y + 12);
+        this.vfxLayer.add(container);
+
+        this.activeIconDisplays.set(unitId, {
+            container: container,
+            icons: new Map()
+        });
+        
+        // 유닛의 스프라이트와 바인딩될 수 있도록 컨테이너를 반환합니다.
+        return container;
+    }
+
+    /**
+     * 매 턴, 모든 유닛의 상태 효과 아이콘을 최신 정보로 업데이트합니다.
+     */
+    updateAllIcons() {
+        for (const unitId of this.activeIconDisplays.keys()) {
+            this.updateIconsForUnit(unitId);
+        }
+    }
+
+    /**
+     * 특정 유닛의 상태 효과 아이콘을 업데이트합니다.
+     * @param {number} unitId - 대상 유닛의 고유 ID
+     */
+    updateIconsForUnit(unitId) {
+        const display = this.activeIconDisplays.get(unitId);
+        if (!display) return;
+
+        const activeEffects = statusEffectManager.activeEffects.get(unitId) || [];
+        const existingIconIds = new Set(display.icons.keys());
+
+        // 활성 효과를 기반으로 아이콘을 추가하거나 업데이트합니다.
+        activeEffects.forEach((effect, index) => {
+            const skillData = skillCardDatabase[effect.sourceSkillName];
+            if (!skillData) return;
+
+            let iconData = display.icons.get(effect.instanceId);
+
+            if (!iconData) { // 새로운 아이콘 생성
+                const iconContainer = this.scene.add.container(0, 0);
+                const icon = this.scene.add.image(0, 0, skillData.id).setScale(0.2);
+                const turnText = this.scene.add.text(0, 8, effect.duration, {
+                    fontSize: '12px',
+                    color: '#fff',
+                    stroke: '#000',
+                    strokeThickness: 2
+                }).setOrigin(0.5);
+
+                iconContainer.add([icon, turnText]);
+                display.container.add(iconContainer);
+                iconData = { icon: iconContainer, text: turnText };
+                display.icons.set(effect.instanceId, iconData);
+            }
+
+            // 턴 수 업데이트 및 위치 조정
+            iconData.text.setText(effect.duration);
+            iconData.icon.setX(index * 22); // 아이콘 간 간격 조정
+            existingIconIds.delete(effect.instanceId);
+        });
+
+        // 만료된 아이콘 제거
+        existingIconIds.forEach(instanceId => {
+            display.icons.get(instanceId).icon.destroy();
+            display.icons.delete(instanceId);
+        });
+    }
+
+    /**
+     * 유닛이 제거될 때 관련 아이콘 디스플레이도 함께 제거합니다.
+     * @param {number} unitId
+     */
+    removeIconDisplay(unitId) {
+        const display = this.activeIconDisplays.get(unitId);
+        if (display) {
+            display.container.destroy();
+            this.activeIconDisplays.delete(unitId);
+        }
+    }
+
+    shutdown() {
+        this.activeIconDisplays.forEach(({ container }) => container.destroy());
+        this.activeIconDisplays.clear();
+        debugLogEngine.log('IconManager', '아이콘 매니저를 종료합니다.');
+    }
+}


### PR DESCRIPTION
## Summary
- create `IconManager` to manage status effect icons
- enhance `VFXManager` with status icon handling and skill name display
- update `BattleSimulatorEngine` to use new VFX utilities
- show cast animation and skill name in `UseSkillNode`
- load new cast sprite and define it for warrior

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6880f378d2d883278a8e3ec90d8a7bd4