### PR TITLE
Update melee, ranged, healer AI behavior trees

### DIFF
--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -30,20 +30,24 @@ function createHealerAI(engines = {}) {
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeHealingPositionNode(engines),
+            // ✨ 이동 전 행동력 소모
+            new SpendActionPointNode(),
             new MoveToTargetNode(engines),
             new IsSkillInRangeNode(engines),
             new UseSkillNode(engines)
         ])
     ]);
 
+    // ✨ 이동 페이즈 수정: 안전 확보(카이팅)를 최우선으로 고려하고, 이동 결정 후 AP 소모
     const movementPhase = new SelectorNode([
         new SequenceNode([
             new ShouldHealerMoveNode(),
-            new SpendActionPointNode(),
+            // 안전 위치 탐색을 우선
             new SelectorNode([
-                new FindKitingPositionNode(engines),
-                new FindSafeHealingPositionNode(engines)
+                new FindKitingPositionNode(engines), // 위협적일 때
+                new FindSafeHealingPositionNode(engines) // 아군을 치유해야 할 때
             ]),
+            new SpendActionPointNode(), // 경로 확보 후 AP 소모
             new MoveToTargetNode(engines)
         ]),
         new SuccessNode()
@@ -78,18 +82,16 @@ function createHealerAI(engines = {}) {
         new SuccessNode()
     ]);
 
-    // 토큰이 남아 있다면 여러 스킬을 연속으로 사용할 수 있도록 스킬 단계를 반복합니다.
-    const rootNode = new SelectorNode([
-        new SequenceNode([
-            movementPhase,
-            new SelectorNode([
-                skillPhase,
-                skillPhase,
-                skillPhase,
-                skillPhase,
-                skillPhase,
-                new SuccessNode()
-            ])
+    // ✨ 루트 노드 수정: 이동 후 스킬 페이즈를 여러 번 반복
+    const rootNode = new SequenceNode([
+        movementPhase,
+        new SelectorNode([
+            skillPhase,
+            skillPhase,
+            skillPhase,
+            skillPhase,
+            skillPhase,
+            new SuccessNode()
         ])
     ]);
 


### PR DESCRIPTION
## Summary
- update melee AI behavior tree to consume AP only after a path is found
- update ranged AI logic to consider kiting movement and adjust AP spending
- update healer AI logic for safer movement and repeated skill attempts

## Testing
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688522b20cc4832784e5ff9a2fd7b8a0