### PR TITLE
Fix skill UI grade decorations

### DIFF
--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -137,12 +137,27 @@ export class SkillManagementDOMEngine {
             const baseSkillData = skillInventoryManager.getSkillData(instanceData.skillId, instanceData.grade);
             const modifiedSkill = skillModifierEngine.getModifiedSkill(baseSkillData, index + 1, instanceData.grade);
 
+            // 등급별 테두리 클래스를 부여합니다.
+            slot.classList.add(`grade-${instanceData.grade.toLowerCase()}`);
+
             slot.style.backgroundImage = `url(${modifiedSkill.illustrationPath})`;
             slot.dataset.instanceId = instanceId;
             slot.draggable = true;
             slot.ondragstart = e => this.onDragStart(e, { source: 'slot', instanceId, slotIndex: index });
             slot.onmouseenter = e => SkillTooltipManager.show(modifiedSkill, e, instanceData.grade);
             slot.onmouseleave = () => SkillTooltipManager.hide();
+
+            // 등급에 따른 별 표시
+            const gradeMap = { NORMAL: 1, RARE: 2, EPIC: 3, LEGENDARY: 4 };
+            const starsContainer = document.createElement('div');
+            starsContainer.className = 'grade-stars';
+            const starCount = gradeMap[instanceData.grade] || 1;
+            for (let i = 0; i < starCount; i++) {
+                const starImg = document.createElement('img');
+                starImg.src = 'assets/images/territory/skill-card-star.png';
+                starsContainer.appendChild(starImg);
+            }
+            slot.appendChild(starsContainer);
         } else {
             slot.style.backgroundImage = 'url(assets/images/skills/skill-slot.png)';
         }
@@ -183,13 +198,7 @@ export class SkillManagementDOMEngine {
             }
             card.appendChild(starsContainer);
 
-            if (data.requiredClass) {
-                const tag = document.createElement('div');
-                tag.className = 'skill-class-tag';
-                const className = data.requiredClass === 'warrior' ? '전사' : data.requiredClass;
-                tag.innerText = `[${className}]`;
-                card.appendChild(tag);
-            }
+            // 인벤토리 카드에서는 클래스 태그를 표시하지 않습니다.
             this.skillInventoryContent.appendChild(card);
         });
     }

--- a/src/game/dom/SkillTooltipManager.js
+++ b/src/game/dom/SkillTooltipManager.js
@@ -19,10 +19,17 @@ export class SkillTooltipManager {
             description = description.replace('{{damage}}%', `${Math.round(skillData.damageMultiplier * 100)}%`);
         }
 
+        // 스킬 이름 옆에 클래스 전용 여부를 표시
+        let skillNameHTML = skillData.name;
+        if (skillData.requiredClass) {
+            const className = skillData.requiredClass === 'warrior' ? '전사' : skillData.requiredClass;
+            skillNameHTML += ` <span style="font-size: 14px; color: #ffc107;">[${className} 전용]</span>`;
+        }
+
         tooltip.innerHTML = `
             <div class="skill-illustration-large" style="background-image: url(${skillData.illustrationPath})"></div>
             <div class="skill-info-large">
-                <div class="skill-name-large">${skillData.name}</div>
+                <div class="skill-name-large">${skillNameHTML}</div>
                 <div class="skill-type-cost-large">
                     <span style="color: ${SKILL_TYPES[skillData.type].color};">[${SKILL_TYPES[skillData.type].name}]</span>
                     <span>쿨타임 ${skillData.cooldown || 0}</span>

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -74,6 +74,7 @@ export class UnitDetailDOM {
         skillGrid.className = 'skill-grid';
 
         const equippedSkills = ownedSkillsManager.getEquippedSkills(unitData.uniqueId);
+        const gradeMap = { NORMAL: 1, RARE: 2, EPIC: 3, LEGENDARY: 4 };
 
         if (unitData.skillSlots && unitData.skillSlots.length > 0) {
             unitData.skillSlots.forEach((slotType, index) => {
@@ -92,11 +93,23 @@ export class UnitDetailDOM {
                         bgImage = `url(${modifiedSkill.illustrationPath})`;
                         slot.onmouseenter = (e) => SkillTooltipManager.show(modifiedSkill, e, instData.grade);
                         slot.onmouseleave = () => SkillTooltipManager.hide();
+
+                        // 등급 표시를 위한 클래스와 별 이미지 추가
+                        slot.classList.add(`grade-${instData.grade.toLowerCase()}`);
+                        const starsContainer = document.createElement('div');
+                        starsContainer.className = 'grade-stars';
+                        const starCount = gradeMap[instData.grade] || 1;
+                        for (let i = 0; i < starCount; i++) {
+                            const starImg = document.createElement('img');
+                            starImg.src = 'assets/images/territory/skill-card-star.png';
+                            starsContainer.appendChild(starImg);
+                        }
+                        slot.appendChild(starsContainer);
                     }
                 }
                 slot.style.backgroundImage = bgImage;
 
-                slot.innerHTML = `<span class="slot-rank">${index + 1} 순위</span>`;
+                slot.innerHTML += `<span class="slot-rank">${index + 1} 순위</span>`;
                 skillGrid.appendChild(slot);
             });
         }


### PR DESCRIPTION
## Summary
- show grade borders and stars for equipped skill slots
- remove class tags from inventory skill icons
- display grade decorations in unit detail slots
- append class requirement next to skill name in tooltip

## Testing
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`
- `npm run build-nolog`

------
https://chatgpt.com/codex/tasks/task_e_6882113ecbdc832799dae3f2c28188c0