### PR TITLE
Add weight-based turn order and healer AI

### DIFF
--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -17,7 +17,8 @@ export const mercenaryData = {
         baseStats: {
             hp: 120, valor: 10, strength: 15, endurance: 12,
             agility: 8, intelligence: 5, wisdom: 5, luck: 7,
-            movement: 3 // 전사의 기본 이동력
+            movement: 3,
+            weight: 10 // ✨ 전사 무게 추가
         }
     },
     gunner: {
@@ -39,7 +40,8 @@ export const mercenaryData = {
             hp: 80, valor: 5, strength: 7, endurance: 6,
             agility: 15, intelligence: 8, wisdom: 10, luck: 12,
             attackRange: 3,
-            movement: 3 // 거너의 기본 이동력
+            movement: 3,
+            weight: 12 // ✨ 거너 무게 추가
         }
     },
     // --- ▼ [신규] 메딕 클래스 데이터 추가 ▼ ---
@@ -61,7 +63,8 @@ export const mercenaryData = {
             hp: 90, valor: 8, strength: 6, endurance: 8,
             agility: 10, intelligence: 12, wisdom: 15, luck: 9,
             attackRange: 2,
-            movement: 2 // 메딕의 기본 이동력
+            movement: 2,
+            weight: 18 // ✨ 메딕 무게 추가
         }
     }
     // --- ▲ [신규] 메딕 클래스 데이터 추가 ▲ ---

--- a/src/game/data/monster.js
+++ b/src/game/data/monster.js
@@ -7,7 +7,11 @@ export const monsterData = {
         // ✨ 클래스를 '전사(임시)'로 설정
         className: '전사(임시)',
         battleSprite: 'zombie',
-        baseStats: { hp: 50, valor: 0, strength: 5, endurance: 3, agility: 1, intelligence: 0, wisdom: 0, luck: 0 },
+        baseStats: { 
+            hp: 50, valor: 0, strength: 5, endurance: 3, 
+            agility: 1, intelligence: 0, wisdom: 0, luck: 0,
+            weight: 15 // ✨ 좀비 무게 추가
+        },
         // ✨ 좀비 생성 시 실행될 초기화 함수 수정
         onSpawn: (unit) => {
             // 좀비를 위한 고유 'attack' 스킬 인스턴스를 생성하고 장착합니다.

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -8,6 +8,8 @@ import { TerminationManager } from './TerminationManager.js';
 import { aiManager } from '../../ai/AIManager.js';
 import { createMeleeAI } from '../../ai/behaviors/MeleeAI.js';
 import { createRangedAI } from '../../ai/behaviors/RangedAI.js';
+// ✨ 메딕을 위한 Healer AI를 import 합니다.
+import { createHealerAI } from '../../ai/behaviors/createHealerAI.js';
 
 import { targetManager } from './TargetManager.js';
 import { pathfinderEngine } from './PathfinderEngine.js';
@@ -91,6 +93,9 @@ export class BattleSimulatorEngine {
                 aiManager.registerUnit(unit, createRangedAI(this.aiEngines));
             } else if (unit.name === '전사' || unit.name === '좀비') {
                 aiManager.registerUnit(unit, createMeleeAI(this.aiEngines));
+            } else if (unit.name === '메딕') {
+                // ✨ 메딕 AI 등록 로직 추가
+                aiManager.registerUnit(unit, createHealerAI(this.aiEngines));
             }
         });
 

--- a/src/game/utils/StatEngine.js
+++ b/src/game/utils/StatEngine.js
@@ -48,7 +48,7 @@ class WeightEngine {
      * @returns {number} - \uD569\uC0B0\uB41C \uCD1D \uBB34\uAC8C
      */
     calculateTotalWeight(unitData = {}, equippedItems = []) {
-        let totalWeight = unitData.baseWeight || 0;
+        let totalWeight = unitData.weight || 0;
         for (const item of equippedItems) {
             totalWeight += item.weight || 0;
         }
@@ -100,13 +100,19 @@ class StatEngine {
             luck: baseStats.luck || 0,
             attackRange: baseStats.attackRange || 1,
             movement: baseStats.movement || 0,
+            weight: baseStats.weight || 0, // ✨ baseStats에서 weight를 직접 읽습니다.
         });
 
         // 2. \uC804\uBB38 \uC5D4\uC9C4\uC744 \uD1B5\uD574 \uD30C\uC9C0 \uC2A4\uD0EF\uC744 \uACC4\uC0B0\uD569\uB2C8\uB2E4.
         calculated.barrier = this.valorEngine.calculateInitialBarrier(calculated.valor);
         calculated.damageAmplification = this.valorEngine.calculateDamageAmplification(calculated.barrier, calculated.barrier);
-        calculated.totalWeight = this.weightEngine.calculateTotalWeight(unitData, equippedItems);
-        calculated.turnValue = this.weightEngine.getTurnValue(calculated.totalWeight);
+        // ✨ WeightEngine 로직을 직접 처리하여 기본 무게와 장비 무게를 합산합니다.
+        let totalWeight = calculated.weight;
+        for (const item of equippedItems) {
+            totalWeight += item.weight || 0;
+        }
+        calculated.totalWeight = totalWeight;
+        calculated.turnValue = totalWeight; // 현재는 totalWeight를 그대로 사용
 
         // 3. \uC8FC\uC6A9 \uC804\uD22C \uB2A5\uB825\uCE58\uB97C \uACC4\uC0B0\uD569\uB2C8\uB2E4.
         calculated.physicalAttack = (calculated.strength || 0) * 1.5;

--- a/src/game/utils/TurnOrderManager.js
+++ b/src/game/utils/TurnOrderManager.js
@@ -14,23 +14,11 @@ class TurnOrderManager {
      * @returns {Array<object>} - 턴 순서에 따라 정렬된 유닛 배열
      */
     createTurnQueue(allUnits) {
-        // 임의의 무게(weight)를 각 유닛의 finalStats에 추가합니다.
-        // 실제 게임에서는 StatEngine이 이 값을 계산해야 합니다.
-        allUnits.forEach(unit => {
-            if (!unit.finalStats) unit.finalStats = {};
-            // 전사는 10, 좀비는 15로 설정하여 전사가 항상 선공하도록 합니다.
-            if (unit.name === '전사') {
-                unit.finalStats.weight = 10;
-            } else if (unit.name === '좀비') {
-                unit.finalStats.weight = 15;
-            } else {
-                unit.finalStats.weight = 20; // 기타
-            }
-        });
+        // ✨ StatEngine이 계산한 turnValue를 기준으로 정렬합니다.
+        const turnQueue = [...allUnits].sort((a, b) => (a.finalStats.turnValue ?? 0) - (b.finalStats.turnValue ?? 0));
 
-        const turnQueue = [...allUnits].sort((a, b) => a.finalStats.weight - b.finalStats.weight);
-        
-        const turnOrderNames = turnQueue.map(u => `${u.instanceName}(w:${u.finalStats.weight})`).join(' -> ');
+        // ✨ 로그에 turnValue를 표시합니다.
+        const turnOrderNames = turnQueue.map(u => `${u.instanceName}(w:${u.finalStats.turnValue})`).join(' -> ');
         debugLogEngine.log('TurnOrderManager', `턴 순서 결정: ${turnOrderNames}`);
 
         return turnQueue;


### PR DESCRIPTION
## Summary
- set `weight` for mercenaries and monsters
- support `weight` calculation in `StatEngine`
- sort turn order using the calculated turn value
- register healer units with their own AI behavior

## Testing
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6883ae07c2108327a4d73cb942983716