### PR TITLE
Add turn order UI to battle scene

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1189,3 +1189,52 @@ body {
     margin-left: 20px; /* 좌측 패널과의 간격 */
 }
 
+
+/* --- 턴 순서 패널 스타일 --- */
+#turn-order-container {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    width: 200px;
+    max-height: 90vh;
+    background-color: rgba(0, 0, 0, 0.6);
+    border: 1px solid #444;
+    border-radius: 8px;
+    padding: 10px;
+    box-sizing: border-box;
+    overflow-y: auto;
+    z-index: 150;
+    pointer-events: none;
+}
+
+.turn-order-entry {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+    padding: 5px;
+    border-radius: 4px;
+    transition: background-color 0.3s;
+}
+
+.turn-order-entry.active-turn {
+    background-color: rgba(255, 215, 0, 0.3);
+    border: 1px solid rgba(255, 215, 0, 0.7);
+}
+
+.turn-order-portrait {
+    width: 40px;
+    height: 40px;
+    background-size: cover;
+    background-position: center;
+    border-radius: 50%;
+    border: 2px solid #666;
+    margin-right: 10px;
+    flex-shrink: 0;
+}
+
+.turn-order-name {
+    color: #fff;
+    font-size: 14px;
+    font-weight: bold;
+    text-shadow: 1px 1px 2px #000;
+}

--- a/src/game/dom/TurnOrderUIManager.js
+++ b/src/game/dom/TurnOrderUIManager.js
@@ -1,0 +1,72 @@
+import { turnOrderManager } from '../utils/TurnOrderManager.js';
+
+/**
+ * 전투 중 턴 순서 UI를 관리하는 DOM 매니저
+ */
+export class TurnOrderUIManager {
+    constructor() {
+        this.container = document.getElementById('turn-order-container');
+        if (!this.container) {
+            this.container = document.createElement('div');
+            this.container.id = 'turn-order-container';
+            document.getElementById('ui-container').appendChild(this.container);
+        }
+        this.container.style.display = 'none';
+    }
+
+    /**
+     * 턴 순서 UI를 표시하고 초기화합니다.
+     * @param {Array<object>} initialTurnQueue - 최초 턴 순서 배열
+     */
+    show(initialTurnQueue) {
+        this.container.innerHTML = '';
+        this.update(initialTurnQueue);
+        this.container.style.display = 'block';
+    }
+
+    /**
+     * 턴 순서 UI를 숨깁니다.
+     */
+    hide() {
+        this.container.style.display = 'none';
+    }
+
+    /**
+     * 새로운 턴 순서에 맞춰 UI를 다시 그립니다.
+     * @param {Array<object>} newTurnQueue - 갱신된 턴 순서 배열
+     */
+    update(newTurnQueue) {
+        this.container.innerHTML = '';
+
+        newTurnQueue.forEach(unit => {
+            if (unit.currentHp <= 0) return;
+
+            const unitEntry = document.createElement('div');
+            unitEntry.className = 'turn-order-entry';
+            if (unit.isTurnActive) {
+                unitEntry.classList.add('active-turn');
+            }
+
+            const portrait = document.createElement('div');
+            portrait.className = 'turn-order-portrait';
+            const imageUrl = unit.uiImage || `assets/images/unit/${unit.battleSprite}.png`;
+            portrait.style.backgroundImage = `url(${imageUrl})`;
+
+            const nameLabel = document.createElement('span');
+            nameLabel.className = 'turn-order-name';
+            nameLabel.innerText = unit.instanceName;
+
+            unitEntry.appendChild(portrait);
+            unitEntry.appendChild(nameLabel);
+            this.container.appendChild(unitEntry);
+        });
+    }
+
+    /**
+     * UI와 관련된 모든 리소스를 정리합니다.
+     */
+    destroy() {
+        this.hide();
+        this.container.innerHTML = '';
+    }
+}


### PR DESCRIPTION
## Summary
- draw battle turn order with a new `TurnOrderUIManager`
- style the turn order panel in CSS
- integrate the manager into `BattleSimulatorEngine`

## Testing
- `node tests/movement_stat_test.js && node tests/warrior_skill_integration_test.js && node tests/medic_skill_integration_test.js && node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6884bbb143888327b6e05dee25898de5