### PR TITLE
Add ActionPoint and Movement tracking

### DIFF
--- a/src/game/utils/ActionPointEngine.js
+++ b/src/game/utils/ActionPointEngine.js
@@ -1,0 +1,65 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * \uc720\ub2c8\uc758 \ud560\ub85c\uadf8(AP)\uc744 \uad00\ub9ac\ud558\ub294 \uc5d4\uc9c4 (\uc2f1\uae00\ud134)
+ * AP\ub294 \uc774\ub3d9 \ub610\ub294 \uc544\uc774\ud15c \uc0ac\uc6a9 \ub4f1\uc5d0 \uc18c\uba3c\ub2e4.
+ */
+class ActionPointEngine {
+    constructor() {
+        this.apData = new Map();
+        debugLogEngine.log('ActionPointEngine', '행동력 엔진이 초기화되었습니다.');
+    }
+
+    /**
+     * \uc804\ud22c \uc2dc\uc791 \uc2dc \ubaa8\ub4e0 \uc720\ub2c8\uc758 AP \uc815\ubcf4\ub97c \ucd94\uac00\ud558\uace0 \ucd08\uae30\ud654\ud569\ub2c8\ub2e4.
+     * @param {Array<object>} units - \uc804\ud22c\uc5d0 \ucc38\uc5ec\ud558\ub294 \ubaa8\ub4e0 \uc720\ub2c8
+     */
+    initializeUnits(units) {
+        this.apData.clear();
+        units.forEach(unit => {
+            this.apData.set(unit.uniqueId, {
+                currentPoints: 1,
+                unitName: unit.instanceName
+            });
+        });
+        debugLogEngine.log('ActionPointEngine', `${units.length}명의 유닛 AP 정보 초기화 완료.`);
+    }
+
+    /**
+     * \uc0c8 \ud134\uc774 \uc2dc\uc791\ub420 \ub54c \ubaa8\ub4e0 \uc720\ub2c8\uc5d0\uac8c AP\ub97c 1\uc529 \ubd80\uc5ec\ud569\ub2c8\ub2e4.
+     */
+    addPointForNewTurn() {
+        for (const [unitId, data] of this.apData.entries()) {
+            data.currentPoints++;
+            debugLogEngine.log('ActionPointEngine', `${data.unitName} (ID: ${unitId})의 턴 시작, AP 1 획득. 현재 AP: ${data.currentPoints}`);
+        }
+    }
+
+    /**
+     * \ud2b9\uc815 \uc720\ub2c8\uc758 AP\ub97c \uc0ac\uc6a9\ud569\ub2c8\ub2e4.
+     * @param {number} unitId - AP\ub97c \uc0ac\uc6a9\ud560 \uc720\ub2c8\uc758 ID
+     * @param {number} [amount=1] - \uc18c\uba3c AP \uc591
+     * @returns {boolean} - AP \uc18c\uba3c \uc131\uacf5 \uc5ec\ubd80
+     */
+    spendPoint(unitId, amount = 1) {
+        const data = this.apData.get(unitId);
+        if (data && data.currentPoints >= amount) {
+            data.currentPoints -= amount;
+            debugLogEngine.log('ActionPointEngine', `${data.unitName} (ID: ${unitId})이(가) AP ${amount} 소모. 남은 AP: ${data.currentPoints}`);
+            return true;
+        }
+        debugLogEngine.warn('ActionPointEngine', `유닛(ID:${unitId}) AP 부족으로 ${amount} 사용 실패.`);
+        return false;
+    }
+
+    /**
+     * \ud2b9\uc815 \uc720\ub2c8\uc758 \ud604\uc7ac AP \uac1c\uc218\ub97c \ubc18\ud658\ud569\ub2c8\ub2e4.
+     * @param {number} unitId - \uc870\ud68c\ud560 \uc720\ub2c8\uc758 ID
+     * @returns {number} - \ud604\uc7ac AP \uac1c\uc218
+     */
+    getPoints(unitId) {
+        return this.apData.get(unitId)?.currentPoints || 0;
+    }
+}
+
+export const actionPointEngine = new ActionPointEngine();

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -24,6 +24,8 @@ import { tokenEngine } from './TokenEngine.js';
 import { skillEngine } from './SkillEngine.js';
 import { statusEffectManager } from './StatusEffectManager.js';
 import { cooldownManager } from './CooldownManager.js';
+import { actionPointEngine } from './ActionPointEngine.js';
+import { movementTrackerManager } from './MovementTrackerManager.js';
 // 전투 중 하단 UI를 관리하는 매니저
 import { CombatUIManager } from '../dom/CombatUIManager.js';
 import { TurnOrderUIManager } from '../dom/TurnOrderUIManager.js';
