### PR TITLE
Implement movement decision nodes

### DIFF
--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -11,11 +11,9 @@ import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
 import UseSkillNode from '../nodes/UseSkillNode.js';
 // ✨ FindPathToSkillRangeNode 대신 FindKitingPositionNode를 공격 이동에도 사용합니다.
 import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
+import ShouldRangedUnitMoveNode from '../nodes/ShouldRangedUnitMoveNode.js';
 
 // 기존 Ranged AI의 핵심 로직 노드들
-import IsTargetTooCloseNode from '../nodes/IsTargetTooCloseNode.js';
-import FindMeleeStrategicTargetNode from '../nodes/FindMeleeStrategicTargetNode.js';
-import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 // ✨ HasNotMovedNode를 import합니다.
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import SpendActionPointNode from '../nodes/SpendActionPointNode.js';
@@ -49,17 +47,9 @@ function createRangedAI(engines = {}) {
 
     const movementPhase = new SelectorNode([
         new SequenceNode([
-            new HasNotMovedNode(),
+            new ShouldRangedUnitMoveNode(),
             new SpendActionPointNode(),
-            new IsTargetTooCloseNode({ ...engines, dangerZone: 2 }),
             new FindKitingPositionNode(engines),
-            new MoveToTargetNode(engines)
-        ]),
-        new SequenceNode([
-            new HasNotMovedNode(),
-            new SpendActionPointNode(),
-            new FindMeleeStrategicTargetNode(engines),
-            new FindPathToTargetNode(engines),
             new MoveToTargetNode(engines)
         ]),
         new SuccessNode()

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -14,7 +14,8 @@ import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
 
 // 힐러 전용 이동 노드
 import FindSafeHealingPositionNode from '../nodes/FindSafeHealingPositionNode.js';
-import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
+import ShouldHealerMoveNode from '../nodes/ShouldHealerMoveNode.js';
 
 /**
  * 힐러 유닛을 위한 행동 트리를 생성합니다.
@@ -37,9 +38,12 @@ function createHealerAI(engines = {}) {
 
     const movementPhase = new SelectorNode([
         new SequenceNode([
-            new HasNotMovedNode(),
+            new ShouldHealerMoveNode(),
             new SpendActionPointNode(),
-            new FindSafeRepositionNode(engines),
+            new SelectorNode([
+                new FindKitingPositionNode(engines),
+                new FindSafeHealingPositionNode(engines)
+            ]),
             new MoveToTargetNode(engines)
         ]),
         new SuccessNode()

--- a/src/ai/nodes/ShouldHealerMoveNode.js
+++ b/src/ai/nodes/ShouldHealerMoveNode.js
@@ -1,0 +1,62 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { actionPointEngine } from '../../game/utils/ActionPointEngine.js';
+import { movementTrackerManager } from '../../game/utils/MovementTrackerManager.js';
+
+/**
+ * 힐러 유닛이 이동해야 하는지 판단하는 조건 노드.
+ * 생존(카이팅) 또는 임무(치유)를 위해 이동이 필요할 때 SUCCESS를 반환합니다.
+ */
+class ShouldHealerMoveNode extends Node {
+    constructor() {
+        super();
+        this.dangerZone = 3; // 힐러는 더 넓은 안전거리를 확보합니다.
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+
+        // 기본 조건: 이미 움직였거나 AP가 없으면 이동 불가
+        if (movementTrackerManager.hasMoved(unit.uniqueId) || actionPointEngine.getPoints(unit.uniqueId) < 1) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '이미 이동했거나 AP가 부족합니다.');
+            return NodeState.FAILURE;
+        }
+
+        const allies = blackboard.get('allyUnits');
+        const enemies = blackboard.get('enemyUnits');
+        const healRange = 2; // (임시) 힐 스킬 기본 사거리
+
+        // 판단 1 (생존): 위험한 적이 있는가?
+        if (enemies && enemies.length > 0) {
+            const isThreatened = enemies.some(enemy => {
+                const distance = Math.abs(unit.gridX - enemy.gridX) + Math.abs(unit.gridY - enemy.gridY);
+                return distance <= this.dangerZone;
+            });
+            if (isThreatened) {
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `적이 너무 가까워 생존을 위해 이동이 필요합니다.`);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        // 판단 2 (임무): 치유가 필요한데 사거리가 닿지 않는 아군이 있는가?
+        if (allies && allies.length > 0) {
+            const woundedAllies = allies.filter(a => a.currentHp < a.finalStats.hp);
+            if (woundedAllies.length > 0) {
+                const isAnyWoundedAllyOutOfRange = woundedAllies.some(ally => {
+                    const distance = Math.abs(unit.gridX - ally.gridX) + Math.abs(unit.gridY - ally.gridY);
+                    return distance > healRange;
+                });
+                if (isAnyWoundedAllyOutOfRange) {
+                    debugAIManager.logNodeResult(NodeState.SUCCESS, `치유할 아군이 사거리 밖에 있어 이동이 필요합니다.`);
+                    return NodeState.SUCCESS;
+                }
+            }
+        }
+
+        // 위 모든 상황에 해당하지 않으면 이동 불필요
+        debugAIManager.logNodeResult(NodeState.FAILURE, '현재 위치가 최적이므로 이동이 불필요합니다.');
+        return NodeState.FAILURE;
+    }
+}
+
+export default ShouldHealerMoveNode;

--- a/src/ai/nodes/ShouldRangedUnitMoveNode.js
+++ b/src/ai/nodes/ShouldRangedUnitMoveNode.js
@@ -1,0 +1,61 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { actionPointEngine } from '../../game/utils/ActionPointEngine.js';
+import { movementTrackerManager } from '../../game/utils/MovementTrackerManager.js';
+import { targetManager } from '../../game/utils/TargetManager.js';
+
+/**
+ * 원거리 유닛이 이동해야 하는지 판단하는 조건 노드.
+ * 카이팅(후퇴) 또는 교전(접근)이 필요할 때 SUCCESS를 반환합니다.
+ */
+class ShouldRangedUnitMoveNode extends Node {
+    constructor() {
+        super();
+        this.dangerZone = 2; // 이 거리 안으로 적이 들어오면 위험하다고 판단
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+
+        // 기본 조건: 이미 움직였거나 AP가 없으면 이동 불가
+        if (movementTrackerManager.hasMoved(unit.uniqueId) || actionPointEngine.getPoints(unit.uniqueId) < 1) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '이미 이동했거나 AP가 부족합니다.');
+            return NodeState.FAILURE;
+        }
+
+        const enemyUnits = blackboard.get('enemyUnits');
+        if (!enemyUnits || enemyUnits.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '주변에 적이 없어 이동이 불필요합니다.');
+            return NodeState.FAILURE;
+        }
+
+        // 판단 1: 카이팅이 필요한가? (적이 너무 가까운가?)
+        const nearestEnemy = targetManager.findNearestEnemy(unit, enemyUnits);
+        if (nearestEnemy) {
+            const distance = Math.abs(unit.gridX - nearestEnemy.gridX) + Math.abs(unit.gridY - nearestEnemy.gridY);
+            if (distance <= this.dangerZone) {
+                blackboard.set('threateningUnit', nearestEnemy); // 카이팅 대상을 블랙보드에 기록
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `적이 위험지역 내에 있어 카이팅이 필요합니다.`);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        // 판단 2: 교전이 필요한가? (모든 적이 사거리 밖에 있는가?)
+        const attackRange = unit.finalStats.attackRange || 3;
+        const enemiesInRange = enemyUnits.filter(e => {
+            const distance = Math.abs(unit.gridX - e.gridX) + Math.abs(unit.gridY - e.gridY);
+            return e.currentHp > 0 && distance <= attackRange;
+        });
+
+        if (enemiesInRange.length === 0) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, '모든 적이 사거리 밖에 있어 교전을 위해 이동이 필요합니다.');
+            return NodeState.SUCCESS;
+        }
+
+        // 위 모든 상황에 해당하지 않으면, 현재 위치가 최적이므로 이동 불필요
+        debugAIManager.logNodeResult(NodeState.FAILURE, '현재 위치가 최적이므로 이동이 불필요합니다.');
+        return NodeState.FAILURE;
+    }
+}
+
+export default ShouldRangedUnitMoveNode;


### PR DESCRIPTION
## Summary
- add ShouldRangedUnitMoveNode for kiting or closing range
- add ShouldHealerMoveNode for healer-specific movement logic
- update RangedAI to use ShouldRangedUnitMoveNode
- update createHealerAI to use ShouldHealerMoveNode

## Testing
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &` then `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6885182ace6c8327ac7d32acefc7916e