### PR TITLE
Add team info to spawned monsters

### DIFF
--- a/src/game/utils/MonsterEngine.js
+++ b/src/game/utils/MonsterEngine.js
@@ -23,6 +23,8 @@ class MonsterEngine {
             ...baseData,
             uniqueId: id,
             instanceName: baseData.instanceName || baseData.name || `Monster${id}`,
+            // 생성된 몬스터가 어느 진영 소속인지 명확히 남겨둔다.
+            team: type,
             skillSlots: [null, null, null, null] // 몬스터를 위한 스킬 슬롯 초기화
         };
 


### PR DESCRIPTION
## Summary
- expose a `team` property when creating monsters

## Testing
- `node tests/medic_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68852cb254288327b29f25e23835faa1