### PR TITLE
Add summon skill type and 5th slot

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -746,6 +746,11 @@ body {
 .merc-skill-slot.buff-slot { border-color: #1E90FF; }
 .merc-skill-slot.debuff-slot { border-color: #DC143C; }
 .merc-skill-slot.passive-slot { border-color: #32CD32; }
+/* ✨ [수정] 소환 스킬 슬롯 스타일 */
+.merc-skill-slot.summon-slot {
+    border-color: #9966CC;
+    border-width: 4px;
+}
 .merc-skill-slot span {
     background-color: rgba(0,0,0,0.7);
     width: 100%;

--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -66,8 +66,14 @@ function createMeleeAI(engines = {}) {
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
+        // ✨ [신규] 우선순위 5: 5번 슬롯(소환) 스킬 사용 시도
+        new SequenceNode([
+            new CanUseSkillBySlotNode(4),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
 
-        // 우선순위 5: 사용할 스킬이 없을 경우, 이동만 실행
+        // 우선순위 6: 사용할 스킬이 없을 경우, 이동만 실행
         new SequenceNode([
             // ✨ 이동하기 전에 아직 움직이지 않았는지 확인합니다.
             new HasNotMovedNode(),

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -76,6 +76,12 @@ function createRangedAI(engines = {}) {
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
+        // ✨ [신규] 5순위 스킬
+        new SequenceNode([
+            new CanUseSkillBySlotNode(4),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
     ]);
 
     const rootNode = new SelectorNode([

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -63,7 +63,12 @@ function createHealerAI(engines = {}) {
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-
+        // ✨ [신규] 우선순위 5: 5번 슬롯(소환) 스킬 사용 시도
+        new SequenceNode([
+            new CanUseSkillBySlotNode(4),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
         // 최후의 수단 1: 사용할 스킬이 없을 경우, 안전한 위치로 이동
         new SequenceNode([
             new HasNotMovedNode(),

--- a/src/ai/nodes/FindTargetBySkillTypeNode.js
+++ b/src/ai/nodes/FindTargetBySkillTypeNode.js
@@ -65,6 +65,10 @@ class FindTargetBySkillTypeNode extends Node {
                     return healthRatioA - healthRatioB;
                 })[0];
                 break;
+            // ✨ [신규] 소환 스킬은 임시로 시전자 자신을 대상으로 합니다.
+            case 'SUMMON':
+                target = unit;
+                break;
             default:
                 target = this.targetManager.findNearestEnemy(unit, enemyUnits);
                 break;

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -86,7 +86,10 @@ class MercenaryEngine {
             // 4번째 슬롯을 빈 슬롯(null)으로 추가
             newInstance.skillSlots.push(null);
         }
-        
+
+        // ✨ [신규] 5번째 슬롯은 소환 스킬 전용으로 고정합니다.
+        newInstance.skillSlots.push('SUMMON');
+
         newInstance.finalStats = statEngine.calculateStats(newInstance, newInstance.baseStats, newInstance.equippedItems);
 
         if (type === 'ally') {

--- a/src/game/utils/OwnedSkillsManager.js
+++ b/src/game/utils/OwnedSkillsManager.js
@@ -13,8 +13,8 @@ class OwnedSkillsManager {
 
     initializeSlots(unitId) {
         if (!this.equippedSkills.has(unitId)) {
-            // ✨ 슬롯을 4개로 확장합니다.
-            this.equippedSkills.set(unitId, [null, null, null, null]);
+            // ✨ [수정] 기본 장착 슬롯을 5개로 확장합니다.
+            this.equippedSkills.set(unitId, [null, null, null, null, null]);
         }
     }
 

--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -10,7 +10,9 @@ export const SKILL_TYPES = {
     DEBUFF: { name: '디버프', color: '#DC143C' }, // 빨강색
     PASSIVE:{ name: '패시브', color: '#32CD32' },  // 초록색
     // ✨ [변경] AID 타입을 하얀색 계열로 변경합니다.
-    AID:    { name: '지원',   color: '#F5F5F5' }  // 하얀색 (순백색(#FFF) 대신 약간의 회색을 섞어 배경과 구분되도록 함)
+    AID:    { name: '지원',   color: '#F5F5F5' },  // 하얀색 (순백색(#FFF) 대신 약간의 회색을 섞어 배경과 구분되도록 함)
+    // ✨ [신규] 소환 스킬 타입 추가
+    SUMMON: { name: '소환',   color: '#9966CC' }   // 보라색 계열
 };
 
 /**


### PR DESCRIPTION
## Summary
- introduce `SUMMON` skill type
- expand equipped skill slots to 5
- add summon-only slot when creating mercenaries
- handle summon target and allow AI to use 5th slot
- style summon slots in purple

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/movement_stat_test.js`


------
https://chatgpt.com/codex/tasks/task_e_68844852b5208327b77cafa5c2deb2eb