@@ -85,6 +87,10 @@ export class BattleSimulatorEngine {
         statusEffectManager.setBattleSimulator(this);
 
         const allUnits = [...allies, ...enemies];
+
+        // --- ✨ 새 엔진 초기화 로직 추가 ---
+        actionPointEngine.initializeUnits(allUnits);
+        movementTrackerManager.initializeUnits(allUnits);
         // --- ✨ 전투 시작 시 토큰 엔진 초기화 ---
         tokenEngine.initializeUnits(allUnits);
         allies.forEach(u => u.team = 'ally');
@@ -195,6 +201,10 @@ export class BattleSimulatorEngine {
             if (this.currentTurnIndex >= this.turnQueue.length) {
                 this.currentTurnIndex = 0;
                 this.currentTurnNumber++; // 모든 유닛의 턴이 끝나면 전체 턴 수 증가
+
+                // --- ✨ 새 턴 시작 시 엔진 호출 로직 추가 ---
+                actionPointEngine.addPointForNewTurn();
+                movementTrackerManager.resetForNewTurn();
 
                 statusEffectManager.onTurnEnd();
                 tokenEngine.addTokensForNewTurn();

--- a/src/game/utils/MovementTrackerManager.js
+++ b/src/game/utils/MovementTrackerManager.js
@@ -1,0 +1,54 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * \uac01 \uc720\ub2c8\uac00 \ud574\ub2f9 \ud134\uc5d0 \uc774\ub3d9\ud588\ub294\uc9c0 \uc5d0\ub7ec\ub9ac\ub9c1\ud558\ub294 \ub9e4\ub2c8\uc800 (\uc2f1\uae00\ud134)
+ */
+class MovementTrackerManager {
+    constructor() {
+        this.hasMovedThisTurn = new Map();
+        debugLogEngine.log('MovementTrackerManager', '이동 추적 매니저가 초기화되었습니다.');
+    }
+
+    /**
+     * \uc804\ud22c \uc2dc\uc791 \uc2dc \ubaa8\ub4e0 \uc720\ub2c8\uc758 \uc774\ub3d9 \uc0c1\ud0dc\ub97c \ucd08\uae30\ud654\ud569\ub2c8\ub2e4.
+     * @param {Array<object>} units - \uc804\ud22c \ucc38\uc5ec \uc720\ub2c8 \ubaa9\ub85d
+     */
+    initializeUnits(units) {
+        this.hasMovedThisTurn.clear();
+        units.forEach(unit => {
+            this.hasMovedThisTurn.set(unit.uniqueId, false);
+        });
+    }
+
+    /**
+     * \uc0c8 \ud134 \uc2dc\uc791 \uc2dc \ubaa8\ub4e0 \uc720\ub2c8\uc758 \uc774\ub3d9 \uc0c1\ud0dc\ub97c 'false'\ub85c \ubaa8\ub450 \ucd08\uae30\ud654\ud569\ub2c8\ub2e4.
+     */
+    resetForNewTurn() {
+        for (const unitId of this.hasMovedThisTurn.keys()) {
+            this.hasMovedThisTurn.set(unitId, false);
+        }
+        debugLogEngine.log('MovementTrackerManager', '새 턴 시작, 모든 유닛 이동 기록 초기화.');
+    }
+
+    /**
+     * \ud2b9\uc815 \uc720\ub2c8\uc758 \uc774\ub3d9\uc744 \uae30\ub85d\ud569\ub2c8\ub2e4.
+     * @param {number} unitId - \uc774\ub3d9\ud55c \uc720\ub2c8\uc758 ID
+     */
+    recordMovement(unitId) {
+        if (this.hasMovedThisTurn.has(unitId)) {
+            this.hasMovedThisTurn.set(unitId, true);
+            debugLogEngine.log('MovementTrackerManager', `유닛(ID:${unitId})의 이번 턴 이동이 기록되었습니다.`);
+        }
+    }
+
+    /**
+     * \ud2b9\uc815 \uc720\ub2c8\uac00 \uc774\ub2e4\uc639 \ud5c8\uc6a9\ub418\uc5c8\ub294\uc9c0 \ud655\uc778\ud569\ub2c8\ub2e4.
+     * @param {number} unitId - \ud655\uc778\ud560 \uc720\ub2c8 ID
+     * @returns {boolean}
+     */
+    hasMoved(unitId) {
+        return this.hasMovedThisTurn.get(unitId) || false;
+    }
+}
+
+export const movementTrackerManager = new MovementTrackerManager();


### PR DESCRIPTION
## Summary
- add `ActionPointEngine` to manage per-unit AP
- add `MovementTrackerManager` to track movement each turn
- integrate the new engines into `BattleSimulatorEngine`
- update game loop to reset trackers and give AP each round

## Testing
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68851451fb988327aa5875862cbc239e