### PR TITLE
Add summon management scene

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -676,6 +676,20 @@ body {
     display: none; /* 초기에는 숨김 */
 }
 
+/* --- 선조 소환 씬 스타일 --- */
+#summon-management-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    background-size: cover;
+    background-position: center;
+    pointer-events: auto;
+    display: none;
+}
+
 #skill-main-layout {
     display: flex;
     justify-content: center;

--- a/src/game/dom/SummonManagementDOMEngine.js
+++ b/src/game/dom/SummonManagementDOMEngine.js
@@ -1,0 +1,294 @@
+import { mercenaryEngine } from '../utils/MercenaryEngine.js';
+import { partyEngine } from '../utils/PartyEngine.js';
+import { skillInventoryManager } from '../utils/SkillInventoryManager.js';
+import { ownedSkillsManager } from '../utils/OwnedSkillsManager.js';
+import { UnitDetailDOM } from './UnitDetailDOM.js';
+import { SkillTooltipManager } from './SkillTooltipManager.js';
+import { skillModifierEngine } from '../utils/SkillModifierEngine.js';
+
+export class SummonManagementDOMEngine {
+    constructor(scene) {
+        this.scene = scene;
+        this.container = document.getElementById('summon-management-container');
+        if (!this.container) {
+            this.container = document.createElement('div');
+            this.container.id = 'summon-management-container';
+            // ID를 CSS와 일치시키기 위해 skill-management-container 클래스를 사용합니다.
+            this.container.className = 'skill-management-container';
+            document.getElementById('app').appendChild(this.container);
+        }
+
+        this.selectedMercenaryData = null;
+        this.draggedData = null;
+
+        this.createView();
+    }
+
+    createView() {
+        this.container.style.display = 'block';
+        // ✨ 새로운 배경 이미지로 설정합니다.
+        this.container.style.backgroundImage = 'url(assets/images/territory/summon-scene.png)';
+
+        const mainLayout = document.createElement('div');
+        mainLayout.id = 'skill-main-layout';
+        this.container.appendChild(mainLayout);
+
+        const listPanel = this.createPanel('skill-list-panel', '출정 용병');
+        mainLayout.appendChild(listPanel);
+        this.mercenaryListContent = listPanel.querySelector('.panel-content');
+
+        const detailsPanel = this.createPanel('skill-details-panel', '용병 스킬 슬롯');
+        mainLayout.appendChild(detailsPanel);
+        this.mercenaryDetailsContent = detailsPanel.querySelector('.panel-content');
+
+        // ✨ 패널 제목을 변경합니다.
+        const inventoryPanel = this.createPanel('skill-inventory-panel', '선조 소환석 인벤토리');
+        mainLayout.appendChild(inventoryPanel);
+        this.skillInventoryContent = inventoryPanel.querySelector('.panel-content');
+
+        this.skillInventoryContent.ondragover = e => e.preventDefault();
+        this.skillInventoryContent.ondrop = e => this.onDropOnInventory(e);
+
+        this.populateMercenaryList();
+        this.refreshSkillInventory();
+
+        const backButton = document.createElement('div');
+        backButton.id = 'skill-back-button';
+        backButton.innerText = '← 영지로';
+        backButton.onclick = () => this.scene.scene.start('TerritoryScene');
+        this.container.appendChild(backButton);
+    }
+
+    createPanel(id, title) {
+        const panel = document.createElement('div');
+        panel.id = id;
+        panel.className = 'skill-panel';
+        panel.appendChild(Object.assign(document.createElement('div'), { className: 'panel-title', innerText: title }));
+        panel.appendChild(Object.assign(document.createElement('div'), { className: 'panel-content' }));
+        return panel;
+    }
+
+    populateMercenaryList() {
+        this.mercenaryListContent.innerHTML = '';
+        const partyMembers = partyEngine.getPartyMembers().filter(id => id !== undefined);
+        const allMercs = mercenaryEngine.getAllAlliedMercenaries();
+
+        partyMembers.forEach(id => {
+            const merc = allMercs.find(m => m.uniqueId === id);
+            if (merc) {
+                const item = document.createElement('div');
+                item.className = 'merc-list-item';
+                item.innerText = merc.instanceName;
+                item.dataset.mercId = merc.uniqueId;
+                item.onclick = () => this.selectMercenary(merc);
+                this.mercenaryListContent.appendChild(item);
+            }
+        });
+
+        if (partyMembers.length > 0) {
+            const first = allMercs.find(m => m.uniqueId === partyMembers[0]);
+            if (first) this.selectMercenary(first);
+        }
+    }
+
+    selectMercenary(mercData) {
+        this.selectedMercenaryData = mercData;
+
+        const selected = this.mercenaryListContent.querySelector('.selected');
+        if (selected) selected.classList.remove('selected');
+        const newSelected = this.mercenaryListContent.querySelector(`[data-merc-id='${mercData.uniqueId}']`);
+        if (newSelected) newSelected.classList.add('selected');
+
+        this.refreshMercenaryDetails();
+    }
+
+    refreshMercenaryDetails() {
+        if (!this.selectedMercenaryData) {
+            this.mercenaryDetailsContent.innerHTML = '<p>용병을 선택하세요.</p>';
+            return;
+        }
+
+        const mercData = this.selectedMercenaryData;
+        this.mercenaryDetailsContent.innerHTML = '';
+
+        const portrait = document.createElement('div');
+        portrait.className = 'merc-portrait-small';
+        portrait.style.backgroundImage = `url(${mercData.uiImage})`;
+        portrait.onclick = () => document.body.appendChild(UnitDetailDOM.create(mercData));
+        this.mercenaryDetailsContent.appendChild(portrait);
+
+        const slotsContainer = document.createElement('div');
+        slotsContainer.className = 'merc-skill-slots-container';
+
+        const equipped = ownedSkillsManager.getEquippedSkills(mercData.uniqueId);
+
+        mercData.skillSlots.forEach((slotType, idx) => {
+            const slot = this.createSkillSlotElement(slotType, idx, equipped[idx]);
+            slotsContainer.appendChild(slot);
+        });
+
+        this.mercenaryDetailsContent.appendChild(slotsContainer);
+    }
+
+    createSkillSlotElement(slotType, index, instanceId) {
+        const slot = document.createElement('div');
+        slot.className = `merc-skill-slot ${slotType.toLowerCase()}-slot`;
+        slot.dataset.slotIndex = index;
+        slot.dataset.slotType = slotType;
+
+        if (instanceId) {
+            const instanceData = skillInventoryManager.getInstanceData(instanceId);
+            const baseSkillData = skillInventoryManager.getSkillData(instanceData.skillId, instanceData.grade);
+            const modifiedSkill = skillModifierEngine.getModifiedSkill(baseSkillData, index + 1, instanceData.grade);
+
+            // 등급별 테두리 클래스를 부여합니다.
+            slot.classList.add(`grade-${instanceData.grade.toLowerCase()}`);
+
+            slot.style.backgroundImage = `url(${modifiedSkill.illustrationPath})`;
+            slot.dataset.instanceId = instanceId;
+            slot.draggable = true;
+            slot.ondragstart = e => this.onDragStart(e, { source: 'slot', instanceId, slotIndex: index });
+            slot.onmouseenter = e => SkillTooltipManager.show(modifiedSkill, e, instanceData.grade);
+            slot.onmouseleave = () => SkillTooltipManager.hide();
+
+            // 등급에 따른 별 표시
+            const gradeMap = { NORMAL: 1, RARE: 2, EPIC: 3, LEGENDARY: 4 };
+            const starsContainer = document.createElement('div');
+            starsContainer.className = 'grade-stars';
+            const starCount = gradeMap[instanceData.grade] || 1;
+            for (let i = 0; i < starCount; i++) {
+                const starImg = document.createElement('img');
+                starImg.src = 'assets/images/territory/skill-card-star.png';
+                starsContainer.appendChild(starImg);
+            }
+            slot.appendChild(starsContainer);
+        } else {
+            slot.style.backgroundImage = 'url(assets/images/skills/skill-slot.png)';
+        }
+
+        slot.ondragover = e => e.preventDefault();
+        slot.ondrop = e => this.onDropOnSlot(e);
+
+        const rank = document.createElement('span');
+        rank.innerText = `${index + 1} 순위`;
+        slot.appendChild(rank);
+
+        return slot;
+    }
+
+    refreshSkillInventory() {
+        this.skillInventoryContent.innerHTML = '';
+        const gradeMap = { 'NORMAL': 1, 'RARE': 2, 'EPIC': 3, 'LEGENDARY': 4 };
+
+        skillInventoryManager.getInventory()
+            // ✨ 1. 인벤토리에서 스킬 데이터를 먼저 가져옵니다.
+            .map(instance => ({
+                instance,
+                data: skillInventoryManager.getSkillData(instance.skillId, instance.grade)
+            }))
+            // ✨ 2. 스킬 타입이 'SUMMON'인 것만 필터링합니다.
+            .filter(item => item.data && item.data.type === 'SUMMON')
+            .forEach(({ instance, data }) => {
+                const card = document.createElement('div');
+                card.className = `skill-inventory-card ${data.type.toLowerCase()}-card grade-${instance.grade.toLowerCase()}`;
+                card.style.backgroundImage = `url(${data.illustrationPath})`;
+                card.draggable = true;
+                card.dataset.instanceId = instance.instanceId;
+                card.ondragstart = e => this.onDragStart(e, { source: 'inventory', instanceId: instance.instanceId });
+                card.onmouseenter = e => SkillTooltipManager.show(data, e, instance.grade);
+                card.onmouseleave = () => SkillTooltipManager.hide();
+
+            // 별 생성 컨테이너
+            const starsContainer = document.createElement('div');
+            starsContainer.className = 'grade-stars';
+            const starCount = gradeMap[instance.grade] || 1;
+            for (let i = 0; i < starCount; i++) {
+                const starImg = document.createElement('img');
+                starImg.src = 'assets/images/territory/skill-card-star.png';
+                starsContainer.appendChild(starImg);
+            }
+            card.appendChild(starsContainer);
+
+            // 인벤토리 카드에서는 클래스 태그를 표시하지 않습니다.
+            this.skillInventoryContent.appendChild(card);
+        });
+    }
+
+    onDragStart(event, data) {
+        this.draggedData = data;
+        event.dataTransfer.setData('text/plain', data.instanceId);
+    }
+
+    onDropOnSlot(event) {
+        event.preventDefault();
+        if (!this.selectedMercenaryData || !this.draggedData) return;
+
+        const targetSlot = event.currentTarget;
+        const targetSlotIndex = parseInt(targetSlot.dataset.slotIndex);
+        const targetSlotType = targetSlot.dataset.slotType;
+        const targetInstanceId = targetSlot.dataset.instanceId ? parseInt(targetSlot.dataset.instanceId) : null;
+
+        const unitId = this.selectedMercenaryData.uniqueId;
+        const draggedInstanceId = this.draggedData.instanceId;
+        const draggedInstanceData = skillInventoryManager.getInstanceData(draggedInstanceId);
+        const draggedSkillData = skillInventoryManager.getSkillData(draggedInstanceData.skillId, draggedInstanceData.grade);
+
+        if (draggedSkillData.requiredClass && this.selectedMercenaryData.id !== draggedSkillData.requiredClass) {
+            alert(`이 스킬은 ${draggedSkillData.requiredClass} 전용입니다.`);
+            return;
+        }
+        if (draggedSkillData.type !== targetSlotType) {
+            alert('스킬과 슬롯의 타입이 일치하지 않습니다.');
+            return;
+        }
+
+        if (this.draggedData.source === 'inventory') {
+            ownedSkillsManager.equipSkill(unitId, targetSlotIndex, draggedInstanceId);
+            // 인벤토리 목록에서만 제거하여 장착 후에도 스킬 데이터를 참조할 수 있게 합니다.
+            skillInventoryManager.removeSkillFromInventoryList(draggedInstanceId);
+            if (targetInstanceId) {
+                ownedSkillsManager.equipSkill(unitId, targetSlotIndex, draggedInstanceId);
+                this.addSkillToInventory(targetInstanceId);
+            }
+        } else if (this.draggedData.source === 'slot') {
+            const sourceSlotIndex = this.draggedData.slotIndex;
+            ownedSkillsManager.equipSkill(unitId, targetSlotIndex, draggedInstanceId);
+            ownedSkillsManager.equipSkill(unitId, sourceSlotIndex, targetInstanceId);
+        }
+
+        this.refreshAll();
+    }
+
+    onDropOnInventory(event) {
+        event.preventDefault();
+        if (!this.selectedMercenaryData || !this.draggedData || this.draggedData.source !== 'slot') return;
+
+        const unitId = this.selectedMercenaryData.uniqueId;
+        const sourceSlotIndex = this.draggedData.slotIndex;
+        const instanceId = this.draggedData.instanceId;
+
+        ownedSkillsManager.unequipSkill(unitId, sourceSlotIndex);
+        this.addSkillToInventory(instanceId);
+
+        this.refreshAll();
+    }
+
+    addSkillToInventory(instanceId) {
+        const inst = skillInventoryManager.getInstanceData(instanceId);
+        if (inst) {
+            skillInventoryManager.skillInventory.push({ instanceId, skillId: inst.skillId, grade: inst.grade });
+            skillInventoryManager.skillInventory.sort((a, b) => a.instanceId - b.instanceId);
+        }
+    }
+
+    refreshAll() {
+        this.refreshMercenaryDetails();
+        this.refreshSkillInventory();
+        this.draggedData = null;
+    }
+
+    destroy() {
+        this.container.innerHTML = '';
+        this.container.style.display = 'none';
+    }
+}

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -32,6 +32,8 @@ export class TerritoryDOMEngine {
         this.addFormationButton(0, 1);
         // --- 스킬 관리 버튼 추가 ---
         this.addSkillManagementButton(1, 1);
+        // --- ✨ [신규] 선조 소환 관리 버튼 추가 ---
+        this.addSummonManagementButton(2, 1); // 스킬 관리 옆에 배치
     }
 
     createGrid() {
@@ -131,6 +133,23 @@ export class TerritoryDOMEngine {
         button.addEventListener('click', () => {
             this.container.style.display = 'none';
             this.scene.scene.start('SkillManagementScene');
+        });
+        this.grid.appendChild(button);
+    }
+
+    // ✨ 새로운 버튼 추가 메서드를 만듭니다.
+    addSummonManagementButton(col, row) {
+        const button = document.createElement('div');
+        button.className = 'building-icon';
+        button.style.backgroundImage = `url(assets/images/territory/summon-icon.png)`; // 새 아이콘 이미지
+        button.style.gridColumnStart = col + 1;
+        button.style.gridRowStart = row + 1;
+        button.addEventListener('mouseover', (event) => this.domEngine.showTooltip(event.clientX, event.clientY, '[선조 소환]'));
+        button.addEventListener('mouseout', () => this.domEngine.hideTooltip());
+        button.addEventListener('click', () => {
+            this.container.style.display = 'none';
+            // ✨ SummonManagementScene을 시작합니다.
+            this.scene.scene.start('SummonManagementScene');
         });
         this.grid.appendChild(button);
     }

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -13,6 +13,8 @@ import { DungeonScene } from './DungeonScene.js';
 import { FormationScene } from './FormationScene.js';
 import { CursedForestBattleScene } from './CursedForestBattleScene.js';
 import { SkillManagementScene } from './SkillManagementScene.js';
+// ✨ SummonManagementScene을 import 합니다.
+import { SummonManagementScene } from './SummonManagementScene.js';
 
 export class Boot extends Scene
 {
@@ -42,6 +44,8 @@ export class Boot extends Scene
         this.scene.add('FormationScene', FormationScene);
         this.scene.add('CursedForestBattle', CursedForestBattleScene);
         this.scene.add('SkillManagementScene', SkillManagementScene);
+        // ✨ 새로 만든 씬을 추가합니다.
+        this.scene.add('SummonManagementScene', SummonManagementScene);
 
         this.scene.start('Preloader');
     }

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -105,6 +105,9 @@ export class Preloader extends Scene
         // --- 스킬 관리 아이콘 및 씬 배경 로드 ---
         this.load.image('skills-icon', 'images/territory/skills-icon.png');
         this.load.image('skills-scene-background', 'images/territory/skills-scene.png');
+        // --- ✨ [신규] 선조 소환 아이콘 및 씬 배경 로드 ---
+        this.load.image('summon-icon', 'images/territory/summon-icon.png');
+        this.load.image('summon-scene-background', 'images/territory/summon-scene.png');
         // --- ✨ [추가] 스킬 슬롯 이미지를 로드합니다. ---
         this.load.image('skill-slot', 'images/skills/skill-slot.png');
         // 공통 패널 배경 이미지

--- a/src/game/scenes/SummonManagementScene.js
+++ b/src/game/scenes/SummonManagementScene.js
@@ -1,0 +1,24 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { DOMEngine } from '../utils/DOMEngine.js';
+import { SummonManagementDOMEngine } from '../dom/SummonManagementDOMEngine.js';
+
+export class SummonManagementScene extends Scene {
+    constructor() {
+        super('SummonManagementScene');
+        this.summonDomEngine = null;
+    }
+
+    create() {
+        const territoryContainer = document.getElementById('territory-container');
+        if (territoryContainer) {
+            territoryContainer.style.display = 'none';
+        }
+
+        const domEngine = new DOMEngine(this);
+        this.summonDomEngine = new SummonManagementDOMEngine(this);
+
+        this.events.on('shutdown', () => {
+            this.summonDomEngine.destroy();
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- register new assets for summon management
- create SummonManagementScene for DOM setup
- add SummonManagementDOMEngine to manage summon UI and show only summon skills
- link summon management from territory view
- register the new scene with Boot
- style summon management container

## Testing
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688454c4940c8327bbd9f7081151a978