### PR TITLE
Fix SpriteEngine undefined scene

### DIFF
--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -51,6 +51,9 @@ class UseSkillNode extends Node {
                 this.terminationManager.handleUnitDeath(skillTarget);
             }
         } else {
+            if (unit.sprite.scene && !spriteEngine.scene) {
+                spriteEngine.setScene(unit.sprite.scene);
+            }
             spriteEngine.changeSpriteForDuration(unit, 'cast', 600);
         }
 

--- a/src/game/utils/SpriteEngine.js
+++ b/src/game/utils/SpriteEngine.js
@@ -20,8 +20,12 @@ class SpriteEngine {
 
         const originalTexture = unit.sprites.idle || unit.battleSprite;
         const actionTexture = unit.sprites[actionType];
+        const scene = this.scene || unit.sprite.scene;
+        if (!this.scene && scene) {
+            this.scene = scene;
+        }
 
-        if (!actionTexture || !this.scene.textures.exists(actionTexture)) {
+        if (!actionTexture || !scene || !scene.textures || !scene.textures.exists(actionTexture)) {
             debugLogEngine.warn('SpriteEngine', `${actionType}\uC5D0 \uD574\uB2F9\uD558\uB294 \uC2A4\uD504\uB77C\uC774\uD2B8 \uD0A4 '${actionTexture}'\uB97C \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.`);
             return;
         }


### PR DESCRIPTION
## Summary
- make SpriteEngine robust when its scene isn't set
- ensure UseSkillNode registers scene before using SpriteEngine

## Testing
- `npm run build`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68812ec922c883278a374a5ff3923571