### PR TITLE
Dynamic stage config and AI tweaks

### DIFF
--- a/src/ai/nodes/FindKitingPositionNode.js
+++ b/src/ai/nodes/FindKitingPositionNode.js
@@ -26,7 +26,10 @@ class FindKitingPositionNode extends Node {
         }
 
         const attackRange = unit.finalStats.attackRange || 3;
-        const dangerZone = 2; // 이 거리 안으로는 어떤 적도 들어오면 안 됨
+        // ✨ 이 노드 자체의 dangerZone 하드코딩을 제거했습니다.
+        // 이제 이 노드는 "안전한 공격 위치"를 찾는 데 집중하고,
+        // "위험 여부" 판단은 IsTargetTooCloseNode가 전담합니다.
+        const dangerZoneFromBlackboard = blackboard.get('threateningUnit') ? 2 : 0; // 위협적인 유닛이 있을 때만 안전거리 고려
         const sightRange = unit.finalStats.sightRange || 10; // 유닛의 시야 범위
         const start = { col: unit.gridX, row: unit.gridY };
 
@@ -49,7 +52,7 @@ class FindKitingPositionNode extends Node {
             // **조건 1: 주변의 "모든" 적으로부터 안전한가?**
             const isSafeFromAllEnemies = enemiesInSight.every(enemy => {
                 const distanceToEnemy = Math.abs(cell.col - enemy.gridX) + Math.abs(cell.row - enemy.gridY);
-                return distanceToEnemy > dangerZone;
+                return distanceToEnemy > dangerZoneFromBlackboard;
             });
 
             if (isSafeFromAllEnemies) {

--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -22,8 +22,16 @@ export class CursedForestBattleScene extends Scene {
             if (el) el.style.display = 'none';
         });
 
+        // ✨ 스테이지 구성을 정의합니다. (나중에 별도 파일로 분리 가능)
+        const stageConfig = {
+            background: 'battle-stage-cursed-forest',
+            monsters: [
+                { id: 'zombie', count: 5 }
+            ]
+        };
+
         this.stageManager = new BattleStageManager(this);
-        this.stageManager.createStage('battle-stage-cursed-forest');
+        this.stageManager.createStage(stageConfig.background);
         this.cameraControl = new CameraControlEngine(this);
 
         // 전투가 시작되면 기본 카메라 줌을 2배로 고정합니다.
@@ -33,16 +41,16 @@ export class CursedForestBattleScene extends Scene {
         this.battleSimulator = new BattleSimulatorEngine(this);
 
         // 파티 유닛과 몬스터 데이터를 준비합니다.
-        const partyIds = partyEngine.getPartyMembers().filter(id => id !== undefined);
-        const allMercs = mercenaryEngine.getAllAlliedMercenaries();
-        const partyUnits = allMercs.filter(m => partyIds.includes(m.uniqueId));
+        const partyUnits = partyEngine.getDeployedMercenaries();
         this.partyUnits = partyUnits; // 추적을 위해 저장
 
         const monsters = [];
-        const zombieBase = getMonsterBase('zombie');
-        for (let i = 0; i < 5; i++) {
-            monsters.push(monsterEngine.spawnMonster(zombieBase, 'enemy'));
-        }
+        stageConfig.monsters.forEach(monsterInfo => {
+            const monsterBase = getMonsterBase(monsterInfo.id);
+            for (let i = 0; i < monsterInfo.count; i++) {
+                monsters.push(monsterEngine.spawnMonster(monsterBase, 'enemy'));
+            }
+        });
 
         // BattleSimulatorEngine을 통해 전투를 시작합니다.
         this.battleSimulator.start(partyUnits, monsters);


### PR DESCRIPTION
## Summary
- set up `stageConfig` in CursedForestBattleScene and spawn monsters from it
- rely on `getDeployedMercenaries()` for party units
- remove hardcoded danger zone in `FindKitingPositionNode`

## Testing
- `node tests/movement_stat_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6883aee72b8c8327b7ec0a7be8132012