### PR TITLE
Fix AI turn loop

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -70,28 +70,8 @@ class AIManager {
 
         console.group(`[AIManager] --- ${data.instance.instanceName} (ID: ${unit.uniqueId}) 턴 시작 ---`);
 
-        // 반복적으로 행동 트리를 실행하여 남은 토큰이 허용하는 한 여러 번 행동합니다.
-        while (tokenEngine.getTokens(unit.uniqueId) > 0) {
-            const blackboard = data.behaviorTree.blackboard;
-            const prevTokens = tokenEngine.getTokens(unit.uniqueId);
-            const prevSkillsUsedSize = blackboard.get('usedSkillsThisTurn').size;
-            const wasMoved = blackboard.get('hasMovedThisTurn');
-
-            await data.behaviorTree.execute(unit, allUnits, enemyUnits);
-
-            const currentTokens = tokenEngine.getTokens(unit.uniqueId);
-            const currentSkillsUsedSize = blackboard.get('usedSkillsThisTurn').size;
-            const hasMoved = blackboard.get('hasMovedThisTurn');
-
-            const tokenSpent = currentTokens < prevTokens;
-            const skillUsed = currentSkillsUsedSize > prevSkillsUsedSize;
-            const movedThisLoop = !wasMoved && hasMoved;
-
-            // 토큰 소모, 스킬 사용, 이동 중 아무것도 하지 않았다면 루프를 중단합니다.
-            if (!tokenSpent && !skillUsed && !movedThisLoop) {
-                break;
-            }
-        }
+        // 행동 트리를 한 번만 실행하여 턴을 처리합니다.
+        await data.behaviorTree.execute(unit, allUnits, enemyUnits);
 
         console.groupEnd();
     }

--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -81,10 +81,18 @@ function createMeleeAI(engines = {}) {
         new SuccessNode()
     ]);
 
+    // 여러 번의 스킬 사용을 위해 스킬 단계를 반복합니다.
     const rootNode = new SelectorNode([
         new SequenceNode([
             movementPhase,
-            skillPhase
+            new SelectorNode([
+                skillPhase,
+                skillPhase,
+                skillPhase,
+                skillPhase,
+                skillPhase,
+                new SuccessNode()
+            ])
         ])
     ]);
 

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -84,10 +84,18 @@ function createRangedAI(engines = {}) {
         new SuccessNode()
     ]);
 
+    // 여러 스킬을 연속으로 사용하기 위해 스킬 단계를 반복합니다.
     const rootNode = new SelectorNode([
         new SequenceNode([
             movementPhase,
-            skillPhase
+            new SelectorNode([
+                skillPhase,
+                skillPhase,
+                skillPhase,
+                skillPhase,
+                skillPhase,
+                new SuccessNode()
+            ])
         ])
     ]);
 

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -78,10 +78,18 @@ function createHealerAI(engines = {}) {
         new SuccessNode()
     ]);
 
+    // 토큰이 남아 있다면 여러 스킬을 연속으로 사용할 수 있도록 스킬 단계를 반복합니다.
     const rootNode = new SelectorNode([
         new SequenceNode([
             movementPhase,
-            skillPhase
+            new SelectorNode([
+                skillPhase,
+                skillPhase,
+                skillPhase,
+                skillPhase,
+                skillPhase,
+                new SuccessNode()
+            ])
         ])
     ]);
 


### PR DESCRIPTION
## Summary
- execute AI behavior tree only once per turn
- repeat skill phases so AI can spend remaining tokens

## Testing
- `node tests/medic_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68851debc008832794e764119e539e41