### PR TITLE
Fix AI movement and healing bugs

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -28,6 +28,7 @@ function createMeleeAI(engines = {}) {
             new UseSkillNode(engines)
         ]),
         new SequenceNode([
+            new HasNotMovedNode(engines),
             new FindPathToSkillRangeNode(engines),
             new MoveToTargetNode(engines),
             new IsSkillInRangeNode(engines),

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -34,6 +34,7 @@ function createRangedAI(engines = {}) {
             new UseSkillNode(engines)
         ]),
         new SequenceNode([
+            new HasNotMovedNode(engines),
             new FindKitingPositionNode(engines),
             new MoveToTargetNode(engines),
             new IsSkillInRangeNode(engines),

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -30,6 +30,7 @@ function createHealerAI(engines = {}) {
             new UseSkillNode(engines)
         ]),
         new SequenceNode([
+            new HasNotMovedNode(engines),
             new FindSafeHealingPositionNode(engines),
             new MoveToTargetNode(engines),
             new IsSkillInRangeNode(engines),

--- a/src/ai/nodes/FindTargetBySkillTypeNode.js
+++ b/src/ai/nodes/FindTargetBySkillTypeNode.js
@@ -58,11 +58,16 @@ class FindTargetBySkillTypeNode extends Node {
                     debugAIManager.logNodeResult(NodeState.FAILURE, "아군 유닛 없음");
                     return NodeState.FAILURE;
                 }
-                // 체력 비율이 가장 낮은 아군을 찾습니다 (자신 포함).
-                target = [...alliedUnits].sort((a, b) => {
-                    const healthRatioA = a.currentHp / a.finalStats.hp;
-                    const healthRatioB = b.currentHp / b.finalStats.hp;
-                    return healthRatioA - healthRatioB;
+                // 체력이 감소한 아군만 대상으로 고려합니다.
+                const injuredAllies = alliedUnits.filter(u => u.currentHp < u.finalStats.hp);
+                if (injuredAllies.length === 0) {
+                    debugAIManager.logNodeResult(NodeState.FAILURE, '부상당한 아군 없음');
+                    return NodeState.FAILURE;
+                }
+                target = injuredAllies.sort((a, b) => {
+                    const ratioA = a.currentHp / a.finalStats.hp;
+                    const ratioB = b.currentHp / b.finalStats.hp;
+                    return ratioA - ratioB;
                 })[0];
                 break;
             // ✨ [신규] 소환 스킬은 임시로 시전자 자신을 대상으로 합니다.

--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -31,19 +31,8 @@ class MoveToTargetNode extends Node {
         // 관련된 자원(행동력 등)을 소모하고 턴 플래그를 설정합니다.
         // 이것이 "이동 안 한 전사가 힐링포션을 쓰는" 로직의 핵심입니다.
         if (path.length === 0) {
-            debugAIManager.logNodeResult(NodeState.SUCCESS, '이미 목표 위치에 있음 (행동력은 소모)');
-            // 스킬 사용 기록 (행동력 소모)
-            if (skillData) {
-                skillEngine.recordSkillUse(unit, skillData);
-            }
-            // 블랙보드에 스킬 사용 기록
-            if (instanceId) {
-                const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
-                usedSkills.add(instanceId);
-                blackboard.set('usedSkillsThisTurn', usedSkills);
-            }
-            // 이동 완료 플래그 설정
-            blackboard.set('hasMovedThisTurn', true);
+            // 이동이 실제로 발생하지 않았으므로 자원 소모 없이 종료합니다.
+            debugAIManager.logNodeResult(NodeState.SUCCESS, '이미 목표 위치에 있음 (이동 생략)');
             return NodeState.SUCCESS;
         }
         // --- 수정 끝 ---


### PR DESCRIPTION
## Summary
- prevent spending resources when a unit doesn't actually move
- restrict movement to once per turn when using skills
- make healers target only injured allies

## Testing
- `node tests/movement_stat_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68850c10451883279e8cea0f730d2748