### PR TITLE
Add summon token registration

### DIFF
--- a/src/game/utils/SummoningEngine.js
+++ b/src/game/utils/SummoningEngine.js
@@ -6,6 +6,8 @@ import { getSummonBase } from '../data/summon.js';
 // AI 매니저와 근접 AI를 불러와 소환된 유닛을 즉시 등록할 수 있도록 합니다.
 import { aiManager } from '../../ai/AIManager.js';
 import { createMeleeAI } from '../../ai/behaviors/MeleeAI.js';
+// 소환된 유닛을 토큰 시스템에 등록하기 위해 토큰 엔진을 불러옵니다.
+import { tokenEngine } from './TokenEngine.js';
 
 /**
  * 전투 중 유닛 소환을 담당하는 엔진
@@ -60,6 +62,9 @@ class SummoningEngine {
         }
         // 소환수는 소환사와 같은 팀으로 생성됩니다.
         const summonedUnit = monsterEngine.spawnMonster(monsterBase, summoner.team);
+
+        // 생성 직후 토큰 엔진에 등록하여 바로 행동할 수 있게 합니다.
+        tokenEngine.registerUnit(summonedUnit);
 
         // 3. 소환수 전장 배치
         formationEngine.placeUnitAt(this.scene, summonedUnit, summonCell.col, summonCell.row);

--- a/src/game/utils/TokenEngine.js
+++ b/src/game/utils/TokenEngine.js
@@ -28,6 +28,22 @@ class TokenEngine {
     }
 
     /**
+     * 전투 중 새로 생성된 단일 유닛의 토큰 정보를 등록합니다.
+     * 소환수 등 전투 도중에 등장한 유닛을 위한 용도입니다.
+     * @param {object} unit - 등록할 유닛 인스턴스
+     */
+    registerUnit(unit) {
+        if (!this.tokenData.has(unit.uniqueId)) {
+            this.tokenData.set(unit.uniqueId, {
+                currentTokens: 3,
+                unitName: unit.instanceName
+            });
+            // 로그를 통해 토큰 지급 내역을 기록합니다.
+            debugTokenManager.logTokenChange(unit.uniqueId, unit.instanceName, '소환됨', 3, 3);
+        }
+    }
+
+    /**
      * 특정 유닛에게 토큰을 추가합니다.
      * @param {number} unitId - 토큰을 받을 유닛의 고유 ID
      * @param {number} amount - 추가할 토큰의 양


### PR DESCRIPTION
## Summary
- allow TokenEngine to register units dynamically with initial tokens
- ensure SummoningEngine registers summoned units with TokenEngine

## Testing
- `node tests/movement_stat_test.js && node tests/medic_skill_integration_test.js && node tests/summon_skill_integration_test.js && node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8001` *(curl debug.html)*

------
https://chatgpt.com/codex/tasks/task_e_688529daedf08327abc7877e26c9b9c9