### PR TITLE
Fix AI action management and targeting

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -12,10 +12,7 @@ import UseSkillNode from '../nodes/UseSkillNode.js';
 import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import FindMeleeStrategicTargetNode from '../nodes/FindMeleeStrategicTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
-// ✨ HasNotMovedNode를 import합니다.
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
-// ✨ 수정: 더 지능적인 타겟팅을 위해 FindPreferredTargetNode를 import합니다.
-import FindPreferredTargetNode from '../nodes/FindPreferredTargetNode.js';
 
 /**
  * 근접 유닛(전사)을 위한 행동 트리를 재구성합니다.
@@ -66,8 +63,7 @@ function createMeleeAI(engines = {}) {
         // 우선순위 4: 4번 슬롯 스킬 사용 시도 (보통 일반 공격)
         new SequenceNode([
             new CanUseSkillBySlotNode(3),
-            // ✨ 수정: 비효율적인 타겟팅 노드를 더 스마트한 노드로 교체
-            new FindPreferredTargetNode(engines),
+            new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
 


### PR DESCRIPTION
## Summary
- update AIManager to check for movement as an action so AI can attack after moving
- improve FindTargetBySkillTypeNode to pick lowest‑HP enemy in range or move toward the nearest target
- simplify MeleeAI behavior tree by removing FindPreferredTargetNode and using the improved targeting node

## Testing
- `node tests/charge_skill_test.js`
- `node tests/ironwill_skill_test.js`
- `node tests/shieldbreak_skill_test.js`
- `node tests/skill_integration_test.js`
- `node tests/stoneskin_skill_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688275cbc8fc8327adeb210932915ee0