### PR TITLE
Fix melee AI to attack after moving

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -58,14 +58,18 @@ class AIManager {
         while (tokenEngine.getTokens(unit.uniqueId) > 0) {
             const prevTokens = tokenEngine.getTokens(unit.uniqueId);
             const prevSkillCount = data.behaviorTree.blackboard.get('usedSkillsThisTurn').size;
+            const prevMoved = data.behaviorTree.blackboard.get('hasMovedThisTurn');
 
             await data.behaviorTree.execute(unit, allUnits, enemyUnits);
 
             const tokensAfter = tokenEngine.getTokens(unit.uniqueId);
             const skillsAfter = data.behaviorTree.blackboard.get('usedSkillsThisTurn').size;
+            const movedAfter = data.behaviorTree.blackboard.get('hasMovedThisTurn');
 
-            // 행동 결과 토큰 소모나 스킬 사용이 없었다면 더 이상 할 수 있는 행동이 없다고 판단
-            if (tokensAfter === prevTokens && skillsAfter === prevSkillCount) {
+            // 토큰, 스킬 사용, 이동 중 아무 변화도 없었다면 더 이상 할 행동이 없다고 판단
+            if (tokensAfter === prevTokens &&
+                skillsAfter === prevSkillCount &&
+                movedAfter === prevMoved) {
                 break;
             }
 


### PR DESCRIPTION
## Summary
- improve AI loop break conditions to check for movement
- this allows melee units like zombies to attack after closing distance on the first turn

## Testing
- `python3 -m http.server 8000 &>/tmp/http.log &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6881cf56c0a48327ace98b60936b9f3b