### PR TITLE
Enhance ranged AI kiting logic

### DIFF
--- a/src/ai/Blackboard.js
+++ b/src/ai/Blackboard.js
@@ -24,6 +24,7 @@ class Blackboard {
         this.set('isThreatened', false);
         this.set('squadAdvantage', 0);
         this.set('enemyHealerUnit', null);
+        this.set('threateningUnit', null);
 
         // --- 🤖 AI 자신의 상태 정보 ---
         this.set('canUseSkill_1', false);

--- a/src/ai/nodes/FindKitingPositionNode.js
+++ b/src/ai/nodes/FindKitingPositionNode.js
@@ -13,7 +13,11 @@ class FindKitingPositionNode extends Node {
 
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
-        const target = blackboard.get('currentTargetUnit');
+        // ✨ [핵심 변경] 카이팅의 기준이 될 대상을 결정합니다.
+        // 1순위: IsTargetTooCloseNode가 설정한 '위협적인 적'
+        // 2순위: 현재 공격하려는 '스킬 대상'
+        // 3순위: AI가 정한 '일반 공격 대상'
+        const target = blackboard.get('threateningUnit') || blackboard.get('skillTarget') || blackboard.get('currentTargetUnit');
         const enemyUnits = blackboard.get('enemyUnits');
 
         if (!target) {

--- a/src/ai/nodes/IsTargetTooCloseNode.js
+++ b/src/ai/nodes/IsTargetTooCloseNode.js
@@ -24,10 +24,15 @@ class IsTargetTooCloseNode extends Node {
         const distance = Math.abs(unit.gridX - nearestEnemy.gridX) + Math.abs(unit.gridY - nearestEnemy.gridY);
 
         if (distance <= this.dangerZone) {
+            // ✨ [핵심 변경] 어떤 적이 위협적인지 블랙보드에 기록합니다.
+            // FindKitingPositionNode가 이 정보를 사용하여 "누구로부터" 도망칠지 결정합니다.
+            blackboard.set('threateningUnit', nearestEnemy);
             debugAIManager.logNodeResult(NodeState.SUCCESS, `가장 가까운 적 '${nearestEnemy.instanceName}'이 위험거리(${this.dangerZone}) 내에 있음!`);
             return NodeState.SUCCESS; // 너무 가까움!
         }
-        
+
+        // 위협적인 적이 없으므로 정보를 초기화합니다.
+        blackboard.set('threateningUnit', null);
         debugAIManager.logNodeResult(NodeState.FAILURE, `가장 가까운 적 '${nearestEnemy.instanceName}'과의 거리가 안전함`);
         return NodeState.FAILURE; // 안전함
     }


### PR DESCRIPTION
## Summary
- use `FindKitingPositionNode` for both kiting and approach logic in `RangedAI`
- store threatening enemy on the blackboard
- base kiting target selection on threatening unit or skill target
- add `threateningUnit` key to `Blackboard`

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6882f8141ff483279e8e70a0816d8534