### PR TITLE
Add movement check node for AI

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -12,6 +12,8 @@ import UseSkillNode from '../nodes/UseSkillNode.js';
 import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import FindMeleeStrategicTargetNode from '../nodes/FindMeleeStrategicTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
+// ✨ HasNotMovedNode를 import합니다.
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 
 /**
  * 근접 유닛(전사)을 위한 행동 트리를 재구성합니다.
@@ -31,6 +33,8 @@ function createMeleeAI(engines = {}) {
         ]),
         // B. 이동 후 사용
         new SequenceNode([
+            // ✨ 이동하기 전에 아직 움직이지 않았는지 확인합니다.
+            new HasNotMovedNode(),
             new FindPathToSkillRangeNode(engines),
             new MoveToTargetNode(engines),
             new IsSkillInRangeNode(engines), // 이동 후 사거리 재확인
@@ -66,6 +70,8 @@ function createMeleeAI(engines = {}) {
 
         // 우선순위 5: 사용할 스킬이 없을 경우, 이동만 실행
         new SequenceNode([
+            // ✨ 이동하기 전에 아직 움직이지 않았는지 확인합니다.
+            new HasNotMovedNode(),
             new FindMeleeStrategicTargetNode(engines),
             new FindPathToTargetNode(engines),
             new MoveToTargetNode(engines)

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -16,6 +16,8 @@ import IsTargetTooCloseNode from '../nodes/IsTargetTooCloseNode.js';
 import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
 import FindMeleeStrategicTargetNode from '../nodes/FindMeleeStrategicTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
+// ✨ HasNotMovedNode를 import합니다.
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 
 /**
  * 원거리 유닛(거너)을 위한 행동 트리를 재구성합니다.
@@ -38,6 +40,8 @@ function createRangedAI(engines = {}) {
         ]),
         // B. 이동 후 사용 (카이팅 AI는 적에게 다가갈 때도 사용)
         new SequenceNode([
+            // ✨ 이동하기 전에 아직 움직이지 않았는지 확인합니다.
+            new HasNotMovedNode(),
             new FindPathToSkillRangeNode(engines),
             new MoveToTargetNode(engines),
             new IsSkillInRangeNode(engines), // 이동 후 사거리 재확인
@@ -76,6 +80,8 @@ function createRangedAI(engines = {}) {
     const rootNode = new SelectorNode([
         // 최우선 순위 1: 생존 - 적이 너무 가까우면 카이팅부터 실행
         new SequenceNode([
+            // ✨ 이동하기 전에 아직 움직이지 않았는지 확인합니다.
+            new HasNotMovedNode(),
             new IsTargetTooCloseNode({ ...engines, dangerZone: 2 }), // 위험 거리 설정
             new FindKitingPositionNode(engines),
             new MoveToTargetNode(engines),
@@ -91,6 +97,8 @@ function createRangedAI(engines = {}) {
 
         // 우선순위 3: 이동 - 공격할 스킬이 없다면, 다음 턴을 위해 이동만 실행
         new SequenceNode([
+            // ✨ 이동하기 전에 아직 움직이지 않았는지 확인합니다.
+            new HasNotMovedNode(),
             new FindMeleeStrategicTargetNode(engines),
             new FindPathToTargetNode(engines),
             new MoveToTargetNode(engines)

--- a/src/ai/nodes/HasNotMovedNode.js
+++ b/src/ai/nodes/HasNotMovedNode.js
@@ -1,0 +1,23 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * Checks if the unit has already performed its move action this turn.
+ */
+class HasNotMovedNode extends Node {
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+
+        const hasMoved = blackboard.get('hasMovedThisTurn');
+
+        if (!hasMoved) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, '아직 이동하지 않음');
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '이번 턴에 이미 이동함');
+        return NodeState.FAILURE;
+    }
+}
+
+export default HasNotMovedNode;

--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -13,9 +13,15 @@ class MoveToTargetNode extends Node {
         const path = blackboard.get('movementPath');
         const movementRange = unit.finalStats.movement || 3;
 
-        if (!path || path.length === 0) {
-            debugAIManager.logNodeResult(NodeState.FAILURE);
+        // ✨ [수정] 경로가 없는 경우(null)와 이미 도착한 경우(빈 배열)를 분리해서 처리합니다.
+        if (!path) { // 경로 탐색 실패
+            debugAIManager.logNodeResult(NodeState.FAILURE, '경로가 없음');
             return NodeState.FAILURE;
+        }
+
+        if (path.length === 0) { // 이미 목표 위치에 도달함
+            debugAIManager.logNodeResult(NodeState.SUCCESS, '이미 목표 위치에 있음');
+            return NodeState.SUCCESS;
         }
 
         // 이동력만큼만 경로를 잘라냅니다.


### PR DESCRIPTION
## Summary
- add `HasNotMovedNode` for checking whether a unit already moved
- integrate the node into melee/ranged behavior trees
- improve `MoveToTargetNode` handling when path is missing or already at destination

## Testing
- `node tests/charge_skill_test.js`
- `node tests/ironwill_skill_test.js`
- `node tests/shieldbreak_skill_test.js`
- `node tests/stoneskin_skill_test.js`
- `node tests/skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6882438c6b6c8327a45f0b5c1353796c