### PR TITLE
Fix skill management back button & start with attack cards

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -668,7 +668,8 @@ body {
     z-index: 10;
     background-size: cover;
     background-position: center;
-    pointer-events: none;
+    /* 상호작용을 위해 pointer-events를 허용합니다 */
+    pointer-events: auto;
     display: none; /* 초기에는 숨김 */
 }
 

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -18,17 +18,18 @@ class SkillInventoryManager {
      * 게임 시작 시 기본 스킬 카드를 지급합니다.
      */
     initializeSkillCards() {
-        // 등급별 차지 스킬 2장씩 지급
+        // 등급별 기본 스킬 지급
         const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
         grades.forEach(grade => {
             for (let i = 0; i < 2; i++) {
                 this.addSkillById('charge', grade);
+                this.addSkillById('attack', grade); // 공격 스킬도 각 등급별 2장 지급
             }
         });
 
         // 나머지 스킬은 노멀 등급으로 10장씩 생성
         for (const skillId in skillCardDatabase) {
-            if (skillCardDatabase.hasOwnProperty(skillId) && skillId !== 'charge') {
+            if (skillCardDatabase.hasOwnProperty(skillId) && skillId !== 'charge' && skillId !== 'attack') {
                 for (let i = 0; i < 10; i++) {
                     this.addSkillById(skillId, 'NORMAL');
                 }


### PR DESCRIPTION
## Summary
- show the Skill Management back button by allowing pointer events on its container
- grant Attack skill cards alongside Charge cards at game start

## Testing
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6881f66bd69083278bfb097942370b94