### PR TITLE
Add summon AI registration

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -39,6 +39,22 @@ class AIManager {
     }
 
     /**
+     * 전장의 모든 유닛 정보를 모든 AI의 블랙보드에 갱신합니다.
+     * 유닛이 새로 등장하거나 사라질 때 호출하세요.
+     * @param {Array<object>} allUnits
+     */
+    updateBlackboard(allUnits) {
+        for (const data of this.unitData.values()) {
+            const allies = allUnits.filter(u => u.team === data.instance.team && u.currentHp > 0);
+            const enemies = allUnits.filter(u => u.team !== data.instance.team && u.currentHp > 0);
+
+            data.behaviorTree.blackboard.set('allUnits', allUnits);
+            data.behaviorTree.blackboard.set('enemyUnits', enemies);
+            data.behaviorTree.blackboard.set('allyUnits', allies);
+        }
+    }
+
+    /**
      * 특정 유닛의 턴을 실행합니다.
      * @param {object} unit - 턴을 실행할 유닛
      * @param {Array<object>} allUnits - 전장의 모든 유닛


### PR DESCRIPTION
## Summary
- register newly summoned melee units with ai manager
- update all AIs' blackboards when the battlefield changes
- keep ancestor summon data explicit about className

## Testing
- `node tests/movement_stat_test.js && node tests/warrior_skill_integration_test.js && node tests/medic_skill_integration_test.js && node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6884ccf140cc83279fcb43282b34a39e