### PR TITLE
Integrate ShadowManager with battle engine

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -23,6 +23,9 @@ import { cooldownManager } from './CooldownManager.js';
 // 전투 중 하단 UI를 관리하는 매니저
 import { CombatUIManager } from '../dom/CombatUIManager.js';
 
+// 그림자 생성을 담당하는 매니저
+import { ShadowManager } from './ShadowManager.js';
+
 
 export class BattleSimulatorEngine {
     constructor(scene) {
@@ -33,6 +36,8 @@ export class BattleSimulatorEngine {
         this.animationEngine = new AnimationEngine(scene);
         this.textEngine = new OffscreenTextEngine(scene);
         this.bindingManager = new BindingManager(scene);
+        // 그림자 생성용 매니저 초기화
+        this.shadowManager = new ShadowManager(scene);
         this.vfxManager = new VFXManager(scene, this.textEngine, this.bindingManager);
         this.terminationManager = new TerminationManager(scene);
         // 전투 중 유닛 정보를 표시할 UI 매니저
@@ -121,9 +126,13 @@ export class BattleSimulatorEngine {
             }
 
             // ✨ [수정] 팀에 따라 이름표 색상을 다르게 설정합니다.
-            const nameColor = unit.team === 'ally' ? '#60a5fa' : '#f87171'; // 아군: 파랑, 적군: 빨강
+            const nameColor = unit.team === 'ally' ? '#60a5fa' : '#f87171';
             const nameTag = this.textEngine.createLabel(unit.sprite, unit.instanceName, nameColor);
-            this.bindingManager.bind(unit.sprite, [nameTag]);
+
+            // 그림자 생성 후 원본 스프라이트와 함께 이동하도록 바인딩합니다.
+            const shadow = this.shadowManager.createShadow(unit.sprite);
+
+            this.bindingManager.bind(unit.sprite, [nameTag, shadow]);
         });
     }
 
@@ -199,6 +208,9 @@ export class BattleSimulatorEngine {
         }
         if (this.textEngine) {
             this.textEngine.shutdown();
+        }
+        if (this.shadowManager) {
+            this.shadowManager.shutdown();
         }
         if (this.combatUI) {
             this.combatUI.destroy();

--- a/src/game/utils/ShadowManager.js
+++ b/src/game/utils/ShadowManager.js
@@ -1,22 +1,34 @@
 import { debugLogEngine } from './DebugLogEngine.js';
-// Phaser의 Math 모듈만 불러와 필요한 범위에서 사용합니다.
-import { Math as PhaserMath } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 /**
  * 유닛의 그림자를 생성하고 관리하는 엔진
  */
-class ShadowManager {
+export class ShadowManager {
     constructor(scene) {
         this.scene = scene;
         // 그림자를 다른 요소보다 먼저, 배경 위에 표시하기 위해 레이어를 생성합니다.
         this.shadowLayer = this.scene.add.layer();
+        this.shadowTextureKey = 'oval-shadow';
+
+        // 게임 시작 시 한 번만 타원형 텍스처를 생성합니다.
+        this._createShadowTexture();
         debugLogEngine.log('ShadowManager', '그림자 매니저가 초기화되었습니다.');
+    }
+
+    /**
+     * 재사용할 타원형 그림자 텍스처를 생성하는 내부 메서드
+     */
+    _createShadowTexture() {
+        const graphics = this.scene.make.graphics({ fillStyle: { color: 0x000000, alpha: 0.4 } }, false);
+        graphics.fillEllipse(50, 15, 100, 30); // 너비 100, 높이 30의 타원
+        graphics.generateTexture(this.shadowTextureKey, 100, 30);
+        graphics.destroy();
     }
 
     /**
      * 특정 스프라이트에 대한 그림자를 생성합니다.
      * @param {Phaser.GameObjects.Sprite} parentSprite 원본 스프라이트
-     * @returns {Phaser.GameObjects.Sprite|null} 생성된 그림자 스프라이트
+     * @returns {Phaser.GameObjects.Image|null} 생성된 그림자 이미지
      */
     createShadow(parentSprite) {
         if (!parentSprite || !parentSprite.texture || parentSprite.texture.key === '__MISSING') {
@@ -24,22 +36,16 @@ class ShadowManager {
             return null;
         }
 
-        // 원본과 동일한 텍스처의 스프라이트를 생성합니다.
-        const shadow = this.scene.add.sprite(parentSprite.x, parentSprite.y, parentSprite.texture.key);
+        // 유닛 발밑 중앙에 위치하도록 좌표를 계산합니다.
+        const shadowX = parentSprite.x;
+        const shadowY = parentSprite.y + parentSprite.displayHeight / 2 - 5; // 발밑에 살짝 붙도록 조정
 
-        shadow.setTint(0x000000); // 검은색 틴트
-        shadow.setAlpha(0.4); // 반투명하게
-        shadow.setScale(parentSprite.scaleX, parentSprite.scaleY);
-        shadow.setOrigin(parentSprite.originX, parentSprite.originY);
+        // 미리 생성된 텍스처로 그림자 이미지를 만듭니다.
+        const shadow = this.scene.add.image(shadowX, shadowY, this.shadowTextureKey);
 
-        // 60도로 더 기울이고 세로 크기를 조금 더 눌러줍니다.
-        shadow.skewX = PhaserMath.DegToRad(60);
-        shadow.scaleY *= 0.4;
-
-        // 발밑에 보이도록 위치 조정하고 약간 오른쪽으로 이동
-        const parentHeight = parentSprite.displayHeight;
-        shadow.x += parentSprite.displayWidth * 0.2; // 오른쪽으로 20% 이동
-        shadow.y += parentHeight / 2 - (shadow.displayHeight / 2);
+        // 유닛 크기에 맞춰 그림자 너비를 조정하고, 높이는 살짝만 조정하여 자연스럽게 만듭니다.
+        shadow.displayWidth = parentSprite.displayWidth * 0.8;
+        shadow.displayHeight = parentSprite.displayWidth * 0.2;
 
         // 레이어에 추가하고 깊이를 원본보다 한 단계 낮춥니다.
         this.shadowLayer.add(shadow);
@@ -57,5 +63,3 @@ class ShadowManager {
         debugLogEngine.log('ShadowManager', '그림자 매니저를 종료하고 모든 그림자를 제거합니다.');
     }
 }
-
-export const shadowManager = (scene) => new ShadowManager(scene);


### PR DESCRIPTION
## Summary
- add a ShadowManager that creates reusable oval textures for unit shadows
- integrate ShadowManager in BattleSimulatorEngine so every unit gets a shadow bound alongside their name label
- clean up shadows when the battle engine shuts down

## Testing
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68836f2a62708327bb3dc4139f506d71