### PR TITLE
Implement skill damage multipliers and new effects

### DIFF
--- a/src/ai/nodes/AttackTargetNode.js
+++ b/src/ai/nodes/AttackTargetNode.js
@@ -43,7 +43,8 @@ class AttackTargetNode extends Node {
         spriteEngine.changeSpriteForDuration(target, 'hitted', 300);
 
         // 데미지 계산 및 적용
-        const damage = this.combatEngine.calculateDamage(unit, target);
+        // ✨ 데미지 계산 시 스킬 정보 전달
+        const damage = this.combatEngine.calculateDamage(unit, target, attackSkill);
         target.currentHp -= damage;
 
         // 시각 효과

--- a/src/game/data/monster.js
+++ b/src/game/data/monster.js
@@ -1,8 +1,21 @@
+import { ownedSkillsManager } from '../utils/OwnedSkillsManager.js';
+import { skillInventoryManager } from '../utils/SkillInventoryManager.js';
+
 export const monsterData = {
     zombie: {
         name: '좀비',
+        // ✨ 클래스를 '전사(임시)'로 설정
+        className: '전사(임시)',
         battleSprite: 'zombie',
-        baseStats: { hp: 50, valor: 0, strength: 5, endurance: 3, agility: 1, intelligence: 0, wisdom: 0, luck: 0 }
+        baseStats: { hp: 50, valor: 0, strength: 5, endurance: 3, agility: 1, intelligence: 0, wisdom: 0, luck: 0 },
+        // ✨ 좀비가 생성될 때 실행될 초기화 함수
+        onSpawn: (unit) => {
+            // 'attack' 스킬 인스턴스를 찾아 1번 슬롯(인덱스 0)에 장착
+            const attackInstance = skillInventoryManager.findAndRemoveInstanceOfSkill('attack');
+            if (attackInstance) {
+                ownedSkillsManager.equipSkill(unit.uniqueId, 0, attackInstance.instanceId);
+            }
+        }
     }
 };
 

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -21,11 +21,11 @@ export const activeSkills = {
         type: 'ACTIVE',
         cost: 2,
         // 적에게 돌진하여 데미지를 주고 2턴간 기절시키는 스킬
-        description: '적에게 돌진하여 120%의 데미지를 주고 2턴간 기절시킵니다. (쿨타임 2턴)',
+        description: '적을 120%의 데미지로 공격하고, 2턴간 기절 시킵니다. (쿨타임 3턴)',
         illustrationPath: 'assets/images/skills/charge.png',
         requiredClass: 'warrior',
         damageMultiplier: 1.2,
-        cooldown: 2,
+        cooldown: 3,
         range: 1,
         effect: {
             type: EFFECT_TYPES.STATUS_EFFECT,

--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -9,16 +9,17 @@ export const buffSkills = {
         cost: 1,
         // 대상 유형을 명시하여 AI 등이 올바르게 처리하도록 함
         targetType: 'self', // 'self', 'enemy', 'ally' 등
-        description: '5턴간 자기 자신에게 데미지 감소 5%의 버프를 겁니다. 최대 중첩 25%',
+        description: '4턴간 받는 데미지가 15% 감소합니다. (쿨타임 3턴)',
         illustrationPath: 'assets/images/skills/ston-skin.png',
         requiredClass: 'warrior', // ✨ 전사 전용 설정
+        cooldown: 3,
         effect: {
             type: EFFECT_TYPES.BUFF,
-            duration: 5,
+            duration: 4,
             modifiers: {
                 stat: 'damageReduction',
                 type: 'percentage',
-                value: 0.05
+                value: 0.15
             }
         }
     },

--- a/src/game/data/skills/debuff.js
+++ b/src/game/data/skills/debuff.js
@@ -1,3 +1,5 @@
+import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
+
 // 디버프 스킬 데이터 정의
 export const debuffSkills = {
     shieldBreak: {
@@ -5,8 +7,21 @@ export const debuffSkills = {
         name: '쉴드 브레이크',
         type: 'DEBUFF',
         cost: 2,
-        description: '적에게 5턴간 물리방어력 감소 5%의 디버프를 겁니다. 최대 중첩 25%',
+        targetType: 'enemy',
+        description: '적에게 3턴간 받는 데미지 15% 증가 디버프를 겁니다. (쿨타임 2턴)',
         illustrationPath: 'assets/images/skills/shield-break.png',
-        requiredClass: 'warrior', // ✨ 전사 전용 설정
+        requiredClass: 'warrior',
+        cooldown: 2,
+        range: 1,
+        effect: {
+            id: 'shieldBreak',
+            type: EFFECT_TYPES.DEBUFF,
+            duration: 3,
+            modifiers: {
+                stat: 'damageIncrease',
+                type: 'percentage',
+                value: 0.15
+            }
+        }
     },
 };

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -17,5 +17,16 @@ export const statusEffects = {
             unit.isStunned = false;
         },
     },
-    // 다른 상태 효과들은 필요 시 여기에 추가합니다.
+    // ✨ 스톤 스킨 효과 추가
+    stoneSkin: {
+        id: 'stoneSkin',
+        name: '스톤 스킨',
+        iconPath: 'assets/images/skills/ston-skin.png',
+    },
+    // ✨ 쉴드 브레이크 효과 추가
+    shieldBreak: {
+        id: 'shieldBreak',
+        name: '쉴드 브레이크',
+        iconPath: 'assets/images/skills/shield-break.png',
+    }
 };

--- a/src/game/utils/IconManager.js
+++ b/src/game/utils/IconManager.js
@@ -58,16 +58,15 @@ export class IconManager {
 
         // 활성 효과를 기반으로 아이콘을 추가하거나 업데이트합니다.
         activeEffects.forEach((effect, index) => {
-            const effectDef = statusEffects[effect.id];
-            const skillData = skillCardDatabase[effect.sourceSkillName];
-            const iconKey = effectDef ? effectDef.id : (skillData ? skillData.id : null);
+            const effectDef = statusEffects[effect.id] || skillCardDatabase[effect.id];
+            const iconKey = effectDef ? effectDef.id : null;
             if (!iconKey) return;
 
             let iconData = display.icons.get(effect.instanceId);
 
             if (!iconData) { // 새로운 아이콘 생성
                 const iconContainer = this.scene.add.container(0, 0);
-                const icon = this.scene.add.image(0, 0, iconKey).setScale(0.2);
+                const icon = this.scene.add.image(0, 0, iconKey).setScale(0.04);
                 const turnText = this.scene.add.text(0, 8, effect.duration, {
                     fontSize: '12px',
                     color: '#fff',

--- a/src/game/utils/MonsterEngine.js
+++ b/src/game/utils/MonsterEngine.js
@@ -23,9 +23,15 @@ class MonsterEngine {
             ...baseData,
             uniqueId: id,
             instanceName: baseData.instanceName || baseData.name || `Monster${id}`,
+            skillSlots: [null, null, null, null] // 몬스터를 위한 스킬 슬롯 초기화
         };
 
         instance.finalStats = statEngine.calculateStats(instance, baseData.baseStats || {}, []);
+
+        // ✨ onSpawn 콜백이 있으면 실행
+        if (typeof baseData.onSpawn === 'function') {
+            baseData.onSpawn(instance);
+        }
 
         if (type === 'ally') {
             this.alliedMonsters.set(id, instance);


### PR DESCRIPTION
## Summary
- enhance active skills with damage multipliers and cooldowns
- tweak Stone Skin buff values
- add new Shield Break debuff skill
- hook new debuff file into skill database
- give zombies a temporary warrior class and equip attack on spawn
- allow MonsterEngine to initialize skill slots and run an `onSpawn` callback
- shrink status icons and display them for new effects
- compute damage using skill multipliers and damage modifiers
- apply damage calculations in AI nodes

## Testing
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68812a70a5288327a6a121b320270ef8