### PR TITLE
Add move debug manager and action power UI

### DIFF
--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -1,6 +1,10 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
 import { formationEngine } from '../../game/utils/FormationEngine.js';
+// ✨ [신규] DebugMoveManager를 import 합니다.
+import { debugMoveManager } from '../../game/debug/DebugMoveManager.js';
+import { skillInventoryManager } from '../../game/utils/SkillInventoryManager.js';
+import { skillEngine } from '../../game/utils/SkillEngine.js';
 
 class MoveToTargetNode extends Node {
     constructor({ animationEngine, cameraControl }) {
@@ -30,6 +34,11 @@ class MoveToTargetNode extends Node {
         if (movePath.length === 0) {
             return NodeState.SUCCESS;
         }
+
+        // ✨ [신규] 이동 실행 전 이동 스킬(0번 슬롯)을 사용 처리합니다.
+        // 이 노드는 0번 슬롯 스킬의 결과로 실행되므로, 여기서 자원을 소모하는 것이 타당합니다.
+        const skillData = skillInventoryManager.getSkillData('move');
+        skillEngine.recordSkillUse(unit, skillData);
 
         // 현재 위치의 점유 상태를 해제합니다.
         const originalCell = formationEngine.grid.getCell(unit.gridX, unit.gridY);
@@ -65,6 +74,9 @@ class MoveToTargetNode extends Node {
             finalCell.isOccupied = true;
             finalCell.sprite = unit.sprite;
         }
+
+        // ✨ [신규] 이동 완료 후 로그를 기록합니다.
+        debugMoveManager.logMoveAction(unit, movePath);
 
         // 이동 완료 플래그 설정
         blackboard.set('hasMovedThisTurn', true);

--- a/src/game/debug/DebugMoveManager.js
+++ b/src/game/debug/DebugMoveManager.js
@@ -1,0 +1,37 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * 유닛의 이동 행동을 추적하고 로그로 남기는 디버그 매니저
+ */
+class DebugMoveManager {
+    constructor() {
+        this.name = 'DebugMove';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 유닛이 이동 스킬을 사용하여 이동했음을 로그로 남깁니다.
+     * @param {object} unit - 이동한 유닛
+     * @param {Array<object>} path - 이동한 경로
+     */
+    logMoveAction(unit, path) {
+        if (!unit || !path) return;
+
+        const pathLength = path.length;
+        const startPos = { col: unit.gridX - path[0].col, row: unit.gridY - path[0].row };
+        const endPos = { col: unit.gridX, row: unit.gridY };
+
+        console.groupCollapsed(
+            `%c[${this.name}]`,
+            `color: #3b82f6; font-weight: bold;`,
+            `${unit.instanceName} 이동 완료`
+        );
+
+        debugLogEngine.log(this.name, `이동 거리: ${pathLength}칸`);
+        debugLogEngine.log(this.name, `경로: (${startPos.col}, ${startPos.row}) -> (${endPos.col}, ${endPos.row})`);
+
+        console.groupEnd();
+    }
+}
+
+export const debugMoveManager = new DebugMoveManager();

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -122,6 +122,8 @@ export class Preloader extends Scene
 
         // --- 추가된 토큰 이미지 로드 ---
         this.load.image('token', 'images/battle/token.png');
+        // ✨ [신규] 행동력(AP) 아이콘 이미지 로드
+        this.load.image('ap', 'images/battle/AP.png');
 
         // 상태 효과 아이콘 로드
         Object.values(statusEffects).forEach(e => {

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -126,9 +126,12 @@ export class BattleSimulatorEngine {
         // 스킬 사용 기록 초기화
         skillEngine.resetTurnActions();
 
-        // [✨ 수정] 첫 턴 시작 직후 모든 유닛의 토큰 UI를 업데이트합니다.
+        // [✨ 수정] 첫 턴 시작 직후 모든 유닛의 토큰 및 행동력 UI를 업데이트합니다.
         // unit.uniqueId 대신 unit 객체 전체를 전달합니다.
-        allUnits.forEach(unit => this.vfxManager.updateTokenDisplay(unit));
+        allUnits.forEach(unit => {
+            this.vfxManager.updateTokenDisplay(unit);
+            this.vfxManager.updateActionPowerDisplay(unit);
+        });
 
         this.gameLoop(); // 수정된 루프 시작
     }
@@ -210,11 +213,11 @@ export class BattleSimulatorEngine {
             this.turnQueue.forEach((u, idx) => u.isTurnActive = (idx === this.currentTurnIndex));
             this.turnOrderUI.update(this.turnQueue);
 
-            // --- ✨ 매 행동 후 모든 유닛의 토큰 UI 업데이트 ---
-            // unit.uniqueId 대신 unit 객체 전체를 전달합니다.
+            // --- ✨ 매 행동 후 모든 유닛의 토큰 및 행동력 UI 업데이트 ---
             this.turnQueue.forEach(unit => {
                 if (unit.sprite && unit.sprite.active) {
                     this.vfxManager.updateTokenDisplay(unit);
+                    this.vfxManager.updateActionPowerDisplay(unit);
                 }
             });
 

--- a/src/game/utils/VFXManager.js
+++ b/src/game/utils/VFXManager.js
@@ -1,6 +1,8 @@
 import { debugLogEngine } from './DebugLogEngine.js';
 // tokenEngine을 import하여 현재 토큰 개수를 가져옵니다.
 import { tokenEngine } from './TokenEngine.js';
+// ✨ [신규] actionPowerEngine을 import 합니다.
+import { actionPowerEngine } from './ActionPowerEngine.js';
 
 /**
  * 체력바, 데미지 텍스트 등 전투 시각 효과(VFX)를 생성하고 관리하는 엔진
@@ -17,6 +19,8 @@ export class VFXManager {
 
         // 각 유닛의 토큰 UI를 관리하기 위한 Map을 추가합니다.
         this.activeTokenDisplays = new Map();
+        // ✨ [신규] 각 유닛의 행동력 UI를 관리하기 위한 Map
+        this.activeAPDisplays = new Map();
 
         debugLogEngine.log('VFXManager', 'VFX 매니저가 초기화되었습니다.');
     }
@@ -71,6 +75,48 @@ export class VFXManager {
             const tokenImage = this.scene.add.image(startX + i * tokenSpacing, 0, 'token').setScale(0.04);
             display.container.add(tokenImage);
             display.tokens.push(tokenImage);
+        }
+    }
+
+    /**
+     * ✨ [신규 추가]
+     * 특정 유닛의 행동력 개수에 맞춰 화면에 아이콘을 업데이트합니다.
+     * @param {object} unit - 대상 유닛
+     */
+    updateActionPowerDisplay(unit) {
+        if (!unit || !unit.sprite || !unit.sprite.active) return;
+
+        const unitId = unit.uniqueId;
+        let display = this.activeAPDisplays.get(unitId);
+
+        if (!display) {
+            // 토큰보다 살짝 위에 위치하도록 yOffset 조정
+            const yOffset = -(unit.sprite.displayHeight / 2) - 30;
+            const container = this.scene.add.container(unit.sprite.x, unit.sprite.y + yOffset);
+            this.vfxLayer.add(container);
+
+            this.bindingManager.bind(unit.sprite, [container]);
+
+            display = { container, aps: [] };
+            this.activeAPDisplays.set(unitId, display);
+        }
+
+        const apCount = actionPowerEngine.getActionPower(unitId);
+
+        if (display.aps.length === apCount) return;
+
+        display.aps.forEach(ap => ap.destroy());
+        display.aps = [];
+
+        const apSpacing = 12;
+        const totalWidth = (apCount - 1) * apSpacing;
+        const startX = -totalWidth / 2;
+
+        for (let i = 0; i < apCount; i++) {
+            // ✨ 'ap' 이미지 키 사용 및 4배 축소 (setScale(0.25))
+            const apImage = this.scene.add.image(startX + i * apSpacing, 0, 'ap').setScale(0.25);
+            display.container.add(apImage);
+            display.aps.push(apImage);
         }
     }
 
@@ -225,6 +271,11 @@ export class VFXManager {
             display.container.destroy();
         });
         this.activeTokenDisplays.clear();
+        // ✨ [신규] 행동력 UI도 함께 정리
+        this.activeAPDisplays.forEach(display => {
+            display.container.destroy();
+        });
+        this.activeAPDisplays.clear();
         debugLogEngine.log("VFXManager", "VFX 매니저를 종료합니다.");
     }
 }


### PR DESCRIPTION
## Summary
- create `DebugMoveManager` to log unit movement
- display AP icons via `VFXManager`
- preload AP icon asset
- update UI after each turn in `BattleSimulatorEngine`
- log movement and consume move skill in `MoveToTargetNode`

## Testing
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6884fad1541c83278c4bda9229f65ddb