### PR TITLE
Add healer AI nodes and AID skill type

### DIFF
--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -1,0 +1,68 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import SuccessNode from '../nodes/SuccessNode.js';
+
+// 기존 노드들
+import CanUseSkillBySlotNode from '../nodes/CanUseSkillBySlotNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+
+// 신규 힐러 전용 노드들
+import FindLowestHealthAllyNode from '../nodes/FindLowestHealthAllyNode.js';
+import FindSafeHealingPositionNode from '../nodes/FindSafeHealingPositionNode.js';
+import FindAllyToBuffNode from '../nodes/FindAllyToBuffNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+
+/**
+ * 힐러 유닛을 위한 행동 트리를 생성합니다.
+ */
+function createHealerAI(engines = {}) {
+    // 최우선: 이동 없이 즉시 치유
+    const immediateHealBranch = new SequenceNode([
+        new CanUseSkillBySlotNode(0),
+        new FindLowestHealthAllyNode({ inRangeOnly: true }),
+        new IsSkillInRangeNode(engines),
+        new UseSkillNode(engines),
+    ]);
+
+    // 이동 후 치유 시도
+    const moveAndHealBranch = new SequenceNode([
+        new HasNotMovedNode(),
+        new CanUseSkillBySlotNode(0),
+        new FindLowestHealthAllyNode({ inRangeOnly: false }),
+        new FindSafeHealingPositionNode(engines),
+        new MoveToTargetNode(engines),
+        new IsSkillInRangeNode(engines),
+        new UseSkillNode(engines),
+    ]);
+
+    // 버프 시도 (2번 슬롯 가정)
+    const buffBranch = new SequenceNode([
+        new CanUseSkillBySlotNode(1),
+        new FindAllyToBuffNode(),
+        new IsSkillInRangeNode(engines),
+        new UseSkillNode(engines),
+    ]);
+
+    // 안전한 위치로 재배치
+    const repositionBranch = new SequenceNode([
+        new HasNotMovedNode(),
+        new FindSafeRepositionNode(engines),
+        new MoveToTargetNode(engines),
+    ]);
+
+    const rootNode = new SelectorNode([
+        immediateHealBranch,
+        moveAndHealBranch,
+        buffBranch,
+        repositionBranch,
+        new SuccessNode(),
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createHealerAI };

--- a/src/ai/nodes/FindAllyToBuffNode.js
+++ b/src/ai/nodes/FindAllyToBuffNode.js
@@ -1,0 +1,42 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { statusEffectManager } from '../../game/utils/StatusEffectManager.js';
+
+/**
+ * 버프가 적용되지 않았거나 버프가 필요한 아군을 찾습니다.
+ */
+class FindAllyToBuffNode extends Node {
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const allUnits = blackboard.get('allUnits');
+        const skillData = blackboard.get('currentSkillData');
+        if (!allUnits || !skillData) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '유닛 또는 스킬 데이터 없음');
+            return NodeState.FAILURE;
+        }
+
+        const allies = allUnits.filter(u => u.team === unit.team && u.currentHp > 0);
+        if (allies.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '버프 대상 아군 없음');
+            return NodeState.FAILURE;
+        }
+
+        const buffId = skillData.effect?.id;
+        let target = null;
+        if (buffId) {
+            const candidates = allies.filter(a => {
+                const effects = statusEffectManager.activeEffects.get(a.uniqueId) || [];
+                return !effects.some(e => e.id === buffId);
+            });
+            target = candidates[0] || allies[0];
+        } else {
+            target = allies[0];
+        }
+
+        blackboard.set('skillTarget', target);
+        debugAIManager.logNodeResult(NodeState.SUCCESS, `버프 대상 [${target.instanceName}] 설정`);
+        return NodeState.SUCCESS;
+    }
+}
+
+export default FindAllyToBuffNode;

