### PR TITLE
Add grade star visuals for skills

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -968,3 +968,30 @@ body {
         box-shadow: 0 0 25px #f39c12, 0 0 15px #f39c12 inset;
     }
 }
+
+/* --- 스킬 등급 별 스타일 --- */
+.grade-stars {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    display: flex;
+    gap: 1px;
+}
+
+.grade-stars img {
+    width: 10px;
+    height: 10px;
+}
+
+.grade-stars-large {
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    display: flex;
+    gap: 2px;
+}
+
+.grade-stars-large img {
+    width: 20px;
+    height: 20px;
+}

--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -159,6 +159,8 @@ export class SkillManagementDOMEngine {
 
     refreshSkillInventory() {
         this.skillInventoryContent.innerHTML = '';
+        const gradeMap = { 'NORMAL': 1, 'RARE': 2, 'EPIC': 3, 'LEGENDARY': 4 };
+
         skillInventoryManager.getInventory().forEach(instance => {
             const data = skillInventoryManager.getSkillData(instance.skillId, instance.grade);
             const card = document.createElement('div');
@@ -169,6 +171,17 @@ export class SkillManagementDOMEngine {
             card.ondragstart = e => this.onDragStart(e, { source: 'inventory', instanceId: instance.instanceId });
             card.onmouseenter = e => SkillTooltipManager.show(data, e, instance.grade);
             card.onmouseleave = () => SkillTooltipManager.hide();
+
+            // 별 생성 컨테이너
+            const starsContainer = document.createElement('div');
+            starsContainer.className = 'grade-stars';
+            const starCount = gradeMap[instance.grade] || 1;
+            for (let i = 0; i < starCount; i++) {
+                const starImg = document.createElement('img');
+                starImg.src = 'assets/images/territory/skill-card-star.png';
+                starsContainer.appendChild(starImg);
+            }
+            card.appendChild(starsContainer);
 
             if (data.requiredClass) {
                 const tag = document.createElement('div');

--- a/src/game/dom/SkillTooltipManager.js
+++ b/src/game/dom/SkillTooltipManager.js
@@ -31,6 +31,18 @@ export class SkillTooltipManager {
             </div>
         `;
 
+        // 별 생성 로직 추가
+        const gradeMap = { 'NORMAL': 1, 'RARE': 2, 'EPIC': 3, 'LEGENDARY': 4 };
+        const starsContainer = document.createElement('div');
+        starsContainer.className = 'grade-stars-large';
+        const starCount = gradeMap[grade] || 1;
+        for (let i = 0; i < starCount; i++) {
+            const starImg = document.createElement('img');
+            starImg.src = 'assets/images/territory/skill-card-star.png';
+            starsContainer.appendChild(starImg);
+        }
+        tooltip.appendChild(starsContainer);
+
         // 토큰 아이콘 추가
         const costContainer = tooltip.querySelector('.skill-cost-container-large');
         for (let i = 0; i < skillData.cost; i++) {


### PR DESCRIPTION
## Summary
- show stars on skill cards and tooltips based on grade
- style star display for small and large cards

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6882062a7df08327a173777176ae37db