### PR TITLE
Update combat HUD with skills and cooldown

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1023,10 +1023,22 @@ body {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
-    justify-content: flex-start;
+    justify-content: space-between;
     color: #e0e0e0;
     font-family: sans-serif;
-    gap: 8px; /* 요소간 간격 추가 */
+    gap: 4px;
+}
+
+.combat-top-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.combat-bottom-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
 }
 
 .unit-name-level {
@@ -1042,11 +1054,19 @@ body {
 
 /* 체력바 스타일 */
 .combat-health-bar-container {
-    width: 100%;
+    position: relative;
+    flex-grow: 1;
     height: 10px;
     background-color: #333;
     border: 1px solid #555;
     border-radius: 5px;
+}
+
+.combat-health-bar-container .unit-stats {
+    position: absolute;
+    top: -18px;
+    right: 0;
+    font-size: 12px;
 }
 
 .combat-health-bar {
@@ -1067,12 +1087,41 @@ body {
     height: 20px;
 }
 
+.combat-skill-container {
+    display: flex;
+    gap: 6px;
+}
+
+.combat-skill-icon {
+    width: 40px;
+    height: 40px;
+    background-size: cover;
+    background-position: center;
+    border: 1px solid #666;
+    border-radius: 4px;
+    position: relative;
+}
+
+.skill-cooldown-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-weight: bold;
+}
+
 
 .unit-effects {
     display: flex;
     gap: 8px;
     align-items: center;
-    margin-top: auto; /* info-panel 하단에 붙도록 */
+    margin-top: 0;
 }
 
 .effect-icon-wrapper {

--- a/src/game/utils/CooldownManager.js
+++ b/src/game/utils/CooldownManager.js
@@ -56,6 +56,17 @@ class CooldownManager {
         const remainingTurns = this.cooldowns.get(unitId).get(skillId) || 0;
         return remainingTurns <= 0;
     }
+
+    /**
+     * 남은 쿨타임 턴 수를 조회합니다.
+     * @param {number} unitId
+     * @param {string} skillId
+     * @returns {number} 남은 턴 수 (없으면 0)
+     */
+    getRemaining(unitId, skillId) {
+        if (!this.cooldowns.has(unitId)) return 0;
+        return this.cooldowns.get(unitId).get(skillId) || 0;
+    }
 }
 
 export const cooldownManager = new CooldownManager();


### PR DESCRIPTION
## Summary
- add cooldown query helper
- redesign combat HUD layout
- show skill icons with cooldown overlay

## Testing
- `node tests/charge_skill_test.js`
- `node tests/ironwill_skill_test.js`
- `node tests/shieldbreak_skill_test.js`
- `node tests/stoneskin_skill_test.js`
- `node tests/skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688281913cb0832790137ababd5c1840