### PR TITLE
Fix movement path calculation

### DIFF
--- a/src/game/utils/GridEngine.js
+++ b/src/game/utils/GridEngine.js
@@ -25,6 +25,9 @@ export class GridEngine {
         // 디버깅 목적으로 그리드를 시각적으로 표시할 그래픽스 객체
         this.graphics = this.scene.add.graphics({ lineStyle: { width: 2, color: 0x00ff00, alpha: 0.5 } });
 
+        this.cols = cols;
+        this.rows = rows;
+
         for (let row = 0; row < rows; row++) {
             for (let col = 0; col < cols; col++) {
                 const cellX = x + col * cellWidth;


### PR DESCRIPTION
## Summary
- save `cols` and `rows` when building the battle grid

## Testing
- `npm run build-nolog`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6881bd30ce5083279cc4de410e8d8c34