### PR TITLE
Update Stone Skin buff and modifier engine

### DIFF
--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -3,24 +3,91 @@ import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
 // 버프 스킬 데이터 정의
 export const buffSkills = {
     stoneSkin: {
-        id: 'stoneSkin',
-        name: '스톤 스킨',
-        type: 'BUFF',
-        cost: 1,
-        // 대상 유형을 명시하여 AI 등이 올바르게 처리하도록 함
-        targetType: 'self', // 'self', 'enemy', 'ally' 등
-        description: '4턴간 받는 데미지가 15% 감소합니다. (쿨타임 3턴)',
-        illustrationPath: 'assets/images/skills/ston-skin.png',
-        requiredClass: 'warrior', // ✨ 전사 전용 설정
-        cooldown: 3,
-        effect: {
+        // NORMAL 등급: 기본 효과
+        NORMAL: {
             id: 'stoneSkin',
-            type: EFFECT_TYPES.BUFF,
-            duration: 4,
-            modifiers: {
-                stat: 'damageReduction',
-                type: 'percentage',
-                value: 0.15
+            name: '스톤 스킨',
+            type: 'BUFF',
+            cost: 2,
+            targetType: 'self',
+            description: '4턴간 자신에게 데미지 감소 15% 버프를 겁니다. (쿨타임 3턴)',
+            illustrationPath: 'assets/images/skills/ston-skin.png',
+            requiredClass: 'warrior',
+            cooldown: 3,
+            effect: {
+                id: 'stoneSkin',
+                type: EFFECT_TYPES.BUFF,
+                duration: 4,
+                modifiers: {
+                    stat: 'damageReduction',
+                    type: 'percentage',
+                    value: 0.15
+                }
+            }
+        },
+        // RARE 등급: 토큰 소모량 감소
+        RARE: {
+            id: 'stoneSkin',
+            name: '스톤 스킨 [R]',
+            type: 'BUFF',
+            cost: 1,
+            targetType: 'self',
+            description: '4턴간 자신에게 데미지 감소 15% 버프를 겁니다. (쿨타임 3턴)',
+            illustrationPath: 'assets/images/skills/ston-skin.png',
+            requiredClass: 'warrior',
+            cooldown: 3,
+            effect: {
+                id: 'stoneSkin',
+                type: EFFECT_TYPES.BUFF,
+                duration: 4,
+                modifiers: {
+                    stat: 'damageReduction',
+                    type: 'percentage',
+                    value: 0.15
+                }
+            }
+        },
+        // EPIC 등급: 방어력 상승 효과 추가
+        EPIC: {
+            id: 'stoneSkin',
+            name: '스톤 스킨 [E]',
+            type: 'BUFF',
+            cost: 1,
+            targetType: 'self',
+            description: '4턴간 자신에게 데미지 감소 15%, 방어력 상승 10% 버프를 겁니다. (쿨타임 3턴)',
+            illustrationPath: 'assets/images/skills/ston-skin.png',
+            requiredClass: 'warrior',
+            cooldown: 3,
+            effect: {
+                id: 'stoneSkin',
+                type: EFFECT_TYPES.BUFF,
+                duration: 4,
+                // 여러 효과를 적용할 수 있도록 modifiers를 배열로 변경
+                modifiers: [
+                    { stat: 'damageReduction', type: 'percentage', value: 0.15 },
+                    { stat: 'physicalDefense', type: 'percentage', value: 0.10 }
+                ]
+            }
+        },
+        // LEGENDARY 등급: 방어력 상승 효과 강화
+        LEGENDARY: {
+            id: 'stoneSkin',
+            name: '스톤 스킨 [L]',
+            type: 'BUFF',
+            cost: 1,
+            targetType: 'self',
+            description: '4턴간 자신에게 데미지 감소 15%, 방어력 상승 15% 버프를 겁니다. (쿨타임 3턴)',
+            illustrationPath: 'assets/images/skills/ston-skin.png',
+            requiredClass: 'warrior',
+            cooldown: 3,
+            effect: {
+                id: 'stoneSkin',
+                type: EFFECT_TYPES.BUFF,
+                duration: 4,
+                modifiers: [
+                    { stat: 'damageReduction', type: 'percentage', value: 0.15 },
+                    { stat: 'physicalDefense', type: 'percentage', value: 0.15 }
+                ]
             }
         }
     },

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -42,7 +42,13 @@ class CombatCalculationEngine {
 
         if (damageReductionPercent > 0 || damageIncreasePercent > 0) {
             const effects = (statusEffectManager.activeEffects.get(defender.uniqueId) || [])
-                .filter(e => e.modifiers && (e.modifiers.stat === 'damageReduction' || e.modifiers.stat === 'damageIncrease'));
+                .filter(e => {
+                    if (!e.modifiers) return false;
+                    if (Array.isArray(e.modifiers)) {
+                        return e.modifiers.some(m => m.stat === 'damageReduction' || m.stat === 'damageIncrease');
+                    }
+                    return e.modifiers.stat === 'damageReduction' || e.modifiers.stat === 'damageIncrease';
+                });
             debugStatusEffectManager.logDamageModification(defender, initialDamage, finalDamage, effects);
         }
 

--- a/src/game/utils/SkillModifierEngine.js
+++ b/src/game/utils/SkillModifierEngine.js
@@ -5,11 +5,12 @@ import { debugLogEngine } from './DebugLogEngine.js';
  */
 class SkillModifierEngine {
     constructor() {
-        // 순위별 데미지 계수 (1순위 -> 4순위)
-        // 스킬마다 별도의 계수를 지정해 세밀한 밸런싱을 가능하게 합니다.
+        // 순위별 계수 (1순위 -> 4순위)
         this.rankModifiers = {
             'charge': [1.5, 1.2, 1.0, 0.8],
-            'attack': [1.3, 1.2, 1.1, 1.0]
+            'attack': [1.3, 1.2, 1.1, 1.0],
+            // 'stoneSkin' 스킬의 순위별 데미지 감소율
+            'stoneSkin': [0.24, 0.21, 0.18, 0.15]
         };
         debugLogEngine.log('SkillModifierEngine', '스킬 보정 엔진이 초기화되었습니다.');
     }
@@ -23,12 +24,28 @@ class SkillModifierEngine {
     getModifiedSkill(baseSkillData, rank, grade = 'NORMAL') {
         if (!baseSkillData) return null;
 
-        const modifiedSkill = { ...baseSkillData };
+        // 원본 훼손을 막기 위해 깊은 복사를 수행합니다.
+        const modifiedSkill = JSON.parse(JSON.stringify(baseSkillData));
         const rankIndex = rank - 1;
 
-        const modifiers = this.rankModifiers[baseSkillData.id];
-        if (modifiers && modifiers[rankIndex] && modifiedSkill.damageMultiplier) {
-            modifiedSkill.damageMultiplier = modifiers[rankIndex];
+        const damageModifiers = this.rankModifiers[baseSkillData.id];
+        if (damageModifiers && damageModifiers[rankIndex] && modifiedSkill.damageMultiplier) {
+            modifiedSkill.damageMultiplier = damageModifiers[rankIndex];
+        }
+
+        // 'stoneSkin' 스킬의 데미지 감소 효과 보정
+        if (baseSkillData.id === 'stoneSkin' && modifiedSkill.effect) {
+            const reductionModifiers = this.rankModifiers['stoneSkin'];
+            if (reductionModifiers && reductionModifiers[rankIndex] !== undefined) {
+                if (Array.isArray(modifiedSkill.effect.modifiers)) {
+                    const reductionMod = modifiedSkill.effect.modifiers.find(m => m.stat === 'damageReduction');
+                    if (reductionMod) {
+                        reductionMod.value = reductionModifiers[rankIndex];
+                    }
+                } else if (modifiedSkill.effect.modifiers && modifiedSkill.effect.modifiers.stat === 'damageReduction') {
+                    modifiedSkill.effect.modifiers.value = reductionModifiers[rankIndex];
+                }
+            }
         }
 
         // 차지 스킬의 경우 슬롯 순위에 따라 기절 턴 수를 보정합니다.

--- a/src/game/utils/StatusEffectManager.js
+++ b/src/game/utils/StatusEffectManager.js
@@ -100,8 +100,16 @@ class StatusEffectManager {
         const relevantEffects = [];
 
         for (const effect of effects) {
-            if (effect.modifiers && effect.modifiers.stat === modifierType) {
-                totalValue += effect.modifiers.value;
+            const mods = effect.modifiers;
+            if (Array.isArray(mods)) {
+                for (const m of mods) {
+                    if (m.stat === modifierType) {
+                        totalValue += m.value;
+                        relevantEffects.push(effect);
+                    }
+                }
+            } else if (mods && mods.stat === modifierType) {
+                totalValue += mods.value;
                 relevantEffects.push(effect);
             }
         }


### PR DESCRIPTION
## Summary
- expand `stoneSkin` buff with grade-specific data
- adjust `SkillModifierEngine` to support stone skin damage reduction per slot rank
- allow multiple modifiers in `StatusEffectManager`
- handle array modifiers in combat damage logs

## Testing
- `python3 -m http.server 8000 &> /tmp/http.log &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6882166e35d48327a5eef5dec86d60ae