### PR TITLE
Integrate movement tracking and action points

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -13,6 +13,7 @@ import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import FindMeleeStrategicTargetNode from '../nodes/FindMeleeStrategicTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import SpendActionPointNode from '../nodes/SpendActionPointNode.js';
 
 /**
  * 근접 유닛(전사)을 위한 행동 트리를 재구성합니다.
@@ -32,58 +33,59 @@ function createMeleeAI(engines = {}) {
         ]),
         // B. 이동 후 사용
         new SequenceNode([
-            // ✨ 이동하기 전에 아직 움직이지 않았는지 확인합니다.
             new HasNotMovedNode(),
             new FindPathToSkillRangeNode(engines),
             new MoveToTargetNode(engines),
-            new IsSkillInRangeNode(engines), // 이동 후 사거리 재확인
+            new IsSkillInRangeNode(engines),
             new UseSkillNode(engines)
         ])
     ]);
 
-    const rootNode = new SelectorNode([
-        // 우선순위 1: 1번 슬롯 스킬 사용 시도
+    const movementPhase = new SelectorNode([
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new SpendActionPointNode(),
+            new FindMeleeStrategicTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        new SuccessNode()
+    ]);
+
+    const skillPhase = new SelectorNode([
         new SequenceNode([
             new CanUseSkillBySlotNode(0),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 우선순위 2: 2번 슬롯 스킬 사용 시도
         new SequenceNode([
             new CanUseSkillBySlotNode(1),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 우선순위 3: 3번 슬롯 스킬 사용 시도
         new SequenceNode([
             new CanUseSkillBySlotNode(2),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 우선순위 4: 4번 슬롯 스킬 사용 시도 (보통 일반 공격)
         new SequenceNode([
             new CanUseSkillBySlotNode(3),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // ✨ [신규] 우선순위 5: 5번 슬롯(소환) 스킬 사용 시도
         new SequenceNode([
             new CanUseSkillBySlotNode(4),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
+        new SuccessNode()
+    ]);
 
-        // 우선순위 6: 사용할 스킬이 없을 경우, 이동만 실행
+    const rootNode = new SelectorNode([
         new SequenceNode([
-            // ✨ 이동하기 전에 아직 움직이지 않았는지 확인합니다.
-            new HasNotMovedNode(),
-            new FindMeleeStrategicTargetNode(engines),
-            new FindPathToTargetNode(engines),
-            new MoveToTargetNode(engines)
-        ]),
-
-        // 최후의 보루: 아무것도 할 수 없을 때 성공으로 턴 종료
-        new SuccessNode(),
+            movementPhase,
+            skillPhase
+        ])
     ]);
 
     return new BehaviorTree(rootNode);

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -18,6 +18,7 @@ import FindMeleeStrategicTargetNode from '../nodes/FindMeleeStrategicTargetNode.
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 // ✨ HasNotMovedNode를 import합니다.
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import SpendActionPointNode from '../nodes/SpendActionPointNode.js';
 
 /**
  * 원거리 유닛(거너)을 위한 행동 트리를 재구성합니다.
@@ -33,86 +34,71 @@ function createRangedAI(engines = {}) {
 
     // 스킬 하나를 실행하는 공통 로직 (이동 포함)
     const executeSkillBranch = new SelectorNode([
-        // A. 제자리에서 즉시 사용
         new SequenceNode([
             new IsSkillInRangeNode(engines),
             new UseSkillNode(engines)
         ]),
-        // B. 이동 후 사용
         new SequenceNode([
             new HasNotMovedNode(),
-            // ✨ [핵심 변경] 공격을 위한 이동 시, 단순 경로 탐색이 아닌
-            // 주변 모든 위협을 고려하는 '카이팅 위치'를 탐색하도록 변경합니다.
             new FindKitingPositionNode(engines),
             new MoveToTargetNode(engines),
-            new IsSkillInRangeNode(engines), // 이동 후 사거리 재확인
+            new IsSkillInRangeNode(engines),
             new UseSkillNode(engines)
         ])
     ]);
-    
-    // 사용 가능한 가장 높은 우선순위의 스킬을 찾아 실행하는 로직
-    const findAndUseBestSkillSequence = new SelectorNode([
-        // 1순위 스킬
+
+    const movementPhase = new SelectorNode([
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new SpendActionPointNode(),
+            new IsTargetTooCloseNode({ ...engines, dangerZone: 2 }),
+            new FindKitingPositionNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new SpendActionPointNode(),
+            new FindMeleeStrategicTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        new SuccessNode()
+    ]);
+
+    const skillPhase = new SelectorNode([
         new SequenceNode([
             new CanUseSkillBySlotNode(0),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 2순위 스킬
         new SequenceNode([
             new CanUseSkillBySlotNode(1),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 3순위 스킬
         new SequenceNode([
             new CanUseSkillBySlotNode(2),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 4순위 스킬 (보통 일반 공격)
         new SequenceNode([
             new CanUseSkillBySlotNode(3),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // ✨ [신규] 5순위 스킬
         new SequenceNode([
             new CanUseSkillBySlotNode(4),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
+        new SuccessNode()
     ]);
 
     const rootNode = new SelectorNode([
-        // 최우선 순위 1: 생존 - 적이 너무 가까우면 카이팅부터 실행
         new SequenceNode([
-            // ✨ 이동하기 전에 아직 움직이지 않았는지 확인합니다.
-            new HasNotMovedNode(),
-            new IsTargetTooCloseNode({ ...engines, dangerZone: 2 }), // 위험 거리 설정
-            new FindKitingPositionNode(engines),
-            new MoveToTargetNode(engines),
-            // 이동 후, 그 자리에서 공격할 기회가 있다면 공격
-            new SelectorNode([
-                findAndUseBestSkillSequence,
-                new SuccessNode() // 공격할 스킬이 없어도 카이팅 자체는 성공
-            ])
-        ]),
-
-        // 우선순위 2: 공격 - 위협적이지 않다면 스킬 사용 시도
-        findAndUseBestSkillSequence,
-
-        // 우선순위 3: 이동 - 공격할 스킬이 없다면, 다음 턴을 위해 이동만 실행
-        new SequenceNode([
-            // ✨ 이동하기 전에 아직 움직이지 않았는지 확인합니다.
-            new HasNotMovedNode(),
-            new FindMeleeStrategicTargetNode(engines),
-            new FindPathToTargetNode(engines),
-            new MoveToTargetNode(engines)
-        ]),
-
-        // 최후의 보루: 아무것도 할 수 없을 때 성공으로 턴 종료
-        new SuccessNode(),
+            movementPhase,
+            skillPhase
+        ])
     ]);
 
     return new BehaviorTree(rootNode);

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -9,6 +9,7 @@ import CanUseSkillBySlotNode from '../nodes/CanUseSkillBySlotNode.js';
 import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
 import UseSkillNode from '../nodes/UseSkillNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import SpendActionPointNode from '../nodes/SpendActionPointNode.js';
 import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
 
 // 힐러 전용 이동 노드
@@ -20,64 +21,64 @@ import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
  * SKILL-SYSTEM.md 규칙에 따라 스킬 슬롯 순서대로 우선순위를 결정합니다.
  */
 function createHealerAI(engines = {}) {
-    // 스킬 하나를 실행하는 공통 로직 (이동 포함)
     const executeSkillBranch = new SelectorNode([
-        // A. 제자리에서 즉시 사용
         new SequenceNode([
             new IsSkillInRangeNode(engines),
             new UseSkillNode(engines)
         ]),
-        // B. 이동 후 사용
         new SequenceNode([
             new HasNotMovedNode(),
-            // ✨ 힐러는 공격 위치가 아닌 '안전한 치유/버프 위치'를 탐색합니다.
             new FindSafeHealingPositionNode(engines),
             new MoveToTargetNode(engines),
-            new IsSkillInRangeNode(engines), // 이동 후 사거리 재확인
+            new IsSkillInRangeNode(engines),
             new UseSkillNode(engines)
         ])
     ]);
 
-    const rootNode = new SelectorNode([
-        // 우선순위 1: 1번 슬롯 스킬 사용 시도
+    const movementPhase = new SelectorNode([
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new SpendActionPointNode(),
+            new FindSafeRepositionNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        new SuccessNode()
+    ]);
+
+    const skillPhase = new SelectorNode([
         new SequenceNode([
             new CanUseSkillBySlotNode(0),
-            new FindTargetBySkillTypeNode(engines), // 스킬 타입에 맞는 대상(아군)을 찾습니다.
+            new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 우선순위 2: 2번 슬롯 스킬 사용 시도
         new SequenceNode([
             new CanUseSkillBySlotNode(1),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 우선순위 3: 3번 슬롯 스킬 사용 시도
         new SequenceNode([
             new CanUseSkillBySlotNode(2),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 우선순위 4: 4번 슬롯 스킬 사용 시도
         new SequenceNode([
             new CanUseSkillBySlotNode(3),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // ✨ [신규] 우선순위 5: 5번 슬롯(소환) 스킬 사용 시도
         new SequenceNode([
             new CanUseSkillBySlotNode(4),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 최후의 수단 1: 사용할 스킬이 없을 경우, 안전한 위치로 이동
-        new SequenceNode([
-            new HasNotMovedNode(),
-            new FindSafeRepositionNode(engines),
-            new MoveToTargetNode(engines),
-        ]),
+        new SuccessNode()
+    ]);
 
-        // 최후의 수단 2: 아무것도 할 수 없을 때 성공으로 턴 종료
-        new SuccessNode(),
+    const rootNode = new SelectorNode([
+        new SequenceNode([
+            movementPhase,
+            skillPhase
+        ])
     ]);
 
     return new BehaviorTree(rootNode);

--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -1,6 +1,7 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
 import { formationEngine } from '../../game/utils/FormationEngine.js';
+import { movementTrackerManager } from '../../game/utils/MovementTrackerManager.js';
 
 class MoveToTargetNode extends Node {
     constructor({ animationEngine, cameraControl }) {
@@ -66,7 +67,8 @@ class MoveToTargetNode extends Node {
             finalCell.sprite = unit.sprite;
         }
 
-        // 이동 완료 플래그 설정
+        // 이동 완료 기록 및 플래그 설정
+        movementTrackerManager.recordMovement(unit.uniqueId);
         blackboard.set('hasMovedThisTurn', true);
 
         debugAIManager.logNodeResult(NodeState.SUCCESS);

--- a/src/ai/nodes/SpendActionPointNode.js
+++ b/src/ai/nodes/SpendActionPointNode.js
@@ -1,0 +1,23 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { actionPointEngine } from '../../game/utils/ActionPointEngine.js';
+
+/**
+ * 이동을 위해 행동력(AP) 1을 소모하는 노드
+ */
+class SpendActionPointNode extends Node {
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+
+        if (actionPointEngine.getPoints(unit.uniqueId) >= 1) {
+            actionPointEngine.spendPoint(unit.uniqueId, 1);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, '이동을 위해 행동력 1 소모');
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '행동력 부족');
+        return NodeState.FAILURE;
+    }
+}
+
+export default SpendActionPointNode;


### PR DESCRIPTION
## Summary
- log unit movements via `MovementTrackerManager`
- spend action points before moving
- split AI behavior into movement and skill phases
- update melee, ranged, and healer AI trees
- include new `SpendActionPointNode`

## Testing
- `node tests/movement_stat_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6885160071dc8327a90138cfe5f5546f