### PR TITLE
Fix AI movement logic

### DIFF
--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -9,6 +9,7 @@ import CanUseSkillBySlotNode from '../nodes/CanUseSkillBySlotNode.js';
 import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
 import UseSkillNode from '../nodes/UseSkillNode.js';
 import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 
 // 힐러 전용 이동 노드
 import FindSafeHealingPositionNode from '../nodes/FindSafeHealingPositionNode.js';
@@ -16,7 +17,10 @@ import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 
 /**
  * 힐러 유닛을 위한 행동 트리를 생성합니다.
- * SKILL-SYSTEM.md 규칙에 따라 스킬 슬롯 순서대로 우선순위를 결정합니다.
+ *
+ * 행동 우선순위 (사용자님의 원래 의도대로 복원):
+ * 1. 재배치: (아직 이동 안 했으면) 0순위 이동 스킬을 사용해 안전한 위치로 이동합니다.
+ * 2. 스킬 사용: 1~5순위 스킬(힐, 버프 등)을 확인하여 사용합니다.
  */
 function createHealerAI(engines = {}) {
     // 스킬 하나를 실행하는 공통 로직 (이동 포함)
@@ -34,14 +38,16 @@ function createHealerAI(engines = {}) {
     ]);
 
     const rootNode = new SelectorNode([
-        // ✨ [신규] 최우선 순위 0: 안전한 위치로 이동
+        // ✨ 최우선 순위 0: 안전한 위치로 이동 (단, 턴에 한 번만 실행되도록 수정)
         new SequenceNode([
+            // ✨ [핵심 수정] 이 노드가 이동을 한 번만 하도록 막아주는 관문 역할을 합니다.
+            new HasNotMovedNode(engines),
             new CanUseSkillBySlotNode(0),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines),
         ]),
 
-        // ✨ [변경] 기존 스킬 순위 +1
+        // 우선순위 1~5: 힐, 버프 등 주요 스킬 사용 시도
         new SequenceNode([ new CanUseSkillBySlotNode(1), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
         new SequenceNode([ new CanUseSkillBySlotNode(2), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
         new SequenceNode([ new CanUseSkillBySlotNode(3), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),

--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -17,31 +17,48 @@ class MoveToTargetNode extends Node {
         const path = blackboard.get('movementPath');
         const movementRange = unit.finalStats.movement || 3;
 
+        // ✨ [핵심 수정] 블랙보드에서 현재 스킬 정보를 미리 가져옵니다.
+        const skillData = blackboard.get('currentSkillData');
+        const instanceId = blackboard.get('currentSkillInstanceId');
+
         if (!path) {
             debugAIManager.logNodeResult(NodeState.FAILURE, '경로가 없음');
             return NodeState.FAILURE;
         }
 
+        // --- ✨ [핵심 로직 수정] ---
+        // 이동 경로가 없더라도(제자리에 있더라도), 이동 '행동' 자체는 수행한 것으로 간주하고
+        // 관련된 자원(행동력 등)을 소모하고 턴 플래그를 설정합니다.
+        // 이것이 "이동 안 한 전사가 힐링포션을 쓰는" 로직의 핵심입니다.
         if (path.length === 0) {
-            debugAIManager.logNodeResult(NodeState.SUCCESS, '이미 목표 위치에 있음');
+            debugAIManager.logNodeResult(NodeState.SUCCESS, '이미 목표 위치에 있음 (행동력은 소모)');
+            // 스킬 사용 기록 (행동력 소모)
+            if (skillData) {
+                skillEngine.recordSkillUse(unit, skillData);
+            }
+            // 블랙보드에 스킬 사용 기록
+            if (instanceId) {
+                const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
+                usedSkills.add(instanceId);
+                blackboard.set('usedSkillsThisTurn', usedSkills);
+            }
+            // 이동 완료 플래그 설정
+            blackboard.set('hasMovedThisTurn', true);
             return NodeState.SUCCESS;
         }
+        // --- 수정 끝 ---
 
         const movePath = path.slice(0, movementRange);
         if (movePath.length === 0) {
             return NodeState.SUCCESS;
         }
 
-        // ✨ [핵심 수정] 블랙보드에서 현재 스킬 정보를 가져옵니다.
-        const skillData = blackboard.get('currentSkillData');
-        const instanceId = blackboard.get('currentSkillInstanceId');
-
         // 스킬 사용을 SkillEngine에 기록합니다 (자원 소모 등).
         if (skillData) {
             skillEngine.recordSkillUse(unit, skillData);
         }
 
-        // ✨ [핵심 추가] AIManager가 알 수 있도록 블랙보드에도 스킬 사용을 기록합니다.
+        // AIManager가 알 수 있도록 블랙보드에도 스킬 사용을 기록합니다.
         if (instanceId) {
             const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
             usedSkills.add(instanceId);


### PR DESCRIPTION
## Summary
- ensure melee AI only moves once per turn and uses slot 0 movement skill
- ensure healer AI also checks if the unit already moved before repositioning
- count movement as action even if path is empty, recording skill use in MoveToTargetNode

## Testing
- `node tests/movement_stat_test.js && node tests/warrior_skill_integration_test.js && node tests/medic_skill_integration_test.js && node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688506806d488327ba52e2220f1d0845