### PR TITLE
Add melee AI registration for summoned units

### DIFF
--- a/src/game/data/summon.js
+++ b/src/game/data/summon.js
@@ -9,6 +9,7 @@ export const summonData = {
         name: '선조 페오르',
         className: '전사',
         battleSprite: 'ancestor-peor',
+        uiImage: 'assets/images/summon/ancestor-peor.png',
         baseStats: {
             hp: 80, valor: 5, strength: 10, endurance: 8,
             agility: 6, intelligence: 3, wisdom: 3, luck: 5,

--- a/src/game/utils/SummoningEngine.js
+++ b/src/game/utils/SummoningEngine.js
@@ -69,8 +69,9 @@ class SummoningEngine {
         this.battleSimulator._setupUnits([summonedUnit]);
 
         // 5. AI 매니저에 새 유닛을 등록하여 즉시 행동 트리를 갖게 합니다.
-        if (summonedUnit.className === '전사') {
+        if (summonedUnit.className === '전사' || summonedUnit.name === '선조 페오르') {
             aiManager.registerUnit(summonedUnit, createMeleeAI(this.battleSimulator.aiEngines));
+            debugLogEngine.log('SummoningEngine', `${summonedUnit.instanceName}에게 MeleeAI를 등록했습니다.`);
         }
 
         // 6. 소환사에게 체력 페널티 적용


### PR DESCRIPTION
## Summary
- register MeleeAI for the summoned ancestor Peor
- expose ancestor Peor's UI image so it displays correctly

## Testing
- `node tests/summon_skill_integration_test.js && node tests/warrior_skill_integration_test.js && node tests/movement_stat_test.js && node tests/medic_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6884d156feec8327b98a76f487631008