### PR TITLE
Add cooldown manager and enhance charge skill

### DIFF
--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -1,3 +1,5 @@
+import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
+
 // 액티브 스킬 데이터 정의
 export const activeSkills = {
     charge: {
@@ -5,8 +7,16 @@ export const activeSkills = {
         name: '차지',
         type: 'ACTIVE',
         cost: 2,
-        description: '적에게 돌진하여 데미지를 주며 적을 2턴간 기절시킵니다.',
+        // 적에게 돌진하여 데미지를 주고 2턴간 기절시키는 스킬
+        description: '적에게 돌진하여 120%의 데미지를 주고 2턴간 기절시킵니다. (쿨타임 2턴)',
         illustrationPath: 'assets/images/skills/charge.png',
-        requiredClass: 'warrior', // ✨ 전사 전용 설정
+        requiredClass: 'warrior',
+        damageMultiplier: 1.2,
+        cooldown: 2,
+        effect: {
+            type: EFFECT_TYPES.STATUS_EFFECT,
+            id: 'stun',
+            duration: 2,
+        },
     },
 };

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -19,6 +19,7 @@ import { delayEngine } from './DelayEngine.js';
 import { tokenEngine } from './TokenEngine.js';
 import { skillEngine } from './SkillEngine.js';
 import { statusEffectManager } from './StatusEffectManager.js';
+import { cooldownManager } from './CooldownManager.js';
 
 
 export class BattleSimulatorEngine {
@@ -57,6 +58,7 @@ export class BattleSimulatorEngine {
         this.isRunning = true;
 
         aiManager.clear();
+        cooldownManager.reset();
 
         const allUnits = [...allies, ...enemies];
         // --- ✨ 전투 시작 시 토큰 엔진 초기화 ---
@@ -130,6 +132,8 @@ export class BattleSimulatorEngine {
 
                     await aiManager.executeTurn(currentUnit, [...allies, ...enemies], currentUnit.team === 'ally' ? enemies : allies);
                 }
+
+                cooldownManager.reduceCooldowns(currentUnit.uniqueId);
             }
 
             this.currentTurnIndex++;

--- a/src/game/utils/CooldownManager.js
+++ b/src/game/utils/CooldownManager.js
@@ -1,0 +1,61 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+class CooldownManager {
+    constructor() {
+        // key: unitId, value: Map<skillId, remainingTurns>
+        this.cooldowns = new Map();
+        debugLogEngine.log('CooldownManager', '쿨다운 매니저가 초기화되었습니다.');
+    }
+
+    /**
+     * 모든 쿨타임 데이터를 초기화합니다.
+     * 주로 전투 시작 시 호출됩니다.
+     */
+    reset() {
+        this.cooldowns.clear();
+    }
+
+    /**
+     * 유닛의 턴이 끝날 때 호출되어 모든 스킬의 쿨타임을 1턴 감소시킵니다.
+     * @param {number} unitId - 턴을 마친 유닛의 ID
+     */
+    reduceCooldowns(unitId) {
+        if (!this.cooldowns.has(unitId)) return;
+
+        const unitCooldowns = this.cooldowns.get(unitId);
+        for (const [skillId, turns] of unitCooldowns.entries()) {
+            if (turns > 0) {
+                unitCooldowns.set(skillId, turns - 1);
+            }
+        }
+    }
+
+    /**
+     * 특정 스킬을 쿨타임 상태로 설정합니다.
+     * @param {number} unitId
+     * @param {string} skillId
+     * @param {number} duration - 쿨타임 턴 수
+     */
+    setCooldown(unitId, skillId, duration) {
+        if (!this.cooldowns.has(unitId)) {
+            this.cooldowns.set(unitId, new Map());
+        }
+        this.cooldowns.get(unitId).set(skillId, duration);
+        debugLogEngine.log('CooldownManager', `유닛 ${unitId}의 스킬 [${skillId}]에 ${duration}턴 쿨다운 적용.`);
+    }
+
+    /**
+     * 특정 스킬이 사용 가능한 상태인지 확인합니다.
+     * @param {number} unitId
+     * @param {string} skillId
+     * @returns {boolean}
+     */
+    isReady(unitId, skillId) {
+        if (!this.cooldowns.has(unitId)) return true;
+
+        const remainingTurns = this.cooldowns.get(unitId).get(skillId) || 0;
+        return remainingTurns <= 0;
+    }
+}
+
+export const cooldownManager = new CooldownManager();

--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -1,6 +1,7 @@
 import { diceEngine } from './DiceEngine.js';
 import { debugLogEngine } from './DebugLogEngine.js';
-import { tokenEngine } from './TokenEngine.js'; // 토큰 엔진 import
+import { tokenEngine } from './TokenEngine.js';
+import { cooldownManager } from './CooldownManager.js';
 
 // 스킬 종류와 해당 색상, 이름을 상수로 정의합니다.
 export const SKILL_TYPES = {
@@ -56,6 +57,11 @@ class SkillEngine {
             return false;
         }
 
+        // 4. 쿨타임이 지났는가?
+        if (!cooldownManager.isReady(unit.uniqueId, skill.id)) {
+            return false;
+        }
+
         return true;
     }
 
@@ -74,6 +80,10 @@ class SkillEngine {
         this.usedSkillsThisTurn.add(skill.id);
         const currentUses = this.skillUsesThisTurn.get(unit.uniqueId) || 0;
         this.skillUsesThisTurn.set(unit.uniqueId, currentUses + 1);
+
+        if (skill.cooldown && skill.cooldown > 0) {
+            cooldownManager.setCooldown(unit.uniqueId, skill.id, skill.cooldown);
+        }
 
         debugLogEngine.log('SkillEngine', `${unit.instanceName}이(가) 스킬 [${skill.name}] 사용 (토큰 ${skill.cost} 소모).`);
     }


### PR DESCRIPTION
## Summary
- define detailed `charge` skill with damage multiplier, stun effect and cooldown
- implement `CooldownManager` utility for tracking skill cooldowns
- integrate cooldown checks into `SkillEngine`
- decrease cooldowns each turn in `BattleSimulatorEngine`
- reset all cooldowns when a new battle starts

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6880f7e068c8832793a8b4a06e321b4a