### PR TITLE
Add AP debug logger and move skill slot

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -760,6 +760,12 @@ body {
 .merc-skill-slot.buff-slot { border-color: #1E90FF; }
 .merc-skill-slot.debuff-slot { border-color: #DC143C; }
 .merc-skill-slot.passive-slot { border-color: #32CD32; }
+/* 이동 스킬 슬롯 */
+.merc-skill-slot.move-slot,
+.skill-slot.move-slot {
+    border-color: #a0aec0;
+    cursor: default;
+}
 /* ✨ [수정] 소환 스킬 슬롯 스타일 */
 .merc-skill-slot.summon-slot {
     border-color: #9966CC;
@@ -1108,6 +1114,19 @@ body {
 .combat-token-container {
     display: flex;
     gap: 4px;
+}
+
+.combat-ap-container {
+    display: flex;
+    gap: 4px;
+    border-right: 2px solid #555;
+    padding-right: 12px;
+    margin-right: 6px;
+}
+
+.combat-ap-icon {
+    width: 20px;
+    height: 20px;
 }
 
 .combat-token-icon {

--- a/src/game/data/monster.js
+++ b/src/game/data/monster.js
@@ -22,14 +22,15 @@ export const monsterData = {
             // 1. 새 인스턴스를 생성하고 ID를 받습니다.
             const newInstance = skillInventoryManager.addSkillById(skillId, grade);
 
-            // 2. 생성된 스킬을 좀비에게 장착합니다. (워리어와 일관성을 위해 4번 슬롯에)
-            ownedSkillsManager.equipSkill(unit.uniqueId, 3, newInstance.instanceId);
+            // 2. 소환 스킬 전용 슬롯을 먼저 추가합니다.
+            unit.skillSlots.push('SUMMON');
 
-            // 3. 이 스킬은 몬스터 전용이므로, 플레이어의 인벤토리 목록에서는 제거합니다.
+            // 3. 생성된 스킬을 좀비에게 장착합니다. (5번 슬롯에 고정)
+            ownedSkillsManager.equipSkill(unit.uniqueId, 4, newInstance.instanceId);
+
+            // 4. 이 스킬은 몬스터 전용이므로, 플레이어의 인벤토리 목록에서는 제거합니다.
             // (하지만 다른 시스템이 참조할 수 있도록 instanceMap에는 남겨둡니다.)
             skillInventoryManager.removeSkillFromInventoryList(newInstance.instanceId);
-            // 4. 소환 스킬 전용 슬롯을 추가합니다.
-            unit.skillSlots.push('SUMMON');
         }
     }
 };

--- a/src/game/debug/DebugAPManager.js
+++ b/src/game/debug/DebugAPManager.js
@@ -1,0 +1,33 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * 유닛의 행동력(AP) 변화를 추적하고 로그를 남기는 디버그 매니저
+ */
+class DebugAPManager {
+    constructor() {
+        this.name = 'DebugAP';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * AP 변화 로그를 기록합니다.
+     * @param {string} unitName - 유닛 이름
+     * @param {number} change - 변화량 (+1 또는 -1)
+     * @param {number} newTotal - 변화 후 총 AP
+     * @param {string} reason - 변화 이유
+     */
+    logAPChange(unitName, change, newTotal, reason) {
+        const sign = change > 0 ? '+' : '';
+        const message = `${unitName} AP ${sign}${change} -> 현재 ${newTotal} AP (${reason})`;
+        debugLogEngine.log(this.name, message);
+    }
+
+    /**
+     * AP 시스템 초기화 로그를 기록합니다.
+     */
+    logInitialization(unitCount) {
+        debugLogEngine.log(this.name, `모든 유닛(${unitCount}명)의 AP 데이터를 초기화했습니다.`);
+    }
+}
+
+export const debugAPManager = new DebugAPManager();

--- a/src/game/dom/CombatUIManager.js
+++ b/src/game/dom/CombatUIManager.js
@@ -4,6 +4,7 @@ import { statusEffects } from '../data/status-effects.js';
 import { ownedSkillsManager } from '../utils/OwnedSkillsManager.js';
 import { skillInventoryManager } from '../utils/SkillInventoryManager.js';
 import { cooldownManager } from '../utils/CooldownManager.js';
+import { actionPointEngine } from '../utils/ActionPointEngine.js';
 
 /**
  * 전투 중 활성화된 유닛의 상세 정보를 표시하는 하단 UI 매니저 (최적화 버전)
@@ -64,12 +65,16 @@ export class CombatUIManager {
         const bottomRow = document.createElement('div');
         bottomRow.className = 'combat-bottom-row';
 
+        this.apContainer = document.createElement('div');
+        this.apContainer.className = 'combat-ap-container';
+
         this.tokenContainer = document.createElement('div');
         this.tokenContainer.className = 'combat-token-container';
         
         this.skillContainer = document.createElement('div');
         this.skillContainer.className = 'combat-skill-container';
 
+        bottomRow.appendChild(this.apContainer);
         bottomRow.appendChild(this.tokenContainer);
         bottomRow.appendChild(this.skillContainer);
 
@@ -114,6 +119,7 @@ export class CombatUIManager {
         // 매번 업데이트가 필요한 정보들
         this.updateHealth(unit);
         this.updateTokens(unit);
+        this.updateActionPoints(unit);
         this.updateEffects(unit);
         this.updateSkills(unit); // 쿨타임 등 업데이트
 
@@ -155,6 +161,23 @@ export class CombatUIManager {
                 tokenImg.src = 'assets/images/battle/token.png';
                 tokenImg.className = 'combat-token-icon';
                 this.tokenContainer.appendChild(tokenImg);
+            }
+        }
+    }
+
+    /**
+     * 유닛의 행동력 아이콘을 업데이트합니다.
+     * @param {object} unit
+     */
+    updateActionPoints(unit) {
+        const currentPoints = actionPointEngine.getPoints(unit.uniqueId);
+        if (this.apContainer.children.length !== currentPoints) {
+            this.apContainer.innerHTML = '';
+            for (let i = 0; i < currentPoints; i++) {
+                const apImg = document.createElement('img');
+                apImg.src = 'assets/images/battle/AP.png';
+                apImg.className = 'combat-ap-icon';
+                this.apContainer.appendChild(apImg);
             }
         }
     }

--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -128,6 +128,19 @@ export class SkillManagementDOMEngine {
 
     createSkillSlotElement(slotType, index, instanceId) {
         const slot = document.createElement('div');
+
+        if (slotType === 'MOVE') {
+            slot.className = 'merc-skill-slot move-slot';
+            slot.dataset.slotIndex = index;
+            slot.dataset.slotType = slotType;
+            slot.style.backgroundImage = 'url(assets/images/skills/move.png)';
+            slot.draggable = false;
+            const rank = document.createElement('span');
+            rank.innerText = '0 순위';
+            slot.appendChild(rank);
+            return slot;
+        }
+
         slot.className = `merc-skill-slot ${slotType.toLowerCase()}-slot`;
         slot.dataset.slotIndex = index;
         slot.dataset.slotType = slotType;
@@ -135,7 +148,7 @@ export class SkillManagementDOMEngine {
         if (instanceId) {
             const instanceData = skillInventoryManager.getInstanceData(instanceId);
             const baseSkillData = skillInventoryManager.getSkillData(instanceData.skillId, instanceData.grade);
-            const modifiedSkill = skillModifierEngine.getModifiedSkill(baseSkillData, index + 1, instanceData.grade);
+            const modifiedSkill = skillModifierEngine.getModifiedSkill(baseSkillData, index, instanceData.grade);
 
             // 등급별 테두리 클래스를 부여합니다.
             slot.classList.add(`grade-${instanceData.grade.toLowerCase()}`);
@@ -166,7 +179,7 @@ export class SkillManagementDOMEngine {
         slot.ondrop = e => this.onDropOnSlot(e);
 
         const rank = document.createElement('span');
-        rank.innerText = `${index + 1} 순위`;
+        rank.innerText = `${index} 순위`;
         slot.appendChild(rank);
 
         return slot;

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -78,10 +78,20 @@ export class UnitDetailDOM {
 
         if (unitData.skillSlots && unitData.skillSlots.length > 0) {
             unitData.skillSlots.forEach((slotType, index) => {
+                const slot = document.createElement('div');
+
+                if (slotType === 'MOVE') {
+                    slot.className = 'skill-slot move-slot';
+                    slot.style.backgroundImage = 'url(assets/images/skills/move.png)';
+                    slot.draggable = false;
+                    slot.innerHTML = `<span class="slot-rank">0 순위</span>`;
+                    skillGrid.appendChild(slot);
+                    return;
+                }
+
                 const typeClass = `${slotType.toLowerCase()}-slot`;
                 const instanceId = equippedSkills[index];
 
-                const slot = document.createElement('div');
                 slot.className = `skill-slot ${typeClass}`;
 
                 let bgImage = 'url(assets/images/skills/skill-slot.png)';
@@ -89,12 +99,11 @@ export class UnitDetailDOM {
                     const instData = skillInventoryManager.getInstanceData(instanceId);
                     const baseSkillData = skillInventoryManager.getSkillData(instData.skillId, instData.grade);
                     if (baseSkillData) {
-                        const modifiedSkill = skillModifierEngine.getModifiedSkill(baseSkillData, index + 1, instData.grade);
+                        const modifiedSkill = skillModifierEngine.getModifiedSkill(baseSkillData, index, instData.grade);
                         bgImage = `url(${modifiedSkill.illustrationPath})`;
                         slot.onmouseenter = (e) => SkillTooltipManager.show(modifiedSkill, e, instData.grade);
                         slot.onmouseleave = () => SkillTooltipManager.hide();
 
-                        // 등급 표시를 위한 클래스와 별 이미지 추가
                         slot.classList.add(`grade-${instData.grade.toLowerCase()}`);
                         const starsContainer = document.createElement('div');
                         starsContainer.className = 'grade-stars';
@@ -109,7 +118,7 @@ export class UnitDetailDOM {
                 }
                 slot.style.backgroundImage = bgImage;
 
-                slot.innerHTML += `<span class="slot-rank">${index + 1} 순위</span>`;
+                slot.innerHTML += `<span class="slot-rank">${index} 순위</span>`;
                 skillGrid.appendChild(slot);
             });
         }

--- a/src/game/utils/ActionPointEngine.js
+++ b/src/game/utils/ActionPointEngine.js
@@ -1,4 +1,5 @@
 import { debugLogEngine } from './DebugLogEngine.js';
+import { debugAPManager } from '../debug/DebugAPManager.js';
 
 /**
  * \uc720\ub2c8\uc758 \ud560\ub85c\uadf8(AP)\uc744 \uad00\ub9ac\ud558\ub294 \uc5d4\uc9c4 (\uc2f1\uae00\ud134)
@@ -22,7 +23,7 @@ class ActionPointEngine {
                 unitName: unit.instanceName
             });
         });
-        debugLogEngine.log('ActionPointEngine', `${units.length}명의 유닛 AP 정보 초기화 완료.`);
+        debugAPManager.logInitialization(units.length);
     }
 
     /**
@@ -31,7 +32,7 @@ class ActionPointEngine {
     addPointForNewTurn() {
         for (const [unitId, data] of this.apData.entries()) {
             data.currentPoints++;
-            debugLogEngine.log('ActionPointEngine', `${data.unitName} (ID: ${unitId})의 턴 시작, AP 1 획득. 현재 AP: ${data.currentPoints}`);
+            debugAPManager.logAPChange(data.unitName, 1, data.currentPoints, '새 턴 시작');
         }
     }
 
@@ -45,7 +46,7 @@ class ActionPointEngine {
         const data = this.apData.get(unitId);
         if (data && data.currentPoints >= amount) {
             data.currentPoints -= amount;
-            debugLogEngine.log('ActionPointEngine', `${data.unitName} (ID: ${unitId})이(가) AP ${amount} 소모. 남은 AP: ${data.currentPoints}`);
+            debugAPManager.logAPChange(data.unitName, -amount, data.currentPoints, '행동 소모');
             return true;
         }
         debugLogEngine.warn('ActionPointEngine', `유닛(ID:${unitId}) AP 부족으로 ${amount} 사용 실패.`);

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -45,45 +45,44 @@ class MercenaryEngine {
         const nonAidSkillTypes = ['ACTIVE', 'BUFF', 'DEBUFF', 'PASSIVE'];
 
         if (newInstance.id === 'warrior') {
-            newInstance.skillSlots = skillEngine.generateRandomSkillSlots(nonAidSkillTypes);
-            // 4번째 슬롯을 'ACTIVE' 타입으로 고정
+            const randomSlots = skillEngine.generateRandomSkillSlots(nonAidSkillTypes);
+            newInstance.skillSlots = ['MOVE', ...randomSlots];
             newInstance.skillSlots.push('ACTIVE');
 
             // 인벤토리에서 'attack' 스킬 인스턴스를 소비하고, 동일한 스킬을 새로 생성하여 장착합니다.
             const consumed = skillInventoryManager.findAndRemoveInstanceOfSkill('attack');
             if (consumed) {
                 const attackInstance = skillInventoryManager.addSkillById('attack', consumed.grade);
-                // 4번 슬롯(인덱스 3)에 장착
-                ownedSkillsManager.equipSkill(newInstance.uniqueId, 3, attackInstance.instanceId);
+                // 5번 슬롯(인덱스 4)에 장착
+                ownedSkillsManager.equipSkill(newInstance.uniqueId, 4, attackInstance.instanceId);
                 // 새로 생성된 인스턴스는 용병 전용이므로 인벤토리 목록에서는 제거합니다.
                 skillInventoryManager.removeSkillFromInventoryList(attackInstance.instanceId);
             }
         } else if (newInstance.id === 'gunner') {
-            newInstance.skillSlots = skillEngine.generateRandomSkillSlots(nonAidSkillTypes);
-            // 거너를 위한 4번째 슬롯 처리
+            const randomSlots = skillEngine.generateRandomSkillSlots(nonAidSkillTypes);
+            newInstance.skillSlots = ['MOVE', ...randomSlots];
             newInstance.skillSlots.push('ACTIVE');
 
             const consumed = skillInventoryManager.findAndRemoveInstanceOfSkill('rangedAttack');
             if (consumed) {
                 const attackInstance = skillInventoryManager.addSkillById('rangedAttack', consumed.grade);
-                ownedSkillsManager.equipSkill(newInstance.uniqueId, 3, attackInstance.instanceId);
+                ownedSkillsManager.equipSkill(newInstance.uniqueId, 4, attackInstance.instanceId);
                 skillInventoryManager.removeSkillFromInventoryList(attackInstance.instanceId);
             }
-        } else if (newInstance.id === 'medic') { 
-            // ✨ [핵심 변경] 메딕의 랜덤 슬롯은 AID, BUFF, PASSIVE 중에서만 생성합니다.
-            newInstance.skillSlots = skillEngine.generateRandomSkillSlots(['AID', 'BUFF', 'PASSIVE']);
-            // 4번째 슬롯을 'AID'로 고정합니다.
+        } else if (newInstance.id === 'medic') {
+            const randomSlots = skillEngine.generateRandomSkillSlots(['AID', 'BUFF', 'PASSIVE']);
+            newInstance.skillSlots = ['MOVE', ...randomSlots];
             newInstance.skillSlots.push('AID');
             const consumed = skillInventoryManager.findAndRemoveInstanceOfSkill('heal');
             if (consumed) {
                 const instance = skillInventoryManager.addSkillById('heal', consumed.grade);
-                ownedSkillsManager.equipSkill(newInstance.uniqueId, 3, instance.instanceId);
+                ownedSkillsManager.equipSkill(newInstance.uniqueId, 4, instance.instanceId);
                 skillInventoryManager.removeSkillFromInventoryList(instance.instanceId);
             }
         } else {
             // 다른 클래스는 기본 규칙을 따릅니다.
-            newInstance.skillSlots = skillEngine.generateRandomSkillSlots();
-            // 4번째 슬롯을 빈 슬롯(null)으로 추가
+            const randomSlots = skillEngine.generateRandomSkillSlots();
+            newInstance.skillSlots = ['MOVE', ...randomSlots];
             newInstance.skillSlots.push(null);
         }
 

--- a/src/game/utils/MonsterEngine.js
+++ b/src/game/utils/MonsterEngine.js
@@ -23,7 +23,7 @@ class MonsterEngine {
             ...baseData,
             uniqueId: id,
             instanceName: baseData.instanceName || baseData.name || `Monster${id}`,
-            skillSlots: [null, null, null, null] // 몬스터를 위한 스킬 슬롯 초기화
+            skillSlots: ['MOVE', null, null, null] // 몬스터를 위한 스킬 슬롯 초기화
         };
 
         instance.finalStats = statEngine.calculateStats(instance, baseData.baseStats || {}, []);


### PR DESCRIPTION
## Summary
- create `DebugAPManager` to log AP changes
- integrate AP logs into `ActionPointEngine`
- show action points in combat UI
- ensure all units have a fixed move slot and update related UIs
- style AP icons and move slots

## Testing
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 & curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688519a35db083279118617b0be49c92