### PR TITLE
Add strategy skill type and new card

### DIFF
--- a/src/ai/nodes/FindTargetBySkillTypeNode.js
+++ b/src/ai/nodes/FindTargetBySkillTypeNode.js
@@ -20,9 +20,9 @@ class FindTargetBySkillTypeNode extends Node {
         }
 
         // ✨ [수정] 스킬의 targetType을 먼저 확인하여 'self'인 경우 자신을 즉시 타겟으로 설정합니다.
-        if (skillData.targetType === 'self') {
+        if (skillData.targetType === 'self' || skillData.type === 'STRATEGY') {
             blackboard.set('skillTarget', unit);
-            debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skillData.name}]의 대상 (자신) 설정`);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skillData.name}]의 대상 (자신/전략) 설정`);
             return NodeState.SUCCESS;
         }
 

--- a/src/game/data/skills/SkillCardDatabase.js
+++ b/src/game/data/skills/SkillCardDatabase.js
@@ -4,6 +4,7 @@ import { debuffSkills } from './debuff.js';
 import { passiveSkills } from './passive.js';
 import { aidSkills } from './aid.js';
 import { summonSkills } from './summon.js';
+import { strategySkills } from './strategy.js';
 
 // 모든 스킬을 하나의 객체로 통합하여 쉽게 조회할 수 있도록 함
 export const skillCardDatabase = {
@@ -13,4 +14,5 @@ export const skillCardDatabase = {
     ...passiveSkills,
     ...aidSkills,
     ...summonSkills,
+    ...strategySkills,
 };

--- a/src/game/data/skills/strategy.js
+++ b/src/game/data/skills/strategy.js
@@ -1,0 +1,28 @@
+import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
+
+export const strategySkills = {
+    chargeOrder: {
+        NORMAL: {
+            id: 'chargeOrder',
+            name: '돌격 명령',
+            type: 'STRATEGY',
+            cost: 3,
+            targetType: 'self',
+            description: '모든 아군에게 3턴간 공격력 10% 증가 버프를 부여합니다. 전투 당 한 번만 사용할 수 있습니다.',
+            illustrationPath: 'assets/images/skills/charge-order.png',
+            cooldown: 100,
+            range: 0,
+            effect: {
+                id: 'chargeOrderBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 3,
+                isGlobal: true,
+                modifiers: {
+                    stat: 'physicalAttack',
+                    type: 'percentage',
+                    value: 0.10
+                }
+            }
+        }
+    }
+};

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -34,5 +34,11 @@ export const statusEffects = {
         id: 'ironWill',
         name: '아이언 윌',
         iconPath: 'assets/images/skills/iron_will.png',
+    },
+    // ✨ 돌격 명령 버프 추가
+    chargeOrderBuff: {
+        id: 'chargeOrderBuff',
+        name: '돌격 명령',
+        iconPath: 'assets/images/skills/charge-order.png',
     }
 };

--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -12,7 +12,9 @@ export const SKILL_TYPES = {
     // ✨ [변경] AID 타입을 하얀색 계열로 변경합니다.
     AID:    { name: '지원',   color: '#F5F5F5' },  // 하얀색 (순백색(#FFF) 대신 약간의 회색을 섞어 배경과 구분되도록 함)
     // ✨ [신규] 소환 스킬 타입 추가
-    SUMMON: { name: '소환',   color: '#9966CC' }   // 보라색 계열
+    SUMMON: { name: '소환',   color: '#9966CC' },   // 보라색 계열
+    // ✨ [신규] 전략 스킬 타입 추가
+    STRATEGY: { name: '전략',  color: '#FFD700' }   // 금색
 };
 
 /**

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -42,6 +42,11 @@ class SkillInventoryManager {
             this.addSkillById('summonAncestorPeor', 'NORMAL');
         }
 
+        // ✨ [신규] '돌격 명령' 전략 카드 3장 지급
+        for (let i = 0; i < 3; i++) {
+            this.addSkillById('chargeOrder', 'NORMAL');
+        }
+
         // 나머지 스킬은 노멀 등급으로 10장씩 생성
         for (const skillId in skillCardDatabase) {
             if (skillCardDatabase.hasOwnProperty(skillId) && skillId !== 'charge' && skillId !== 'attack') {

--- a/src/game/utils/StatusEffectManager.js
+++ b/src/game/utils/StatusEffectManager.js
@@ -99,6 +99,20 @@ class StatusEffectManager {
      */
     addEffect(targetUnit, sourceSkill) {
         if (!sourceSkill.effect) return;
+
+        // ✨ [신규] isGlobal 효과 처리
+        if (sourceSkill.effect.isGlobal) {
+            const allies = this.battleSimulator.turnQueue.filter(u => u.team === targetUnit.team && u.currentHp > 0);
+            allies.forEach(ally => {
+                this.applySingleEffect(ally, sourceSkill);
+            });
+        } else {
+            this.applySingleEffect(targetUnit, sourceSkill);
+        }
+    }
+
+    // ✨ 기존 addEffect 로직을 별도 함수로 분리
+    applySingleEffect(targetUnit, sourceSkill) {
         const effectId = sourceSkill.effect.id;
         const effectDefinition = statusEffects[effectId];
 


### PR DESCRIPTION
## Summary
- recognize new strategy skill type in `SkillEngine`
- support `chargeOrder` strategy card and register new status effect
- include strategy skills in database and starter inventory
- allow AI target search to handle strategy skills
- enable global status effects

## Testing
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68853488b3308327bdbe14e4cfd3f869