### PR TITLE
Improve pathfinding logic

### DIFF
--- a/src/ai/nodes/FindPathToTargetNode.js
+++ b/src/ai/nodes/FindPathToTargetNode.js
@@ -10,6 +10,7 @@ class FindPathToTargetNode extends Node {
 
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
+        // ✨ [수정] 'currentTargetUnit' 대신 'movementTarget'을 참조하도록 변경
         const target = blackboard.get('movementTarget');
         if (!target) {
             debugAIManager.logNodeResult(NodeState.FAILURE, "이동 목표 없음");

--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -12,6 +12,7 @@ class UseSkillNode extends Node {
         this.vfxManager = vfxManager;
         this.animationEngine = animationEngine;
         this.delayEngine = delayEngine;
+        this.terminationManager = terminationManager; // ✨ terminationManager 추가
         this.skillEngine = se || skillEngine;
         // ✨ combatCalculationEngine 추가
         this.combatEngine = combatCalculationEngine;

--- a/src/game/utils/PathfinderEngine.js
+++ b/src/game/utils/PathfinderEngine.js
@@ -49,8 +49,12 @@ class PathfinderEngine {
                 const cell = grid.getCell(neighbor.col, neighbor.row);
 
                 // ✨ [수정된 부분]
-                // 적군과 아군을 모두 포함하여, 점유된 셀은 경로에서 제외합니다.
-                if (closedSet.has(key) || (cell && cell.isOccupied)) {
+                // 목표 지점(endNode)이 아니라면, 점유된 셀은 경로에서 제외합니다.
+                // 이를 통해 목표 바로 옆까지는 이동할 수 있게 됩니다.
+                const isOccupied = cell && cell.isOccupied;
+                const isEndNode = neighbor.col === endNode.col && neighbor.row === endNode.row;
+
+                if (closedSet.has(key) || (isOccupied && !isEndNode)) {
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- allow occupied end cells in A* pathfinder so units can reach adjacent attack positions
- clarify target reference when finding a path
- store terminationManager in UseSkillNode constructor

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`
- `npm run build-nolog`

------
https://chatgpt.com/codex/tasks/task_e_6881b8f46cec8327a7a5b46c135689f0