### PR TITLE
Add movement stat test

### DIFF
--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -16,7 +16,8 @@ export const mercenaryData = {
         description: '"그는 단 한 사람을 지키기 위해 검을 든다."',
         baseStats: {
             hp: 120, valor: 10, strength: 15, endurance: 12,
-            agility: 8, intelligence: 5, wisdom: 5, luck: 7
+            agility: 8, intelligence: 5, wisdom: 5, luck: 7,
+            movement: 3 // 전사의 기본 이동력
         }
     },
     gunner: {
@@ -37,7 +38,8 @@ export const mercenaryData = {
         baseStats: {
             hp: 80, valor: 5, strength: 7, endurance: 6,
             agility: 15, intelligence: 8, wisdom: 10, luck: 12,
-            attackRange: 3
+            attackRange: 3,
+            movement: 3 // 거너의 기본 이동력
         }
     },
     // --- ▼ [신규] 메딕 클래스 데이터 추가 ▼ ---
@@ -58,7 +60,8 @@ export const mercenaryData = {
         baseStats: {
             hp: 90, valor: 8, strength: 6, endurance: 8,
             agility: 10, intelligence: 12, wisdom: 15, luck: 9,
-            attackRange: 2
+            attackRange: 2,
+            movement: 2 // 메딕의 기본 이동력
         }
     }
     // --- ▲ [신규] 메딕 클래스 데이터 추가 ▲ ---

--- a/src/game/utils/StatEngine.js
+++ b/src/game/utils/StatEngine.js
@@ -99,6 +99,7 @@ class StatEngine {
             wisdom: baseStats.wisdom || 0,
             luck: baseStats.luck || 0,
             attackRange: baseStats.attackRange || 1,
+            movement: baseStats.movement || 0,
         });
 
         // 2. \uC804\uBB38 \uC5D4\uC9C4\uC744 \uD1B5\uD574 \uD30C\uC9C0 \uC2A4\uD0EF\uC744 \uACC4\uC0B0\uD569\uB2C8\uB2E4.

--- a/tests/movement_stat_test.js
+++ b/tests/movement_stat_test.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+import { mercenaryData } from '../src/game/data/mercenaries.js';
+import { statEngine } from '../src/game/utils/StatEngine.js';
+
+const warrior = mercenaryData.warrior;
+const gunner = mercenaryData.gunner;
+const medic = mercenaryData.medic;
+
+assert.strictEqual(statEngine.calculateStats(warrior, warrior.baseStats, []).movement, 3);
+assert.strictEqual(statEngine.calculateStats(gunner, gunner.baseStats, []).movement, 3);
+assert.strictEqual(statEngine.calculateStats(medic, medic.baseStats, []).movement, 2);
+
+console.log('Movement stat tests passed.');


### PR DESCRIPTION
## Summary
- add regression test ensuring mercenary movement stats

## Testing
- `node tests/charge_skill_test.js`
- `node tests/ironwill_skill_test.js`
- `node tests/shieldbreak_skill_test.js`
- `node tests/stoneskin_skill_test.js`
- `node tests/skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688317b3b1508327975f398c4913fd1a