### PR TITLE
Add status effect sprites for mercenaries

### DIFF
--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -5,12 +5,13 @@ export const mercenaryData = {
         hireImage: 'assets/images/territory/warrior-hire.png',
         uiImage: 'assets/images/territory/warrior-ui.png',
         battleSprite: 'warrior',
-        // 유닛의 행동별 스프라이트 키를 정의합니다.
+        // ✨ 전사 스프라이트 정보 업데이트
         sprites: {
             idle: 'warrior',
             attack: 'warrior-attack',
             hitted: 'warrior-hitted',
             cast: 'warrior-cast',
+            'status-effects': 'warrior-status-effects', // 상태이상 이미지 키 추가
         },
         description: '"그는 단 한 사람을 지키기 위해 검을 든다."',
         baseStats: {
@@ -24,10 +25,13 @@ export const mercenaryData = {
         hireImage: 'assets/images/territory/gunner-hire.png',
         uiImage: 'assets/images/territory/gunner-ui.png',
         battleSprite: 'gunner',
+        // ✨ 거너 스프라이트 정보 업데이트
         sprites: {
             idle: 'gunner',
             attack: 'gunner-attack',
             hitted: 'gunner-hitted',
+            cast: 'gunner-cast', // 버프(시전) 이미지 키 추가
+            'status-effects': 'gunner-status-effects', // 상태이상 이미지 키 추가
         },
         description: '"한 발, 한 발. 신중하게, 그리고 차갑게."',
         baseStats: {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -66,10 +66,14 @@ export class Preloader extends Scene
         this.load.image('warrior-attack', 'images/unit/warrior-attack.png');
         this.load.image('warrior-hitted', 'images/unit/warrior-hitted.png');
         this.load.image('warrior-cast', 'images/unit/warrior-cast.png');
+        // 상태이상 표현 스프라이트
+        this.load.image('warrior-status-effects', 'images/unit/warrior-status-effects.png');
 
         // --- 거너의 행동별 스프라이트 로드 ---
         this.load.image('gunner-attack', 'images/unit/gunner-attack.png');
         this.load.image('gunner-hitted', 'images/unit/gunner-hitted.png');
+        this.load.image('gunner-cast', 'images/unit/gunner-cast.png');
+        this.load.image('gunner-status-effects', 'images/unit/gunner-status-effects.png');
 
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');

--- a/src/game/utils/StatusEffectManager.js
+++ b/src/game/utils/StatusEffectManager.js
@@ -5,6 +5,8 @@ import { statusEffects } from '../data/status-effects.js';
 import { ownedSkillsManager } from './OwnedSkillsManager.js';
 import { skillInventoryManager } from './SkillInventoryManager.js';
 import { passiveSkills } from '../data/skills/passive.js';
+// 상태이상 시 스프라이트 교체에 사용
+import { spriteEngine } from './SpriteEngine.js';
 
 // 효과의 종류를 명확히 구분하기 위한 상수
 export const EFFECT_TYPES = {
@@ -124,6 +126,11 @@ class StatusEffectManager {
         if (this.battleSimulator && this.battleSimulator.vfxManager && effectDefinition.name) {
             const color = newEffect.type === EFFECT_TYPES.BUFF ? '#22c55e' : '#ef4444';
             this.battleSimulator.vfxManager.showEffectName(targetUnit.sprite, effectDefinition.name, color);
+        }
+
+        // 버프가 아니라면 상태이상 스프라이트를 잠시 적용
+        if (newEffect.type !== EFFECT_TYPES.BUFF) {
+            spriteEngine.changeSpriteForDuration(targetUnit, 'status-effects', 1000);
         }
 
         debugStatusEffectManager.logEffectApplied(targetUnit, newEffect);


### PR DESCRIPTION
## Summary
- load new warrior and gunner action sprites in the preloader
- expand mercenary sprite tables with cast and status effect images
- swap to status-effect sprite when a debuff is applied

## Testing
- `node tests/charge_skill_test.js`
- `node tests/shieldbreak_skill_test.js`
- `node tests/stoneskin_skill_test.js`
- `node tests/ironwill_skill_test.js`
- `node tests/skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6882fc9ba8a48327bb48e17829af12e7