### PR TITLE
Add heal skill type and medic integration

### DIFF
--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -105,6 +105,19 @@ class UseSkillNode extends Node {
             spriteEngine.changeSpriteForDuration(unit, 'cast', 600);
         }
 
+        // ✨ AID 타입 스킬 처리 - 회복 및 디버프 제거
+        if (modifiedSkill.type === 'AID') {
+            const healAmount = Math.round(unit.finalStats.wisdom * (modifiedSkill.healMultiplier || 0));
+            skillTarget.currentHp = Math.min(skillTarget.finalStats.hp, skillTarget.currentHp + healAmount);
+            if (this.vfxManager.updateHealthBar) {
+                this.vfxManager.updateHealthBar(skillTarget.healthBar, skillTarget.currentHp, skillTarget.finalStats.hp);
+            }
+            this.vfxManager.createDamageNumber(skillTarget.sprite.x, skillTarget.sprite.y, `+${healAmount}`, '#22c55e');
+            if (modifiedSkill.removesDebuff && Math.random() < modifiedSkill.removesDebuff.chance) {
+                statusEffectManager.removeOneDebuff(skillTarget);
+            }
+        }
+
         if (modifiedSkill.effect) {
             statusEffectManager.addEffect(skillTarget, modifiedSkill);
         }

--- a/src/game/data/skills/SkillCardDatabase.js
+++ b/src/game/data/skills/SkillCardDatabase.js
@@ -2,6 +2,7 @@ import { activeSkills } from './active.js';
 import { buffSkills } from './buff.js';
 import { debuffSkills } from './debuff.js';
 import { passiveSkills } from './passive.js';
+import { aidSkills } from './aid.js';
 
 // 모든 스킬을 하나의 객체로 통합하여 쉽게 조회할 수 있도록 함
 export const skillCardDatabase = {
@@ -9,4 +10,5 @@ export const skillCardDatabase = {
     ...buffSkills,
     ...debuffSkills,
     ...passiveSkills,
+    ...aidSkills,
 };

--- a/src/game/data/skills/aid.js
+++ b/src/game/data/skills/aid.js
@@ -1,0 +1,61 @@
+import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
+
+// 지원(AID) 스킬 데이터 정의
+export const aidSkills = {
+    heal: {
+        NORMAL: {
+            id: 'heal',
+            name: '힐',
+            type: 'AID',
+            cost: 1,
+            targetType: 'ally',
+            description: '아군 하나의 체력을 {{heal}}만큼 회복시킵니다.',
+            illustrationPath: 'assets/images/skills/heal.png',
+            requiredClass: 'medic',
+            cooldown: 0,
+            range: 2,
+            healMultiplier: 1.0,
+        },
+        RARE: {
+            id: 'heal',
+            name: '힐 [R]',
+            type: 'AID',
+            cost: 0,
+            targetType: 'ally',
+            description: '아군 하나의 체력을 {{heal}}만큼 회복시킵니다.',
+            illustrationPath: 'assets/images/skills/heal.png',
+            requiredClass: 'medic',
+            cooldown: 0,
+            range: 2,
+            healMultiplier: 1.0,
+        },
+        EPIC: {
+            id: 'heal',
+            name: '힐 [E]',
+            type: 'AID',
+            cost: 0,
+            targetType: 'ally',
+            description: '아군 하나의 체력을 {{heal}}만큼 회복시키고, 50% 확률로 해로운 효과 1개를 제거합니다.',
+            illustrationPath: 'assets/images/skills/heal.png',
+            requiredClass: 'medic',
+            cooldown: 0,
+            range: 2,
+            healMultiplier: 1.0,
+            removesDebuff: { chance: 0.5 }
+        },
+        LEGENDARY: {
+            id: 'heal',
+            name: '힐 [L]',
+            type: 'AID',
+            cost: 0,
+            targetType: 'ally',
+            description: '아군 하나의 체력을 {{heal}}만큼 회복시키고, 100% 확률로 해로운 효과 1개를 제거합니다.',
+            illustrationPath: 'assets/images/skills/heal.png',
+            requiredClass: 'medic',
+            cooldown: 0,
+            range: 2,
+            healMultiplier: 1.0,
+            removesDebuff: { chance: 1.0 }
+        }
+    }
+};

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -64,6 +64,14 @@ class MercenaryEngine {
                 ownedSkillsManager.equipSkill(newInstance.uniqueId, 3, attackInstance.instanceId);
                 skillInventoryManager.removeSkillFromInventoryList(attackInstance.instanceId);
             }
+        } else if (newInstance.id === 'medic') { // ✨ [신규] 메딕 처리
+            newInstance.skillSlots.push('AID');
+            const consumed = skillInventoryManager.findAndRemoveInstanceOfSkill('heal');
+            if (consumed) {
+                const instance = skillInventoryManager.addSkillById('heal', consumed.grade);
+                ownedSkillsManager.equipSkill(newInstance.uniqueId, 3, instance.instanceId);
+                skillInventoryManager.removeSkillFromInventoryList(instance.instanceId);
+            }
         } else {
             // 다른 클래스는 4번째 슬롯을 빈 슬롯(null)으로 추가
             newInstance.skillSlots.push(null);

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -31,6 +31,7 @@ class SkillInventoryManager {
                 this.addSkillById('stoneSkin', grade);
                 this.addSkillById('shieldBreak', grade);
                 this.addSkillById('ironWill', grade);
+                this.addSkillById('heal', grade);
                 // ✨ 넉백샷 카드 추가
                 this.addSkillById('knockbackShot', grade);
             }

--- a/src/game/utils/SkillModifierEngine.js
+++ b/src/game/utils/SkillModifierEngine.js
@@ -18,7 +18,9 @@ class SkillModifierEngine {
             // ✨ 넉백샷 순위별 데미지 계수 추가
             'knockbackShot': [1.4, 1.2, 1.0, 0.8],
             // ✨ [신규] 원거리 공격 순위별 데미지 계수 추가
-            'rangedAttack': [1.3, 1.2, 1.1, 1.0]
+            'rangedAttack': [1.3, 1.2, 1.1, 1.0],
+            // ✨ [신규] 힐 순위별 회복 계수 추가
+            'heal': [1.3, 1.2, 1.1, 1.0],
         };
         debugLogEngine.log('SkillModifierEngine', '스킬 보정 엔진이 초기화되었습니다.');
     }
