### PR TITLE
Add ranged attack skill for gunner class

### DIFF
--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -178,5 +178,59 @@ export const activeSkills = {
             range: 3,
             push: 2
         }
+    },
+
+    // ✨ [신규] 원거리 공격 스킬 추가
+    rangedAttack: {
+        NORMAL: {
+            id: 'rangedAttack',
+            name: '원거리 공격',
+            type: 'ACTIVE',
+            cost: 1,
+            description: '원거리의 적을 {{damage}}% 데미지로 공격합니다.',
+            illustrationPath: 'assets/images/skills/gunner-attack-icon.png',
+            requiredClass: 'gunner',
+            damageMultiplier: 1.0,
+            cooldown: 0,
+            range: 3,
+        },
+        RARE: {
+            id: 'rangedAttack',
+            name: '원거리 공격 [R]',
+            type: 'ACTIVE',
+            cost: 0,
+            description: '원거리의 적을 {{damage}}% 데미지로 공격합니다.',
+            illustrationPath: 'assets/images/skills/gunner-attack-icon.png',
+            requiredClass: 'gunner',
+            damageMultiplier: 1.0,
+            cooldown: 0,
+            range: 3,
+        },
+        EPIC: {
+            id: 'rangedAttack',
+            name: '원거리 공격 [E]',
+            type: 'ACTIVE',
+            cost: 0,
+            description: '원거리의 적을 {{damage}}% 데미지로 공격하고, 50% 확률로 토큰 1개를 생성합니다.',
+            illustrationPath: 'assets/images/skills/gunner-attack-icon.png',
+            requiredClass: 'gunner',
+            damageMultiplier: 1.0,
+            cooldown: 0,
+            range: 3,
+            generatesToken: { chance: 0.5, amount: 1 }
+        },
+        LEGENDARY: {
+            id: 'rangedAttack',
+            name: '원거리 공격 [L]',
+            type: 'ACTIVE',
+            cost: 0,
+            description: '원거리의 적을 {{damage}}% 데미지로 공격하고, 100% 확률로 토큰 1개를 생성합니다.',
+            illustrationPath: 'assets/images/skills/gunner-attack-icon.png',
+            requiredClass: 'gunner',
+            damageMultiplier: 1.0,
+            cooldown: 0,
+            range: 3,
+            generatesToken: { chance: 1.0, amount: 1 }
+        }
     }
 };

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -40,7 +40,7 @@ class MercenaryEngine {
             skillSlots: skillEngine.generateRandomSkillSlots()
         };
 
-        // ✨ 2. '전사' 클래스에 대한 특별 처리
+        // ✨ 2. '전사' 및 '거너' 클래스에 대한 특별 처리
         if (newInstance.id === 'warrior') {
             // 4번째 슬롯을 'ACTIVE' 타입으로 고정
             newInstance.skillSlots.push('ACTIVE');
@@ -52,6 +52,16 @@ class MercenaryEngine {
                 // 4번 슬롯(인덱스 3)에 장착
                 ownedSkillsManager.equipSkill(newInstance.uniqueId, 3, attackInstance.instanceId);
                 // 새로 생성된 인스턴스는 용병 전용이므로 인벤토리 목록에서는 제거합니다.
+                skillInventoryManager.removeSkillFromInventoryList(attackInstance.instanceId);
+            }
+        } else if (newInstance.id === 'gunner') {
+            // ✨ [신규] 거너를 위한 4번째 슬롯 처리
+            newInstance.skillSlots.push('ACTIVE');
+
+            const consumed = skillInventoryManager.findAndRemoveInstanceOfSkill('rangedAttack');
+            if (consumed) {
+                const attackInstance = skillInventoryManager.addSkillById('rangedAttack', consumed.grade);
+                ownedSkillsManager.equipSkill(newInstance.uniqueId, 3, attackInstance.instanceId);
                 skillInventoryManager.removeSkillFromInventoryList(attackInstance.instanceId);
             }
         } else {

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -26,6 +26,8 @@ class SkillInventoryManager {
                 this.addSkillById('attack', grade); // 공격 스킬도 각 등급별 2장 지급
 
                 // ✨ 추가 기본 스킬 카드 지급
+                // 원거리 공격 스킬 카드도 등급별로 지급합니다.
+                this.addSkillById('rangedAttack', grade);
                 this.addSkillById('stoneSkin', grade);
                 this.addSkillById('shieldBreak', grade);
                 this.addSkillById('ironWill', grade);

--- a/src/game/utils/SkillModifierEngine.js
+++ b/src/game/utils/SkillModifierEngine.js
@@ -16,7 +16,9 @@ class SkillModifierEngine {
             // ✨ 쉴드 브레이크의 순위별 '받는 데미지 증가' 효과 수치
             'shieldBreak': [0.24, 0.21, 0.18, 0.15],
             // ✨ 넉백샷 순위별 데미지 계수 추가
-            'knockbackShot': [1.4, 1.2, 1.0, 0.8]
+            'knockbackShot': [1.4, 1.2, 1.0, 0.8],
+            // ✨ [신규] 원거리 공격 순위별 데미지 계수 추가
+            'rangedAttack': [1.3, 1.2, 1.1, 1.0]
         };
         debugLogEngine.log('SkillModifierEngine', '스킬 보정 엔진이 초기화되었습니다.');
     }


### PR DESCRIPTION
## Summary
- introduce `rangedAttack` active skill for gunners
- tune `SkillModifierEngine` with rank modifiers for the new skill
- generate `rangedAttack` cards in initial inventory
- equip gunners with `rangedAttack` when hired
- confirm basic app loads via debug.html

## Testing
- `node tests/charge_skill_test.js`
- `node tests/shieldbreak_skill_test.js`
- `node tests/stoneskin_skill_test.js`
- `node tests/ironwill_skill_test.js`
- `node tests/skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6882f12894208327a67773b5d0ed4411