### PR TITLE
Fix browser import in summon data

### DIFF
--- a/src/game/data/summon.js
+++ b/src/game/data/summon.js
@@ -1,6 +1,8 @@
 
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
+// ES 모듈 환경에서 Node의 `createRequire`를 사용할 필요가 없습니다.
+// 브라우저에서도 동작하도록 직접 필요한 모듈을 import 합니다.
+import { ownedSkillsManager } from '../utils/OwnedSkillsManager.js';
+import { skillInventoryManager } from '../utils/SkillInventoryManager.js';
 
 export const summonData = {
     ancestorPeor: {
@@ -15,8 +17,6 @@ export const summonData = {
             weight: 12
         },
         onSpawn: (unit) => {
-            const { ownedSkillsManager } = require('../utils/OwnedSkillsManager.js');
-            const { skillInventoryManager } = require('../utils/SkillInventoryManager.js');
             const skillId = 'attack';
             const grade = 'NORMAL';
             const newInstance = skillInventoryManager.addSkillById(skillId, grade);


### PR DESCRIPTION
## Summary
- remove Node `createRequire` usage
- directly import utilities for summons

## Testing
- `node tests/movement_stat_test.js && node tests/summon_skill_integration_test.js && node tests/warrior_skill_integration_test.js && node tests/medic_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6884c4e172088327bf5fc10319b20611