### PR TITLE
Implement stun status effect and attack skill

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -25,11 +25,11 @@ function createMeleeAI(engines = {}) {
             new FindPreferredTargetNode(engines),
         ]),
 
-        // [2단계] 주 행동 페이즈
+        // [2단계] 주 행동 페이즈 (✨ 원래의 범용 스킬 사용 로직으로 복원)
         new SelectorNode([
-            // (A) 제자리 스킬 사용
+            // (A) 제자리에서 사용 가능한 첫 번째 스킬 사용
             new SequenceNode([
-                new FindBestSkillNode(engines),
+                new FindBestSkillNode(engines), // 1, 2, 3순위 순서대로 체크
                 new IsSkillInRangeNode(engines),
                 new UseSkillNode(engines),
             ]),
@@ -60,7 +60,7 @@ function createMeleeAI(engines = {}) {
                 new CanExtraMoveNode(engines),
                 new SpendTokenForExtraMoveNode(engines),
                 new SelectorNode([
-                    // (A) 아직 사용 안한 다른 스킬 사용
+                    // (A) 아직 사용 안한 다른 스킬 사용 (2, 3순위 스킬)
                     new SequenceNode([
                         new FindBestSkillNode(engines),
                         new FindPathToSkillRangeNode(engines),

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -2,6 +2,19 @@ import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
 
 // 액티브 스킬 데이터 정의
 export const activeSkills = {
+    // 기본 공격 스킬
+    attack: {
+        id: 'attack',
+        name: '공격',
+        type: 'ACTIVE',
+        cost: 1, // SKILL-SYSTEM.md 규칙에 따라 토큰 1개 소모
+        description: '가장 기본적인 공격입니다.',
+        illustrationPath: 'assets/images/skills/rending_strike.png',
+        requiredClass: null,
+        damageMultiplier: 1.0,
+        cooldown: 0,
+        range: 1,
+    },
     charge: {
         id: 'charge',
         name: '차지',
@@ -13,6 +26,7 @@ export const activeSkills = {
         requiredClass: 'warrior',
         damageMultiplier: 1.2,
         cooldown: 2,
+        range: 1,
         effect: {
             type: EFFECT_TYPES.STATUS_EFFECT,
             id: 'stun',

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -1,0 +1,21 @@
+/**
+ * 모든 상태 효과의 정의를 담는 데이터베이스입니다.
+ * StatusEffectManager는 이 데이터를 참조하여 효과를 적용하고 해제합니다.
+ */
+export const statusEffects = {
+    stun: {
+        id: 'stun',
+        name: '기절',
+        description: '이동, 공격, 스킬 사용이 불가능한 상태가 됩니다.',
+        iconPath: 'assets/images/status-effects/stun.png',
+        onApply: (unit) => {
+            console.log(`${unit.instanceName}이(가) 기절했습니다!`);
+            unit.isStunned = true;
+        },
+        onRemove: (unit) => {
+            console.log(`${unit.instanceName}의 기절이 풀렸습니다.`);
+            unit.isStunned = false;
+        },
+    },
+    // 다른 상태 효과들은 필요 시 여기에 추가합니다.
+};

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,6 +1,7 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { imageSizeManager } from '../utils/ImageSizeManager.js';
+import { statusEffects } from '../data/status-effects.js';
 
 export class Preloader extends Scene
 {
@@ -102,6 +103,12 @@ export class Preloader extends Scene
 
         // --- 추가된 토큰 이미지 로드 ---
         this.load.image('token', 'images/battle/token.png');
+
+        // 상태 효과 아이콘 로드
+        Object.values(statusEffects).forEach(e => {
+            const path = e.iconPath.replace(/^assets\//, '');
+            this.load.image(e.id, path);
+        });
     }
 
     create ()

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -59,6 +59,7 @@ export class BattleSimulatorEngine {
 
         aiManager.clear();
         cooldownManager.reset();
+        statusEffectManager.setBattleSimulator(this);
 
         const allUnits = [...allies, ...enemies];
         // --- ✨ 전투 시작 시 토큰 엔진 초기화 ---
@@ -122,7 +123,7 @@ export class BattleSimulatorEngine {
         while (this.isRunning && !this.isBattleOver()) {
             const currentUnit = this.turnQueue[this.currentTurnIndex];
 
-            if (currentUnit && currentUnit.currentHp > 0) {
+            if (currentUnit && currentUnit.currentHp > 0 && !currentUnit.isStunned) {
                 this.scene.cameraControl.panTo(currentUnit.sprite.x, currentUnit.sprite.y);
                 await delayEngine.hold(500);
 
@@ -133,6 +134,9 @@ export class BattleSimulatorEngine {
                     await aiManager.executeTurn(currentUnit, [...allies, ...enemies], currentUnit.team === 'ally' ? enemies : allies);
                 }
 
+                cooldownManager.reduceCooldowns(currentUnit.uniqueId);
+            } else if (currentUnit && currentUnit.isStunned) {
+                console.log(`%c[Battle] ${currentUnit.instanceName}은(는) 기절해서 움직일 수 없습니다!`, "color: yellow;");
                 cooldownManager.reduceCooldowns(currentUnit.uniqueId);
             }
 

--- a/src/game/utils/IconManager.js
+++ b/src/game/utils/IconManager.js
@@ -1,6 +1,7 @@
 import { debugLogEngine } from './DebugLogEngine.js';
 import { statusEffectManager } from './StatusEffectManager.js';
 import { skillCardDatabase } from '../data/skills/SkillCardDatabase.js';
+import { statusEffects } from '../data/status-effects.js';
 
 /**
  * 상태 효과 아이콘을 생성하고 관리하는 엔진
@@ -57,14 +58,16 @@ export class IconManager {
 
         // 활성 효과를 기반으로 아이콘을 추가하거나 업데이트합니다.
         activeEffects.forEach((effect, index) => {
+            const effectDef = statusEffects[effect.id];
             const skillData = skillCardDatabase[effect.sourceSkillName];
-            if (!skillData) return;
+            const iconKey = effectDef ? effectDef.id : (skillData ? skillData.id : null);
+            if (!iconKey) return;
 
             let iconData = display.icons.get(effect.instanceId);
 
             if (!iconData) { // 새로운 아이콘 생성
                 const iconContainer = this.scene.add.container(0, 0);
-                const icon = this.scene.add.image(0, 0, skillData.id).setScale(0.2);
+                const icon = this.scene.add.image(0, 0, iconKey).setScale(0.2);
                 const turnText = this.scene.add.text(0, 8, effect.duration, {
                     fontSize: '12px',
                     color: '#fff',
@@ -76,6 +79,11 @@ export class IconManager {
                 display.container.add(iconContainer);
                 iconData = { icon: iconContainer, text: turnText };
                 display.icons.set(effect.instanceId, iconData);
+            } else {
+                const image = iconData.icon.list[0];
+                if (image.texture.key !== iconKey) {
+                    image.setTexture(iconKey);
+                }
             }
 
             // 턴 수 업데이트 및 위치 조정


### PR DESCRIPTION
## Summary
- add default `attack` skill alongside `charge`
- define `stun` status effect with onApply/onRemove hooks
- integrate status effect definitions into StatusEffectManager
- skip stunned units in BattleSimulatorEngine
- clarify MeleeAI comments
- hook StatusEffectManager to the battle simulator
- load status effect icons via Preloader and display them with IconManager

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6880fd65705c8327bdae5a656fcc7547