### PR TITLE
Add 9-slice UI styling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1108,7 +1108,31 @@ body {
     background-position: center;
     border: 2px solid #888;
     border-radius: 5px;
-    background-size: 200%; 
+    background-size: 200%;
     margin-left: 20px; /* 좌측 패널과의 간격 */
+}
+
+/* --- 9-Slice 패널 스타일 추가 --- */
+.skill-panel {
+    padding: 50px;
+    border-style: solid;
+    border-width: 50px;
+    border-image-source: url(../assets/images/ui-panel.png);
+    border-image-slice: 60 fill;
+    border-image-repeat: stretch;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    pointer-events: auto;
+}
+
+#hire-modal-content {
+    padding: 60px;
+    border-style: solid;
+    border-width: 60px;
+    border-image-source: url(../assets/images/ui-panel.png);
+    border-image-slice: 60 fill;
+    border-image-repeat: stretch;
+    background-color: transparent;
 }
 

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -17,5 +17,22 @@ export class Game extends Scene {
         
         // 게임 시작 시, 카메라의 초기 상태를 로그로 남깁니다.
         debugCameraLogManager.logInitialState(this.cameras.main, this.sys.game.config);
+
+        // 예시용 9-Slice UI 패널 생성
+        const helpPanel = this.add.nineslice(
+            this.cameras.main.centerX,
+            this.cameras.main.centerY,
+            400,
+            300,
+            'ui-panel',
+            null,
+            60,
+            60
+        );
+
+        this.add.text(helpPanel.x, helpPanel.y, 'Hello 9-Slice!', {
+            fontSize: '32px',
+            color: '#ffffff'
+        }).setOrigin(0.5);
     }
 }

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -95,6 +95,8 @@ export class Preloader extends Scene
         this.load.image('skill-slot', 'images/skills/skill-slot.png');
         // 공통 패널 배경 이미지
         this.load.image('panel-background', 'images/ui-panel.png');
+        // 9-Slice 패널 이미지 로드 (모서리 두께 60px)
+        this.load.nineslice('ui-panel', 'images/ui-panel.png', 60);
         this.load.image('battle-stage-arena', 'images/battle/battle-stage-arena.png');
         this.load.image('battle-stage-cursed-forest', 'images/battle/battle-stage-cursed-forest.png');
 


### PR DESCRIPTION
## Summary
- decorate DOM panels with border-image
- load ui-panel as Phaser NineSlice
- display demo 9-slice panel in `Game` scene

## Testing
- `node tests/skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688259d88f5c83278ce5699df901a796