### PR TITLE
Fix null skill slot logging

### DIFF
--- a/src/game/debug/DebugSkillManager.js
+++ b/src/game/debug/DebugSkillManager.js
@@ -15,10 +15,13 @@ class DebugSkillManager {
         
         const styledSlots = skillSlots.map(slotKey => {
             const skillInfo = SKILL_TYPES[slotKey];
-            return `%c${skillInfo.name}`;
+            return skillInfo ? `%c${skillInfo.name}` : '%c비어 있음';
         }).join(' - ');
 
-        const styles = skillSlots.map(slotKey => `color: ${SKILL_TYPES[slotKey].color}; font-weight: bold;`);
+        const styles = skillSlots.map(slotKey => {
+            const skillInfo = SKILL_TYPES[slotKey];
+            return skillInfo ? `color: ${skillInfo.color}; font-weight: bold;` : 'color: #9ca3af; font-style: italic;';
+        });
         
         console.log(styledSlots, ...styles);
         console.groupEnd();


### PR DESCRIPTION
## Summary
- handle null skill slots in `DebugSkillManager`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68812cb629e883278cb21102b62bcdd1