### PR TITLE
Fix outdated status icon call

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -166,7 +166,6 @@ export class BattleSimulatorEngine {
                     this.vfxManager.updateTokenDisplay(unit);
                 }
             });
-            this.vfxManager.updateAllStatusIcons();
             // 다음 턴의 유닛 정보를 미리 갱신
             this.combatUI.show(this.turnQueue[this.currentTurnIndex]);
 


### PR DESCRIPTION
## Summary
- remove reference to deleted updateAllStatusIcons
- confirm health bar code and styling remain

## Testing
- `node tests/charge_skill_test.js && node tests/ironwill_skill_test.js && node tests/shieldbreak_skill_test.js && node tests/stoneskin_skill_test.js && node tests/skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68826f365eec8327b6bba6e5fe015ce0