### PR TITLE
Fix VFX and UI update logic for summoning

### DIFF
--- a/src/game/utils/SummoningEngine.js
+++ b/src/game/utils/SummoningEngine.js
@@ -69,10 +69,21 @@ class SummoningEngine {
         const penalty = Math.round(summoner.finalStats.hp * (summonSkillData.healthCostPercent || 0.1)); // 기본 10%
         summoner.currentHp -= penalty;
 
-        // VFX 매니저를 통해 시각 효과 업데이트
-        if (this.battleSimulator.vfxManager) {
-            this.battleSimulator.vfxManager.createDamageNumber(summoner.sprite.x, summoner.sprite.y, `-${penalty}`, '#9333ea');
-            this.battleSimulator.vfxManager.updateHealthBar(summoner.healthBar, summoner.currentHp, summoner.finalStats.hp);
+        // ✨ [수정] VFX 및 UI 업데이트 로직 수정
+        if (this.battleSimulator) {
+            // 데미지 숫자는 VFX 매니저로 생성
+            if (this.battleSimulator.vfxManager) {
+                this.battleSimulator.vfxManager.createDamageNumber(
+                    summoner.sprite.x,
+                    summoner.sprite.y,
+                    `-${penalty}`,
+                    '#9333ea'
+                );
+            }
+            // 체력바 업데이트는 Combat UI 매니저로 수행
+            if (this.battleSimulator.combatUI) {
+                this.battleSimulator.combatUI.updateHealth(summoner);
+            }
         }
 
         // 6. 전투 턴 큐에 소환수 추가


### PR DESCRIPTION
## Summary
- tweak SummoningEngine logic for updating health VFX
- health bar now updated via combat UI instead of VFX manager

## Testing
- `node tests/summon_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6884c8860bec83279dec6fe0cb55b01a