--- a/src/ai/nodes/FindLowestHealthAllyNode.js
+++ b/src/ai/nodes/FindLowestHealthAllyNode.js
@@ -1,0 +1,53 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 치유가 필요한(체력이 100%가 아닌) 가장 체력 비율이 낮은 아군을 찾습니다.
+ * 옵션에 따라 사거리 내 아군만 고려할 수 있습니다.
+ */
+class FindLowestHealthAllyNode extends Node {
+    constructor({ inRangeOnly = false } = {}) {
+        super();
+        this.inRangeOnly = inRangeOnly;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const allUnits = blackboard.get('allUnits');
+        if (!allUnits) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '유닛 목록 없음');
+            return NodeState.FAILURE;
+        }
+
+        const allies = allUnits.filter(u =>
+            u.team === unit.team && u.currentHp > 0 && u.currentHp < u.finalStats.hp
+        );
+        if (allies.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '치유가 필요한 아군 없음');
+            return NodeState.FAILURE;
+        }
+
+        let potentialTargets = allies;
+        if (this.inRangeOnly) {
+            const healRange = blackboard.get('currentSkillData')?.range || 2;
+            potentialTargets = allies.filter(a => {
+                const dist = Math.abs(unit.gridX - a.gridX) + Math.abs(unit.gridY - a.gridY);
+                return dist <= healRange;
+            });
+            if (potentialTargets.length === 0) {
+                debugAIManager.logNodeResult(NodeState.FAILURE, '사거리 내 아군 없음');
+                return NodeState.FAILURE;
+            }
+        }
+
+        potentialTargets.sort(
+            (a, b) => a.currentHp / a.finalStats.hp - b.currentHp / b.finalStats.hp
+        );
+        const target = potentialTargets[0];
+        blackboard.set('skillTarget', target);
+        debugAIManager.logNodeResult(NodeState.SUCCESS, `치유 대상 [${target.instanceName}] 설정`);
+        return NodeState.SUCCESS;
+    }
+}
+
+export default FindLowestHealthAllyNode;

--- a/src/ai/nodes/FindSafeHealingPositionNode.js
+++ b/src/ai/nodes/FindSafeHealingPositionNode.js
@@ -1,0 +1,70 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 아군을 치유하면서 적에게서 안전한 위치를 탐색합니다.
+ */
+class FindSafeHealingPositionNode extends Node {
+    constructor({ formationEngine, pathfinderEngine }) {
+        super();
+        this.formationEngine = formationEngine;
+        this.pathfinderEngine = pathfinderEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const targetAlly = blackboard.get('skillTarget');
+        const enemies = blackboard.get('enemyUnits');
+        const healRange = blackboard.get('currentSkillData')?.range || 2;
+
+        if (!targetAlly) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '치유 대상 아군 없음');
+            return NodeState.FAILURE;
+        }
+
+        const cells = this.formationEngine.grid.gridCells.filter(
+            cell => !cell.isOccupied || (cell.col === unit.gridX && cell.row === unit.gridY)
+        );
+
+        let bestCell = null;
+        let maxScore = -Infinity;
+
+        cells.forEach(cell => {
+            const distToAlly = Math.abs(cell.col - targetAlly.gridX) + Math.abs(cell.row - targetAlly.gridY);
+            if (distToAlly > healRange) return;
+
+            let minEnemyDist = Infinity;
+            if (enemies && enemies.length > 0) {
+                enemies.forEach(enemy => {
+                    const d = Math.abs(cell.col - enemy.gridX) + Math.abs(cell.row - enemy.gridY);
+                    if (d < minEnemyDist) minEnemyDist = d;
+                });
+            }
+
+            const travelDist = Math.abs(cell.col - unit.gridX) + Math.abs(cell.row - unit.gridY);
+            const score = minEnemyDist - travelDist * 0.5;
+            if (score > maxScore) {
+                maxScore = score;
+                bestCell = cell;
+            }
+        });
+
+        if (bestCell) {
+            const path = this.pathfinderEngine.findPath(
+                unit,
+                { col: unit.gridX, row: unit.gridY },
+                { col: bestCell.col, row: bestCell.row }
+            );
+            if (path && path.length > 0) {
+                blackboard.set('movementPath', path);
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `안전한 치유 위치 (${bestCell.col}, ${bestCell.row})로 경로 설정`);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '안전한 치유 위치 탐색 실패');
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindSafeHealingPositionNode;

