### PR TITLE
Update MoveToTargetNode to track skill use

### DIFF
--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -1,7 +1,6 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
 import { formationEngine } from '../../game/utils/FormationEngine.js';
-// ✨ [신규] DebugMoveManager를 import 합니다.
 import { debugMoveManager } from '../../game/debug/DebugMoveManager.js';
 import { skillInventoryManager } from '../../game/utils/SkillInventoryManager.js';
 import { skillEngine } from '../../game/utils/SkillEngine.js';
@@ -18,27 +17,36 @@ class MoveToTargetNode extends Node {
         const path = blackboard.get('movementPath');
         const movementRange = unit.finalStats.movement || 3;
 
-        // ✨ [수정] 경로가 없는 경우(null)와 이미 도착한 경우(빈 배열)를 분리해서 처리합니다.
-        if (!path) { // 경로 탐색 실패
+        if (!path) {
             debugAIManager.logNodeResult(NodeState.FAILURE, '경로가 없음');
             return NodeState.FAILURE;
         }
 
-        if (path.length === 0) { // 이미 목표 위치에 도달함
+        if (path.length === 0) {
             debugAIManager.logNodeResult(NodeState.SUCCESS, '이미 목표 위치에 있음');
             return NodeState.SUCCESS;
         }
 
-        // 이동력만큼만 경로를 잘라냅니다.
         const movePath = path.slice(0, movementRange);
         if (movePath.length === 0) {
             return NodeState.SUCCESS;
         }
 
-        // ✨ [신규] 이동 실행 전 이동 스킬(0번 슬롯)을 사용 처리합니다.
-        // 이 노드는 0번 슬롯 스킬의 결과로 실행되므로, 여기서 자원을 소모하는 것이 타당합니다.
-        const skillData = skillInventoryManager.getSkillData('move');
-        skillEngine.recordSkillUse(unit, skillData);
+        // ✨ [핵심 수정] 블랙보드에서 현재 스킬 정보를 가져옵니다.
+        const skillData = blackboard.get('currentSkillData');
+        const instanceId = blackboard.get('currentSkillInstanceId');
+
+        // 스킬 사용을 SkillEngine에 기록합니다 (자원 소모 등).
+        if (skillData) {
+            skillEngine.recordSkillUse(unit, skillData);
+        }
+
+        // ✨ [핵심 추가] AIManager가 알 수 있도록 블랙보드에도 스킬 사용을 기록합니다.
+        if (instanceId) {
+            const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
+            usedSkills.add(instanceId);
+            blackboard.set('usedSkillsThisTurn', usedSkills);
+        }
 
         // 현재 위치의 점유 상태를 해제합니다.
         const originalCell = formationEngine.grid.getCell(unit.gridX, unit.gridY);
@@ -75,7 +83,6 @@ class MoveToTargetNode extends Node {
             finalCell.sprite = unit.sprite;
         }
 
-        // ✨ [신규] 이동 완료 후 로그를 기록합니다.
         debugMoveManager.logMoveAction(unit, movePath);
 
         // 이동 완료 플래그 설정


### PR DESCRIPTION
## Summary
- record skill usage in MoveToTargetNode similar to UseSkillNode
- update AI blackboard with used skills when moving

## Testing
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68850227f9f88327acdc7de0e6a2a940