### PR TITLE
Add melee AI skill nodes and strategy updates

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -1,83 +1,78 @@
 import BehaviorTree from '../BehaviorTree.js';
 import SelectorNode from '../nodes/SelectorNode.js';
 import SequenceNode from '../nodes/SequenceNode.js';
-import IsTargetValidNode from '../nodes/IsTargetValidNode.js';
-import FindPreferredTargetNode from '../nodes/FindPreferredTargetNode.js';
-import IsTargetInRangeNode from '../nodes/IsTargetInRangeNode.js';
-import AttackTargetNode from '../nodes/AttackTargetNode.js';
-import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
 import SuccessNode from '../nodes/SuccessNode.js';
 
-// 스킬 관련 노드 import
-import FindBestSkillNode from '../nodes/FindBestSkillNode.js';
+// 신규 노드 및 재사용 노드 import
+import CanUseSkillBySlotNode from '../nodes/CanUseSkillBySlotNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
 import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
 import UseSkillNode from '../nodes/UseSkillNode.js';
 import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import FindMeleeStrategicTargetNode from '../nodes/FindMeleeStrategicTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
- * 근접 유닛(전사)을 위한 행동 트리를 생성합니다.
- * 행동 로직이 명확한 우선순위를 가지도록 재구성되었습니다.
+ * 근접 유닛(전사)을 위한 행동 트리를 재구성합니다.
  *
  * 행동 우선순위:
