### PR TITLE
Adjust token UI and label positions

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -120,8 +120,9 @@ export class BattleSimulatorEngine {
                 unit.gridY = cell.row;
             }
 
-            // 머리 위 이름표만 생성한다.
-            const nameTag = this.textEngine.createLabel(unit.sprite, unit.instanceName);
+            // ✨ [수정] 팀에 따라 이름표 색상을 다르게 설정합니다.
+            const nameColor = unit.team === 'ally' ? '#60a5fa' : '#f87171'; // 아군: 파랑, 적군: 빨강
+            const nameTag = this.textEngine.createLabel(unit.sprite, unit.instanceName, nameColor);
             this.bindingManager.bind(unit.sprite, [nameTag]);
         });
     }

--- a/src/game/utils/OffscreenTextEngine.js
+++ b/src/game/utils/OffscreenTextEngine.js
@@ -31,8 +31,8 @@ export class OffscreenTextEngine {
         label.setResolution(2);  // 해상도를 2배로 설정
         label.setScale(0.5);     // \ud06c\uae30\ub97c 0.5\ubc84\ub2e4\ub97c \ucd95\uc18c\ud558\uc5ec \uc120\uba85\ub3c4 \ud655\ub960
 
-        // 유닛의 발밑으로 위치를 조정합니다. (상수 5는 약간의 여백)
-        label.y = sprite.y + (sprite.displayHeight / 2) + 5;
+        // ✨ [수정] 유닛 발밑과의 여백을 5에서 2로 줄여 더 가깝게 만듭니다.
+        label.y = sprite.y + (sprite.displayHeight / 2) + 2;
 
         this.labels.push({ label, sprite });
         return label;
@@ -46,7 +46,8 @@ export class OffscreenTextEngine {
         this.labels.forEach(item => {
             if (item.sprite.active) {
                 item.label.x = item.sprite.x;
-                item.label.y = item.sprite.y + (item.sprite.displayHeight / 2) + 5;
+                // ✨ [수정] 여기도 동일하게 여백을 2로 수정합니다.
+                item.label.y = item.sprite.y + (item.sprite.displayHeight / 2) + 2;
             } else {
                 // \uc2a4\ud504\ub808\uc774\ud2b8\uac00 \ube44\ud65c\uc131\ud654\ub418\uba74 \uc774\ub984\ud3a0\ub3c4 \uc228\uae38\ub9ac\ub2c8\ub2e4.
                 item.label.setVisible(false);

--- a/src/game/utils/VFXManager.js
+++ b/src/game/utils/VFXManager.js
@@ -41,7 +41,8 @@ export class VFXManager {
 
         // 유닛의 토큰 UI가 없다면 새로 생성합니다.
         if (!display) {
-            const yOffset = (unit.sprite.displayHeight / 2) + 15; // 유닛 발밑
+            // ✨ [수정] yOffset을 음수 값으로 변경하여 유닛의 머리 위로 이동시킵니다.
+            const yOffset = -(unit.sprite.displayHeight / 2) - 15; // 유닛 머리 위
             const container = this.scene.add.container(unit.sprite.x, unit.sprite.y + yOffset);
             this.vfxLayer.add(container);
 


### PR DESCRIPTION
## Summary
- display token UI above units
- reduce label spacing from units
- color name tags by team

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688286949b608327ac1973fb3d46b728