### PR TITLE
Improve skill inventory management

### DIFF
--- a/src/game/data/monster.js
+++ b/src/game/data/monster.js
@@ -8,13 +8,22 @@ export const monsterData = {
         className: '전사(임시)',
         battleSprite: 'zombie',
         baseStats: { hp: 50, valor: 0, strength: 5, endurance: 3, agility: 1, intelligence: 0, wisdom: 0, luck: 0 },
-        // ✨ 좀비가 생성될 때 실행될 초기화 함수
+        // ✨ 좀비 생성 시 실행될 초기화 함수 수정
         onSpawn: (unit) => {
-            // 'attack' 스킬 인스턴스를 찾아 1번 슬롯(인덱스 0)에 장착
-            const attackInstance = skillInventoryManager.findAndRemoveInstanceOfSkill('attack');
-            if (attackInstance) {
-                ownedSkillsManager.equipSkill(unit.uniqueId, 0, attackInstance.instanceId);
-            }
+            // 좀비를 위한 고유 'attack' 스킬 인스턴스를 생성하고 장착합니다.
+            // 이 방식은 플레이어의 인벤토리 수량에 영향을 주지 않습니다.
+            const skillId = 'attack';
+            const grade = 'NORMAL';
+
+            // 1. 새 인스턴스를 생성하고 ID를 받습니다.
+            const newInstance = skillInventoryManager.addSkillById(skillId, grade);
+
+            // 2. 생성된 스킬을 좀비에게 장착합니다. (워리어와 일관성을 위해 4번 슬롯에)
+            ownedSkillsManager.equipSkill(unit.uniqueId, 3, newInstance.instanceId);
+
+            // 3. 이 스킬은 몬스터 전용이므로, 플레이어의 인벤토리 목록에서는 제거합니다.
+            // (하지만 다른 시스템이 참조할 수 있도록 instanceMap에는 남겨둡니다.)
+            skillInventoryManager.removeSkillFromInventoryList(newInstance.instanceId);
         }
     }
 };

--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -224,7 +224,8 @@ export class SkillManagementDOMEngine {
 
         if (this.draggedData.source === 'inventory') {
             ownedSkillsManager.equipSkill(unitId, targetSlotIndex, draggedInstanceId);
-            skillInventoryManager.removeSkillByInstanceId(draggedInstanceId);
+            // 인벤토리 목록에서만 제거하여 장착 후에도 스킬 데이터를 참조할 수 있게 합니다.
+            skillInventoryManager.removeSkillFromInventoryList(draggedInstanceId);
             if (targetInstanceId) {
                 ownedSkillsManager.equipSkill(unitId, targetSlotIndex, draggedInstanceId);
                 this.addSkillToInventory(targetInstanceId);

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -45,11 +45,14 @@ class MercenaryEngine {
             // 4번째 슬롯을 'ACTIVE' 타입으로 고정
             newInstance.skillSlots.push('ACTIVE');
 
-            // 인벤토리에서 'attack' 스킬 인스턴스를 찾아 장착
-            const attackInstance = skillInventoryManager.findAndRemoveInstanceOfSkill('attack');
-            if (attackInstance) {
+            // 인벤토리에서 'attack' 스킬 인스턴스를 소비하고, 동일한 스킬을 새로 생성하여 장착합니다.
+            const consumed = skillInventoryManager.findAndRemoveInstanceOfSkill('attack');
+            if (consumed) {
+                const attackInstance = skillInventoryManager.addSkillById('attack', consumed.grade);
                 // 4번 슬롯(인덱스 3)에 장착
                 ownedSkillsManager.equipSkill(newInstance.uniqueId, 3, attackInstance.instanceId);
+                // 새로 생성된 인스턴스는 용병 전용이므로 인벤토리 목록에서는 제거합니다.
+                skillInventoryManager.removeSkillFromInventoryList(attackInstance.instanceId);
             }
         } else {
             // 다른 클래스는 4번째 슬롯을 빈 슬롯(null)으로 추가

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -40,31 +40,47 @@ class SkillInventoryManager {
 
     /**
      * 스킬 ID를 기반으로 새로운 스킬 인스턴스를 생성해 인벤토리에 추가합니다.
+     *
      * @param {string} skillId
+     * @returns {object} 생성된 스킬 인스턴스
      */
     addSkillById(skillId, grade = 'NORMAL') {
         const instance = { instanceId: this.nextInstanceId++, skillId, grade };
         this.skillInventory.push(instance);
         this.instanceMap.set(instance.instanceId, { skillId, grade });
+        return instance;
     }
 
     /**
-     * 인벤토리에서 특정 인스턴스를 제거합니다.
+     * 인벤토리에서 특정 인스턴스를 제거합니다. (맵에서도 제거)
      * @param {number} instanceId
      */
     removeSkillByInstanceId(instanceId) {
         this.skillInventory = this.skillInventory.filter(s => s.instanceId !== instanceId);
+        this.instanceMap.delete(instanceId);
     }
 
     /**
-     * ✨ [새 메서드] 인벤토리에서 특정 skillId를 가진 첫 번째 인스턴스를 찾아 제거하고 반환합니다.
+     * 인벤토리 '목록'에서만 특정 인스턴스를 제거합니다.
+     * instanceMap에는 데이터를 남겨둬 다른 시스템이 스킬 정보를 조회할 수 있습니다.
+     * @param {number} instanceId
+     */
+    removeSkillFromInventoryList(instanceId) {
+        this.skillInventory = this.skillInventory.filter(s => s.instanceId !== instanceId);
+    }
+
+    /**
+     * ✨ [기존 메서드 수정] 인벤토리에서 특정 skillId를 가진 첫 번째 인스턴스를 찾아 제거하고 반환합니다.
      * @param {string} skillId - 찾을 스킬의 ID (예: 'attack')
      * @returns {object|null} - 찾은 스킬 인스턴스 또는 null
      */
     findAndRemoveInstanceOfSkill(skillId, grade = 'NORMAL') {
         const index = this.skillInventory.findIndex(s => s.skillId === skillId && s.grade === grade);
         if (index !== -1) {
-            return this.skillInventory.splice(index, 1)[0];
+            const instance = this.skillInventory.splice(index, 1)[0];
+            // ✨ 인벤토리에서 완전히 제거되므로 instanceMap에서도 삭제합니다.
+            this.instanceMap.delete(instance.instanceId);
+            return instance;
         }
         return null;
     }


### PR DESCRIPTION
## Summary
- return created instance from `addSkillById`
- allow removing skills only from the inventory list
- keep monster skills independent of player inventory
- equip warriors with their own attack skill instance while consuming one from inventory
- adjust DOM to preserve instance data when equipping

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68820d46d0c883278b0956cd11077f6f