### PR TITLE
Add ancestor summon skill

### DIFF
--- a/src/game/data/skills/SkillCardDatabase.js
+++ b/src/game/data/skills/SkillCardDatabase.js
@@ -3,6 +3,7 @@ import { buffSkills } from './buff.js';
 import { debuffSkills } from './debuff.js';
 import { passiveSkills } from './passive.js';
 import { aidSkills } from './aid.js';
+import { summonSkills } from './summon.js';
 
 // 모든 스킬을 하나의 객체로 통합하여 쉽게 조회할 수 있도록 함
 export const skillCardDatabase = {
@@ -11,4 +12,5 @@ export const skillCardDatabase = {
     ...debuffSkills,
     ...passiveSkills,
     ...aidSkills,
+    ...summonSkills,
 };

--- a/src/game/data/skills/summon.js
+++ b/src/game/data/skills/summon.js
@@ -1,0 +1,15 @@
+export const summonSkills = {
+    summonAncestorPeor: {
+        NORMAL: {
+            id: 'summonAncestorPeor',
+            name: '소환: 선조 페오르',
+            type: 'SUMMON',
+            cost: 3,
+            description: '용맹한 전사 선조 페오르를 소환합니다.',
+            illustrationPath: 'assets/images/summon/ancestor-peor.png',
+            cooldown: 100,
+            creatureId: 'ancestorPeor',
+            healthCostPercent: 0.1
+        }
+    }
+};

--- a/src/game/data/summon.js
+++ b/src/game/data/summon.js
@@ -1,0 +1,29 @@
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+export const summonData = {
+    ancestorPeor: {
+        name: '선조 페오르',
+        className: '전사',
+        battleSprite: 'ancestor-peor',
+        baseStats: {
+            hp: 80, valor: 5, strength: 10, endurance: 8,
+            agility: 6, intelligence: 3, wisdom: 3, luck: 5,
+            movement: 3,
+            attackRange: 1,
+            weight: 12
+        },
+        onSpawn: (unit) => {
+            const { ownedSkillsManager } = require('../utils/OwnedSkillsManager.js');
+            const { skillInventoryManager } = require('../utils/SkillInventoryManager.js');
+            const skillId = 'attack';
+            const grade = 'NORMAL';
+            const newInstance = skillInventoryManager.addSkillById(skillId, grade);
+            ownedSkillsManager.equipSkill(unit.uniqueId, 3, newInstance.instanceId);
+            skillInventoryManager.removeSkillFromInventoryList(newInstance.instanceId);
+        }
+    }
+};
+
+export const getSummonBase = (id) => summonData[id];

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -117,6 +117,8 @@ export class Preloader extends Scene
 
         // 몬스터 스프라이트 로드
         this.load.image('zombie', 'images/unit/zombie.png');
+        // 소환수 스프라이트 로드
+        this.load.image('ancestor-peor', 'images/summon/ancestor-peor.png');
 
         // --- 추가된 토큰 이미지 로드 ---
         this.load.image('token', 'images/battle/token.png');
@@ -132,7 +134,7 @@ export class Preloader extends Scene
     {
         // 전투 씬에서 사용될 주요 이미지들의 텍스처 필터링 모드를 설정하여 품질을 향상시킵니다.
         const battleTextures = [
-            'warrior', 'gunner', 'zombie',
+            'warrior', 'gunner', 'zombie', 'ancestor-peor',
             'battle-stage-cursed-forest', 'battle-stage-arena'
         ];
 

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -37,6 +37,11 @@ class SkillInventoryManager {
             }
         });
 
+        // "선조 페오르 소환" 스킬 카드 5장 지급 (NORMAL 등급)
+        for (let i = 0; i < 5; i++) {
+            this.addSkillById('summonAncestorPeor', 'NORMAL');
+        }
+
         // 나머지 스킬은 노멀 등급으로 10장씩 생성
         for (const skillId in skillCardDatabase) {
             if (skillCardDatabase.hasOwnProperty(skillId) && skillId !== 'charge' && skillId !== 'attack') {

--- a/src/game/utils/SummoningEngine.js
+++ b/src/game/utils/SummoningEngine.js
@@ -2,6 +2,7 @@ import { debugLogEngine } from './DebugLogEngine.js';
 import { monsterEngine } from './MonsterEngine.js';
 import { formationEngine } from './FormationEngine.js';
 import { getMonsterBase } from '../data/monster.js';
+import { getSummonBase } from '../data/summon.js';
 
 /**
  * 전투 중 유닛 소환을 담당하는 엔진
@@ -37,7 +38,10 @@ class SummoningEngine {
         }
 
         // 2. 소환수 데이터 생성
-        const monsterBase = getMonsterBase(summonSkillData.creatureId);
+        let monsterBase = getMonsterBase(summonSkillData.creatureId);
+        if (!monsterBase) {
+            monsterBase = getSummonBase(summonSkillData.creatureId);
+        }
         if (!monsterBase) {
             debugLogEngine.error('SummoningEngine', `몬스터 데이터베이스에서 '${summonSkillData.creatureId}'를 찾을 수 없습니다.`);
             return null;

--- a/tests/summon_skill_integration_test.js
+++ b/tests/summon_skill_integration_test.js
@@ -1,0 +1,6 @@
+import assert from 'assert';
+import { getSummonBase } from '../src/game/data/summon.js';
+
+const base = getSummonBase('ancestorPeor');
+assert(base && base.baseStats.hp === 80);
+console.log('Summon skill integration test passed.');


### PR DESCRIPTION
## Summary
- define summonable unit 'ancestor Peor'
- add summoning skill card data and register it in the database
- supply summon skill cards at start of the game
- support loading the new sprite and fallback lookup in SummoningEngine
- include basic test for summon data

## Testing
- `node tests/movement_stat_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6884b58274f083278161e48223e71b69