### PR TITLE
Fix token accumulation and basic attack costs

### DIFF
--- a/src/ai/nodes/AttackTargetNode.js
+++ b/src/ai/nodes/AttackTargetNode.js
@@ -1,6 +1,8 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
 import { spriteEngine } from '../../game/utils/SpriteEngine.js';
+import { skillEngine } from '../../game/utils/SkillEngine.js';
+import { skillCardDatabase } from '../../game/data/skills/SkillCardDatabase.js';
 
 class AttackTargetNode extends Node {
     constructor({ combatCalculationEngine, vfxManager, animationEngine, delayEngine, terminationManager }) {
@@ -19,6 +21,14 @@ class AttackTargetNode extends Node {
             debugAIManager.logNodeResult(NodeState.FAILURE);
             return NodeState.FAILURE;
         }
+
+        // ✨ 일반 공격도 토큰을 사용하는 스킬로 간주
+        const attackSkill = skillCardDatabase.attack;
+        if (!skillEngine.canUseSkill(unit, attackSkill)) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '일반 공격을 위한 토큰 부족');
+            return NodeState.FAILURE;
+        }
+        skillEngine.recordSkillUse(unit, attackSkill);
 
         // 공격 스프라이트로 일시 변경
         if (unit.sprite.scene && !spriteEngine.scene) {

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -88,8 +88,8 @@ export class BattleSimulatorEngine {
         this.currentTurnIndex = 0;
         this.currentTurnNumber = 1; // 턴 번호 초기화
 
-        // --- ✨ 첫 턴 시작 시 모든 유닛에게 토큰 1개 지급 ---
-        tokenEngine.addOneTokenPerTurn();
+        // --- ✨ 첫 턴 시작 시 현재 턴 번호에 맞춰 토큰 지급 ---
+        tokenEngine.addTokensForNewTurn(this.currentTurnNumber);
         // 스킬 사용 기록 초기화
         skillEngine.resetTurnActions();
 
@@ -146,7 +146,7 @@ export class BattleSimulatorEngine {
                 this.currentTurnNumber++; // 모든 유닛의 턴이 끝나면 전체 턴 수 증가
 
                 statusEffectManager.onTurnEnd();
-                tokenEngine.addOneTokenPerTurn();
+                tokenEngine.addTokensForNewTurn(this.currentTurnNumber);
                 skillEngine.resetTurnActions();
             }
 

--- a/src/game/utils/TokenEngine.js
+++ b/src/game/utils/TokenEngine.js
@@ -28,13 +28,18 @@ class TokenEngine {
     }
 
     /**
-     * 새로운 턴이 시작될 때 모든 유닛에게 토큰을 1개씩 지급합니다.
+     * 새로운 턴이 시작될 때 모든 유닛에게 토큰을 지급합니다.
+     * 하스스톤처럼 턴이 지날수록 지급량이 늘어나도록
+     * 현재 턴 번호를 받아 해당 수만큼 지급합니다.
+     * @param {number} turnNumber - 현재 턴 번호
      */
-    addOneTokenPerTurn() {
+    addTokensForNewTurn(turnNumber) {
         for (const [unitId, data] of this.tokenData.entries()) {
-            if (data.currentTokens < this.maxTokens) {
-                data.currentTokens += 1;
-                debugTokenManager.logTokenChange(unitId, data.unitName, '턴 시작', 1, data.currentTokens);
+            const newTokens = Math.min(this.maxTokens, data.currentTokens + turnNumber);
+            if (newTokens > data.currentTokens) {
+                const addedAmount = newTokens - data.currentTokens;
+                data.currentTokens = newTokens;
+                debugTokenManager.logTokenChange(unitId, data.unitName, '턴 시작', addedAmount, data.currentTokens);
             }
         }
     }


### PR DESCRIPTION
## Summary
- give players increasing tokens per turn with `addTokensForNewTurn`
- update `BattleSimulatorEngine` to pass the current turn number to the token engine
- treat the default attack as a skill so it also spends tokens

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688102c03224832794b0f00fc02e5b53