@@ -37,8 +39,14 @@ class SkillModifierEngine {
         const rankIndex = rank - 1;
 
         const damageModifiers = this.rankModifiers[baseSkillData.id];
-        if (damageModifiers && damageModifiers[rankIndex] !== undefined && modifiedSkill.damageMultiplier) {
-            modifiedSkill.damageMultiplier = damageModifiers[rankIndex];
+        if (damageModifiers && damageModifiers[rankIndex] !== undefined) {
+            if (modifiedSkill.damageMultiplier) {
+                modifiedSkill.damageMultiplier = damageModifiers[rankIndex];
+            }
+            // ✨ [신규] 회복 계수 보정
+            if (modifiedSkill.healMultiplier) {
+                modifiedSkill.healMultiplier = damageModifiers[rankIndex];
+            }
         }
 
         // 'stoneSkin' 스킬의 데미지 감소 효과 보정
@@ -103,6 +111,11 @@ class SkillModifierEngine {
             if (baseSkillData.id === 'ironWill') {
                 const maxReductionValue = (passiveSkills.ironWill.rankModifiers[rankIndex] || 0) * 100;
                 modifiedSkill.description = modifiedSkill.description.replace('{{maxReduction}}%', `${maxReductionValue.toFixed(0)}%`);
+            }
+            // ✨ [신규] 힐 스킬 설명 치환
+            if (modifiedSkill.healMultiplier) {
+                const healAmount = `지혜 * ${modifiedSkill.healMultiplier.toFixed(2)}`;
+                modifiedSkill.description = modifiedSkill.description.replace('{{heal}}', healAmount);
             }
         }
 

--- a/src/game/utils/StatusEffectManager.js
+++ b/src/game/utils/StatusEffectManager.js
@@ -171,6 +171,22 @@ class StatusEffectManager {
         // 값의 변화 로그는 CombatCalculationEngine에서 처리합니다.
         return totalValue;
     }
+
+    // ✨ [신규] 해로운 효과 1개를 제거합니다.
+    removeOneDebuff(unit) {
+        const effects = this.activeEffects.get(unit.uniqueId);
+        if (!effects || effects.length === 0) return false;
+        const index = effects.findIndex(e => e.type !== EFFECT_TYPES.BUFF);
+        if (index === -1) return false;
+
+        const [removed] = effects.splice(index, 1);
+        const def = statusEffects[removed.id];
+        if (def && def.onRemove) {
+            def.onRemove(unit);
+        }
+        debugStatusEffectManager.logEffectExpired(unit.uniqueId, removed);
+        return true;
+    }
 }
 
 export const statusEffectManager = new StatusEffectManager();

--- a/tests/medic_skill_integration_test.js
+++ b/tests/medic_skill_integration_test.js
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import { skillModifierEngine } from '../src/game/utils/SkillModifierEngine.js';
+
+const healBase = {
+    NORMAL: { id: 'heal', type: 'AID', cost: 1, cooldown: 0, healMultiplier: 1.0 },
+    RARE: { id: 'heal', type: 'AID', cost: 0, cooldown: 0, healMultiplier: 1.0 },
+    EPIC: { id: 'heal', type: 'AID', cost: 0, cooldown: 0, healMultiplier: 1.0, removesDebuff: { chance: 0.5 } },
+    LEGENDARY: { id: 'heal', type: 'AID', cost: 0, cooldown: 0, healMultiplier: 1.0, removesDebuff: { chance: 1.0 } }
+};
+
+const expectedHeals = [1.3, 1.2, 1.1, 1.0];
+const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
+
+for (const grade of grades) {
+    for (let rank = 1; rank <= 4; rank++) {
+        const skill = skillModifierEngine.getModifiedSkill(healBase[grade], rank, grade);
+        assert.strictEqual(skill.healMultiplier, expectedHeals[rank - 1]);
+        if (grade === 'NORMAL') {
+            assert.strictEqual(skill.cost, 1);
+        } else {
+            assert.strictEqual(skill.cost, 0);
+        }
+    }
+}
+
+console.log('Medic skill integration test passed.');


### PR DESCRIPTION
## Summary
- register AID skill type and create heal skill data
- expose AID data in skill database
- apply heal rank multipliers and description updates
- auto-equip heal when hiring medics and seed heal cards
- support AID logic in UseSkillNode and remove debuffs
- add helper to remove debuffs in StatusEffectManager
- include medic skill integration tests

## Testing
- `node tests/movement_stat_test.js && node tests/warrior_skill_integration_test.js && node tests/medic_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688395674a548327ae04250a735a1317