### PR TITLE
Add token UI updates to battle VFX

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -98,8 +98,9 @@ export class BattleSimulatorEngine {
         // 스킬 사용 기록 초기화
         skillEngine.resetTurnActions();
 
-        // 첫 턴 시작 직후 모든 유닛의 토큰 UI를 업데이트합니다.
-        allUnits.forEach(unit => this.vfxManager.updateTokenDisplay(unit.uniqueId));
+        // [✨ 수정] 첫 턴 시작 직후 모든 유닛의 토큰 UI를 업데이트합니다.
+        // unit.uniqueId 대신 unit 객체 전체를 전달합니다.
+        allUnits.forEach(unit => this.vfxManager.updateTokenDisplay(unit));
 
         this.gameLoop(); // 수정된 루프 시작
     }
@@ -159,9 +160,10 @@ export class BattleSimulatorEngine {
             }
 
             // --- ✨ 매 행동 후 모든 유닛의 토큰 UI 업데이트 ---
+            // unit.uniqueId 대신 unit 객체 전체를 전달합니다.
             this.turnQueue.forEach(unit => {
                 if (unit.sprite && unit.sprite.active) {
-                    this.vfxManager.updateTokenDisplay(unit.uniqueId);
+                    this.vfxManager.updateTokenDisplay(unit);
                 }
             });
             this.vfxManager.updateAllStatusIcons();


### PR DESCRIPTION
## Summary
- enhance VFXManager with token display support
- update BattleSimulatorEngine to pass unit objects to `updateTokenDisplay`

## Testing
- `node tests/charge_skill_test.js`
- `node tests/shieldbreak_skill_test.js`
- `node tests/stoneskin_skill_test.js`
- `node tests/ironwill_skill_test.js`
- `node tests/skill_integration_test.js`
- `python3 -m http.server 8000 &` + `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68826b31bc9c8327942c69380f45cad7