- * 1. (최우선) 스킬 사용: 사용 가능한 스킬이 있다면, 이동해서라도 반드시 사용을 시도합니다.
- * 2. (차선) 일반 공격: 사용할 스킬이 없다면, 이동해서라도 일반 공격을 시도합니다.
- * 3. (최후) 이동만 하기: 공격이나 스킬을 사용할 경로가 없다면, 적에게 최대한 가까이 이동하고 턴을 마칩니다.
+ * 1. 스킬 사용: 1~4순위 스킬을 순서대로 확인하여 사용 가능한 스킬이 있다면, 이동해서라도 사용합니다.
+ * 2. 이동만 하기: 사용할 스킬이 없다면, 전략적 목표를 향해 이동하고 턴을 마칩니다.
  */
 function createMeleeAI(engines = {}) {
-    const rootNode = new SequenceNode([
-        // [1단계] 유효한 타겟 설정 (없으면 새로 찾기)
-        new SelectorNode([
-            new IsTargetValidNode(),
-            new FindPreferredTargetNode(engines),
+
+    // 스킬 하나를 실행하는 공통 로직 (이동 포함)
+    const executeSkillBranch = new SelectorNode([
+        // A. 제자리에서 즉시 사용
+        new SequenceNode([
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ]),
+        // B. 이동 후 사용
+        new SequenceNode([
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines), // 이동 후 사거리 재확인
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 우선순위 1: 1번 슬롯 스킬 사용 시도
+        new SequenceNode([
+            new CanUseSkillBySlotNode(0),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        // 우선순위 2: 2번 슬롯 스킬 사용 시도
+        new SequenceNode([
+            new CanUseSkillBySlotNode(1),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        // 우선순위 3: 3번 슬롯 스킬 사용 시도
+        new SequenceNode([
+            new CanUseSkillBySlotNode(2),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        // 우선순위 4: 4번 슬롯 스킬 사용 시도 (보통 일반 공격)
+        new SequenceNode([
+            new CanUseSkillBySlotNode(3),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
         ]),
 
-        // [2단계] 행동 결정 (위에서부터 순서대로 시도)
-        new SelectorNode([
-            // (우선순위 1) 스킬 사용 시도
-            new SequenceNode([
-                new FindBestSkillNode(engines), // 사용 가능한 스킬 찾기
-                new SelectorNode([
-                    // A. 제자리에서 즉시 사용
-                    new SequenceNode([
-                        new IsSkillInRangeNode(engines),
-                        new UseSkillNode(engines),
-                    ]),
-                    // B. 이동 후 사용
-                    new SequenceNode([
-                        new FindPathToSkillRangeNode(engines),
-                        new MoveToTargetNode(engines),
-                        new IsSkillInRangeNode(engines),
-                        new UseSkillNode(engines),
-                    ]),
-                ]),
-            ]),
-
-            // (우선순위 2) 일반 공격 시도
-            new SequenceNode([
-                 // A. 제자리에서 즉시 공격
-                new SequenceNode([
-                    new IsTargetInRangeNode(),
-                    new AttackTargetNode(engines),
-                ]),
-                // B. 이동 후 공격
-                new SequenceNode([
-                    new FindPathToTargetNode(engines),
-                    new MoveToTargetNode(engines),
-                    new IsTargetInRangeNode(),
-                    new AttackTargetNode(engines),
-                ]),
-            ]),
-            
-            // (우선순위 3) 이동만 하고 턴 종료
-            new SequenceNode([
-                new FindPathToTargetNode(engines), // 이동할 경로를 찾고
-                new MoveToTargetNode(engines),     // 이동만 실행
-            ]),
-
-            // (최후의 보루) 아무것도 할 수 없을 때 성공으로 턴 종료
-            new SuccessNode(),
+        // 우선순위 5: 사용할 스킬이 없을 경우, 이동만 실행
+        new SequenceNode([
+            new FindMeleeStrategicTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
         ]),
+
+        // 최후의 보루: 아무것도 할 수 없을 때 성공으로 턴 종료
+        new SuccessNode(),
     ]);
 
     return new BehaviorTree(rootNode);

--- a/src/ai/nodes/CanUseSkillBySlotNode.js
+++ b/src/ai/nodes/CanUseSkillBySlotNode.js
@@ -1,0 +1,39 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { ownedSkillsManager } from '../../game/utils/OwnedSkillsManager.js';
+import { skillInventoryManager } from '../../game/utils/SkillInventoryManager.js';
+import { skillEngine } from '../../game/utils/SkillEngine.js';
+
+class CanUseSkillBySlotNode extends Node {
+    constructor(slotIndex) {
+        super();
+        this.slotIndex = slotIndex;
+    }
+
+    async evaluate(unit, blackboard) {
+        const nodeName = `CanUseSkillBySlotNode (Slot ${this.slotIndex + 1})`;
+        debugAIManager.logNodeEvaluation({ constructor: { name: nodeName } }, unit);
+
+        const equippedSkillInstances = ownedSkillsManager.getEquippedSkills(unit.uniqueId);
+        const instanceId = equippedSkillInstances[this.slotIndex];
+
+        if (!instanceId) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, `${this.slotIndex + 1}번 슬롯에 스킬이 없음`);
+            return NodeState.FAILURE;
+        }
+
+        const skillId = skillInventoryManager.getSkillIdByInstance(instanceId);
+        const skillData = skillInventoryManager.getSkillData(skillId);
+
+        if (skillEngine.canUseSkill(unit, skillData)) {
+            blackboard.set('currentSkillData', skillData);
+            blackboard.set('currentSkillInstanceId', instanceId);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `${this.slotIndex + 1}번 스킬 [${skillData.name}] 사용 가능`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, `${this.slotIndex + 1}번 스킬 [${skillData.name}] 사용 불가`);
+        return NodeState.FAILURE;
+    }
+}
+export default CanUseSkillBySlotNode;

--- a/src/ai/nodes/FindMeleeStrategicTargetNode.js
+++ b/src/ai/nodes/FindMeleeStrategicTargetNode.js
@@ -1,0 +1,87 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { formationEngine } from '../../game/utils/FormationEngine.js';
+
+class FindMeleeStrategicTargetNode extends Node {
+    constructor({ targetManager, pathfinderEngine }) {
+        super();
+        this.targetManager = targetManager;
+        this.pathfinderEngine = pathfinderEngine;
+    }
+
+    // 유닛을 공격할 수 있는 가장 가까운 위치로의 경로를 찾는 헬퍼 메서드
+    _findPathToUnit(unit, target) {
+        const attackRange = unit.finalStats.attackRange || 1;
+        const start = { col: unit.gridX, row: unit.gridY };
+        const targetPos = { col: target.gridX, row: target.gridY };
+
+        const distanceToTarget = Math.abs(start.col - targetPos.col) + Math.abs(start.row - targetPos.row);
+        if (distanceToTarget <= attackRange) {
+            return [];
+        }
+
+        const potentialAttackCells = [];
+        for (let r = 0; r < formationEngine.grid.rows; r++) {
+            for (let c = 0; c < formationEngine.grid.cols; c++) {
+                const distance = Math.abs(c - targetPos.col) + Math.abs(r - targetPos.row);
+                if (distance <= attackRange) {
+                    const cell = formationEngine.grid.getCell(c, r);
+                    if (cell && (!cell.isOccupied || (c === start.col && r === start.row))) {
+                        potentialAttackCells.push(cell);
+                    }
+                }
+            }
+        }
+
+        if (potentialAttackCells.length === 0) return null;
+
+        potentialAttackCells.sort((a, b) => {
+            const distA = Math.abs(a.col - start.col) + Math.abs(a.row - start.row);
+            const distB = Math.abs(b.col - start.col) + Math.abs(b.row - start.row);
+            return distA - distB;
+        });
+
+        for (const bestCell of potentialAttackCells) {
+            const path = this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
+            if (path && path.length > 0) return path;
+        }
+        return null;
+    }
+
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const enemyUnits = blackboard.get('enemyUnits')?.filter(e => e.currentHp > 0);
+
+        if (!enemyUnits || enemyUnits.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, "적이 없음");
+            return NodeState.FAILURE;
+        }
+
+        const movementRange = unit.finalStats.movement || 3;
+
+        const lowHpEnemies = [...enemyUnits]
+            .filter(e => (e.currentHp / e.finalStats.hp) < 0.5)
+            .sort((a, b) => a.currentHp - b.currentHp);
+
+        for (const lowHpEnemy of lowHpEnemies) {
+            const path = this._findPathToUnit(unit, lowHpEnemy);
+            if (path && path.length <= movementRange) {
+                blackboard.set('movementTarget', lowHpEnemy);
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `체력이 적고 도달 가능한 타겟 [${lowHpEnemy.instanceName}] 설정`);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        const nearestEnemy = this.targetManager.findNearestEnemy(unit, enemyUnits);
+        if (nearestEnemy) {
+            blackboard.set('movementTarget', nearestEnemy);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `가장 가까운 타겟 [${nearestEnemy.instanceName}] 설정`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, "이동할 타겟을 찾지 못함");
+        return NodeState.FAILURE;
+    }
+}
+export default FindMeleeStrategicTargetNode;

--- a/src/ai/nodes/FindPathToSkillRangeNode.js
+++ b/src/ai/nodes/FindPathToSkillRangeNode.js
@@ -10,15 +10,14 @@ class FindPathToSkillRangeNode extends Node {
 
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
-        const target = blackboard.get('currentTargetUnit');
-        const skillInfo = blackboard.get('currentTargetSkill');
+        const target = blackboard.get('skillTarget');
+        const skillData = blackboard.get('currentSkillData');
 
-        if (!target || !skillInfo) {
+        if (!target || !skillData) {
             debugAIManager.logNodeResult(NodeState.FAILURE, '타겟 또는 스킬 정보 없음');
             return NodeState.FAILURE;
         }
 
-        const skillData = skillInfo.skillData;
         const skillRange = skillData.range || unit.finalStats.attackRange || 1;
 
         const path = this._findPathToUnit(unit, target, skillRange);

--- a/src/ai/nodes/FindPathToTargetNode.js
+++ b/src/ai/nodes/FindPathToTargetNode.js
@@ -10,138 +10,59 @@ class FindPathToTargetNode extends Node {
 
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
-        const originalTarget = blackboard.get('currentTargetUnit');
-        if (!originalTarget) {
-            debugAIManager.logNodeResult(NodeState.FAILURE, "원래 타겟 없음");
+        const target = blackboard.get('movementTarget');
+        if (!target) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, "이동 목표 없음");
             return NodeState.FAILURE;
         }
 
-        const start = { col: unit.gridX, row: unit.gridY };
-
-        // --- 1. 원래 타겟에게 접근 시도 ---
-        let pathToTarget = this._findPathToUnit(unit, originalTarget);
-        if (pathToTarget) {
-            blackboard.set('movementPath', pathToTarget);
-            debugAIManager.logNodeResult(NodeState.SUCCESS, `원래 타겟(${originalTarget.instanceName})에게 경로 설정`);
+        const path = this._findPathToUnit(unit, target);
+        if (path) {
+            blackboard.set('movementPath', path);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `목표(${target.instanceName})에게 경로 설정`);
             return NodeState.SUCCESS;
         }
 
-        // --- 2. 경로가 없다면, 다른 적에게 접근 시도 ---
-        debugAIManager.logNodeResult(NodeState.FAILURE, `원래 타겟(${originalTarget.instanceName})에게 접근 불가. 대체 타겟 탐색.`);
-        const enemyUnits = blackboard
-            .get('enemyUnits')
-            .filter(e => e.uniqueId !== originalTarget.uniqueId && e.currentHp > 0);
-
-        // 유닛과의 거리를 기준으로 적들을 정렬합니다.
-        const sortedEnemies = enemyUnits.sort((a, b) => {
-            const distA = Math.abs(a.gridX - start.col) + Math.abs(a.gridY - start.row);
-            const distB = Math.abs(b.gridX - start.col) + Math.abs(b.gridY - start.row);
-            return distA - distB;
-        });
-
-        for (const alternateEnemy of sortedEnemies) {
-            let pathToAlternate = this._findPathToUnit(unit, alternateEnemy);
-            if (pathToAlternate) {
-                blackboard.set('currentTargetUnit', alternateEnemy); // 타겟 교체!
-                blackboard.set('movementPath', pathToAlternate);
-                debugAIManager.logNodeResult(
-                    NodeState.SUCCESS,
-                    `대체 타겟(${alternateEnemy.instanceName})으로 변경하고 경로 설정`
-                );
-                return NodeState.SUCCESS;
-            }
-        }
-
-        // --- 3. 접근 가능한 적이 아무도 없다면, 원래 타겟에게 최대한 가까이 이동 ---
-        debugAIManager.logNodeResult(NodeState.FAILURE, '접근 가능한 대체 타겟 없음. 원래 타겟에게 최대한 접근 시도.');
-        const availableCells = this.formationEngine.grid.gridCells.filter(
-            cell => !cell.isOccupied || (cell.col === start.col && cell.row === start.row)
-        );
-
-        if (availableCells.length === 0) {
-            debugAIManager.logNodeResult(NodeState.FAILURE, '이동 가능한 셀이 없음');
-            return NodeState.FAILURE;
-        }
-
-        // 타겟과 가장 가까우면서 '실제로 이동 가능한' 셀을 찾습니다.
-        availableCells.sort((a, b) => {
-            const distA = Math.abs(a.col - originalTarget.gridX) + Math.abs(a.row - originalTarget.gridY);
-            const distB = Math.abs(b.col - originalTarget.gridX) + Math.abs(b.row - originalTarget.gridY);
-            return distA - distB;
-        });
-
-        for (const closestCell of availableCells) {
-            const path = this.pathfinderEngine.findPath(unit, start, {
-                col: closestCell.col,
-                row: closestCell.row,
-            });
-            if (path && path.length > 0) {
-                blackboard.set('movementPath', path);
-                debugAIManager.logNodeResult(
-                    NodeState.SUCCESS,
-                    `원래 타겟에게 가장 가까운 셀(${closestCell.col}, ${closestCell.row})로 경로 설정`
-                );
-                return NodeState.SUCCESS;
-            }
-        }
-
-        // --- 4. 모든 시도 실패 ---
-        debugAIManager.logNodeResult(NodeState.FAILURE, '이동할 경로를 전혀 찾지 못함');
+        debugAIManager.logNodeResult(NodeState.FAILURE, '경로 탐색 실패');
         return NodeState.FAILURE;
     }
 
-    /**
-     * 특정 유닛을 공격할 수 있는 가장 가까운 위치로의 경로를 찾는 헬퍼 메서드
-     * @param {object} unit - 이동하는 유닛
-     * @param {object} target - 목표 유닛
-     * @returns {Array|null} - 경로 배열 또는 null
-     */
     _findPathToUnit(unit, target) {
         const attackRange = unit.finalStats.attackRange || 1;
         const start = { col: unit.gridX, row: unit.gridY };
         const targetPos = { col: target.gridX, row: target.gridY };
 
-        // 이미 사거리 내에 있는지 확인
         const distanceToTarget = Math.abs(start.col - targetPos.col) + Math.abs(start.row - targetPos.row);
         if (distanceToTarget <= attackRange) {
-            return []; // 이동이 필요 없음
+            return [];
         }
 
-        const potentialAttackCells = [];
-        for (let r = targetPos.row - attackRange; r <= targetPos.row + attackRange; r++) {
-            for (let c = targetPos.col - attackRange; c <= targetPos.col + attackRange; c++) {
+        const potentialCells = [];
+        for (let r = 0; r < this.formationEngine.grid.rows; r++) {
+            for (let c = 0; c < this.formationEngine.grid.cols; c++) {
                 const distance = Math.abs(c - targetPos.col) + Math.abs(r - targetPos.row);
                 if (distance <= attackRange) {
                     const cell = this.formationEngine.grid.getCell(c, r);
-                    // 비어있거나, 자기 자신의 위치인 경우에만 잠재적 목표 셀로 추가
                     if (cell && (!cell.isOccupied || (c === start.col && r === start.row))) {
-                        potentialAttackCells.push(cell);
+                        potentialCells.push(cell);
                     }
                 }
             }
         }
 
-        if (potentialAttackCells.length === 0) {
-            return null; // 공격 위치가 전혀 없음
-        }
+        if (potentialCells.length === 0) return null;
 
-        // 현재 위치에서 가장 가까운 공격 가능 지점을 찾기 위해 정렬
-        potentialAttackCells.sort((a, b) => {
+        potentialCells.sort((a, b) => {
             const distA = Math.abs(a.col - start.col) + Math.abs(a.row - start.row);
             const distB = Math.abs(b.col - start.col) + Math.abs(b.row - start.row);
             return distA - distB;
         });
 
-        // 가장 가까운 지점부터 차례대로 경로 탐색
-        for (const bestCell of potentialAttackCells) {
+        for (const bestCell of potentialCells) {
             const path = this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
-            if (path && path.length > 0) {
-                return path; // 유효한 첫 번째 경로를 즉시 반환
-            }
+            if (path && path.length > 0) return path;
         }
-
-        return null; // 모든 공격 위치로의 경로를 찾지 못함
+        return null;
     }
 }
 export default FindPathToTargetNode;
-

--- a/src/ai/nodes/FindTargetBySkillTypeNode.js
+++ b/src/ai/nodes/FindTargetBySkillTypeNode.js
@@ -1,0 +1,46 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+class FindTargetBySkillTypeNode extends Node {
+    constructor({ targetManager }) {
+        super();
+        this.targetManager = targetManager;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const skillData = blackboard.get('currentSkillData');
+        const enemyUnits = blackboard.get('enemyUnits');
+
+        if (!skillData || !enemyUnits || enemyUnits.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, "스킬 데이터 또는 적 유닛 없음");
+            return NodeState.FAILURE;
+        }
+
+        let target = null;
+        switch (skillData.type) {
+            case 'ACTIVE':
+                target = this.targetManager.findLowestHealthEnemy(enemyUnits);
+                break;
+            case 'DEBUFF':
+                target = this.targetManager.findHighestHealthEnemy(enemyUnits);
+                break;
+            case 'BUFF':
+                target = unit;
+                break;
+            default:
+                target = this.targetManager.findNearestEnemy(unit, enemyUnits);
+                break;
+        }
+
+        if (target) {
+            blackboard.set('skillTarget', target);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skillData.name}]의 대상 (${target.instanceName}) 설정`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, "스킬 대상을 찾지 못함");
+        return NodeState.FAILURE;
+    }
+}
+export default FindTargetBySkillTypeNode;

--- a/src/ai/nodes/IsSkillInRangeNode.js
+++ b/src/ai/nodes/IsSkillInRangeNode.js
@@ -4,15 +4,14 @@ import { debugAIManager } from '../../game/debug/DebugAIManager.js';
 class IsSkillInRangeNode extends Node {
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
-        const target = blackboard.get('currentTargetUnit');
-        const skillInfo = blackboard.get('currentTargetSkill');
+        const target = blackboard.get('skillTarget');
+        const skillData = blackboard.get('currentSkillData');
 
-        if (!target || !skillInfo) {
+        if (!target || !skillData) {
             debugAIManager.logNodeResult(NodeState.FAILURE, '타겟 또는 스킬 정보 없음');
             return NodeState.FAILURE;
         }
 
-        const skillData = skillInfo.skillData;
         const attackRange = skillData.range || unit.finalStats.attackRange || 1;
         const distance = Math.abs(unit.gridX - target.gridX) + Math.abs(unit.gridY - target.gridY);
 

--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -15,24 +15,12 @@ class UseSkillNode extends Node {
 
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
-        // 기본 대상은 현재 AI가 노리고 있는 유닛으로 설정
-        let skillTarget = blackboard.get('currentTargetUnit');
-        const skillInfo = blackboard.get('currentTargetSkill');
+        const skillTarget = blackboard.get('skillTarget');
+        const skillData = blackboard.get('currentSkillData');
+        const instanceId = blackboard.get('currentSkillInstanceId');
 
-        if (!skillInfo) {
-            debugAIManager.logNodeResult(NodeState.FAILURE, '스킬 정보 없음');
-            return NodeState.FAILURE;
-        }
-
-        const { skillData, instanceId } = skillInfo;
-
-        // 스킬의 targetType에 따라 대상 결정. 기본값은 전달된 대상 유지
-        if (skillData.targetType === 'self') {
-            skillTarget = unit;
-        }
-
-        if (!skillTarget) {
-            debugAIManager.logNodeResult(NodeState.FAILURE, '스킬 대상 없음');
+        if (!skillData || !skillTarget) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '스킬 데이터 또는 대상 없음');
             return NodeState.FAILURE;
         }
 
@@ -58,7 +46,9 @@ class UseSkillNode extends Node {
 
         console.log(`[AI] ${unit.instanceName}이(가) ${skillTarget.instanceName}에게 스킬 [${skillData.name}] 사용!`);
 
-        blackboard.set('currentTargetSkill', null);
+        blackboard.set('currentSkillData', null);
+        blackboard.set('currentSkillInstanceId', null);
+        blackboard.set('skillTarget', null);
 
         await this.delayEngine.hold(500);
 

--- a/src/game/utils/TargetManager.js
+++ b/src/game/utils/TargetManager.js
@@ -48,6 +48,19 @@ class TargetManager {
             .filter(enemy => enemy.currentHp > 0)
             .sort((a, b) => a.currentHp - b.currentHp)[0] || null;
     }
+
+    /**
+     * 현재 체력이 가장 높은 적을 찾습니다.
+     * @param {Array<object>} enemyList - 탐색 대상이 되는 적 유닛 목록
+     * @returns {object|null} - 찾은 적 유닛 또는 null
+     */
+    findHighestHealthEnemy(enemyList) {
+        if (!enemyList || enemyList.length === 0) return null;
+
+        return enemyList
+            .filter(enemy => enemy.currentHp > 0)
+            .sort((a, b) => b.currentHp - a.currentHp)[0] || null;
+    }
 }
 
 // 싱글턴으로 관리


### PR DESCRIPTION
## Summary
- extend `TargetManager` with `findHighestHealthEnemy`
- add AI nodes for slot-based skill checks, skill targeting, and strategic melee movement
- update melee AI to use new nodes and prioritize skill usage
- adjust existing nodes to work with new blackboard keys

## Testing
- `npm run build-nolog`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688128ab3c548327a9a7da5f336ad72a