--- a/src/ai/nodes/FindSafeRepositionNode.js
+++ b/src/ai/nodes/FindSafeRepositionNode.js
@@ -1,0 +1,59 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 전투가 잠잠할 때 유리한 위치로 이동하기 위한 위치를 탐색합니다.
+ */
+class FindSafeRepositionNode extends Node {
+    constructor({ formationEngine, pathfinderEngine }) {
+        super();
+        this.formationEngine = formationEngine;
+        this.pathfinderEngine = pathfinderEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const enemies = blackboard.get('enemyUnits');
+        const cells = this.formationEngine.grid.gridCells.filter(
+            cell => !cell.isOccupied || (cell.col === unit.gridX && cell.row === unit.gridY)
+        );
+
+        let bestCell = null;
+        let maxScore = -Infinity;
+
+        cells.forEach(cell => {
+            let minEnemyDist = Infinity;
+            if (enemies && enemies.length > 0) {
+                enemies.forEach(enemy => {
+                    const d = Math.abs(cell.col - enemy.gridX) + Math.abs(cell.row - enemy.gridY);
+                    if (d < minEnemyDist) minEnemyDist = d;
+                });
+            }
+
+            const travelDist = Math.abs(cell.col - unit.gridX) + Math.abs(cell.row - unit.gridY);
+            const score = minEnemyDist - travelDist * 0.5;
+            if (score > maxScore) {
+                maxScore = score;
+                bestCell = cell;
+            }
+        });
+
+        if (bestCell) {
+            const path = this.pathfinderEngine.findPath(
+                unit,
+                { col: unit.gridX, row: unit.gridY },
+                { col: bestCell.col, row: bestCell.row }
+            );
+            if (path && path.length > 0) {
+                blackboard.set('movementPath', path);
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `재배치 위치 (${bestCell.col}, ${bestCell.row}) 경로 설정`);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '재배치 위치 탐색 실패');
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindSafeRepositionNode;

--- a/src/ai/nodes/FindTargetBySkillTypeNode.js
+++ b/src/ai/nodes/FindTargetBySkillTypeNode.js
@@ -11,15 +11,22 @@ class FindTargetBySkillTypeNode extends Node {
         debugAIManager.logNodeEvaluation(this, unit);
         const skillData = blackboard.get('currentSkillData');
         const enemyUnits = blackboard.get('enemyUnits')?.filter(e => e.currentHp > 0);
+        // ✨ 아군 유닛 목록을 블랙보드에서 가져옵니다.
+        const allUnits = blackboard.get('allUnits');
+        const alliedUnits = allUnits?.filter(u => u.team === unit.team && u.currentHp > 0);
 
-        if (!skillData || !enemyUnits || enemyUnits.length === 0) {
-            debugAIManager.logNodeResult(NodeState.FAILURE, "스킬 데이터 또는 적 유닛 없음");
+        if (!skillData) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, "스킬 데이터 없음");
             return NodeState.FAILURE;
         }
 
         let target = null;
         switch (skillData.type) {
             case 'ACTIVE':
+                if (!enemyUnits || enemyUnits.length === 0) {
+                    debugAIManager.logNodeResult(NodeState.FAILURE, "적 유닛 없음");
+                    return NodeState.FAILURE;
+                }
                 const skillRange = skillData.range || unit.finalStats.attackRange || 1;
                 const inRangeEnemies = enemyUnits.filter(e =>
                     Math.abs(unit.gridX - e.gridX) + Math.abs(unit.gridY - e.gridY) <= skillRange
@@ -32,10 +39,25 @@ class FindTargetBySkillTypeNode extends Node {
                 }
                 break;
             case 'DEBUFF':
+                if (!enemyUnits || enemyUnits.length === 0) {
+                    debugAIManager.logNodeResult(NodeState.FAILURE, "적 유닛 없음");
+                    return NodeState.FAILURE;
+                }
                 target = this.targetManager.findHighestHealthEnemy(enemyUnits);
                 break;
+            // ✨ [수정] 'BUFF'와 'AID' 타입을 함께 처리합니다.
             case 'BUFF':
-                target = unit;
+            case 'AID':
+                if (!alliedUnits || alliedUnits.length === 0) {
+                    debugAIManager.logNodeResult(NodeState.FAILURE, "아군 유닛 없음");
+                    return NodeState.FAILURE;
+                }
+                // 체력 비율이 가장 낮은 아군을 찾습니다 (자신 포함).
+                target = [...alliedUnits].sort((a, b) => {
+                    const healthRatioA = a.currentHp / a.finalStats.hp;
+                    const healthRatioB = b.currentHp / b.finalStats.hp;
+                    return healthRatioA - healthRatioB;
+                })[0];
                 break;
             default:
                 target = this.targetManager.findNearestEnemy(unit, enemyUnits);

--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -8,7 +8,9 @@ export const SKILL_TYPES = {
     ACTIVE: { name: '액티브', color: '#FF8C00' }, // 주황색
     BUFF:   { name: '버프',   color: '#1E90FF' }, // 파랑색
     DEBUFF: { name: '디버프', color: '#DC143C' }, // 빨강색
-    PASSIVE:{ name: '패시브', color: '#32CD32' }  // 초록색
+    PASSIVE:{ name: '패시브', color: '#32CD32' },  // 초록색
+    // ✨ [신규] AID 타입을 추가합니다.
+    AID:    { name: '지원',   color: '#FFD700' }  // 금색
 };
 
 /**


### PR DESCRIPTION
## Summary
- extend `SkillEngine` with new `AID` skill type
- adjust `FindTargetBySkillTypeNode` so AID skills target the lowest health ally
- implement healer-specific AI nodes
- add full healer behavior tree
- tests still pass

## Testing
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68839265b7c4832797b1252d35fd6cae