### PR TITLE
Add strategic AI state and health condition node

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -64,9 +64,18 @@ class AIManager {
         const data = this.unitData.get(unit.uniqueId);
         if (!data) return;
 
+        // ✨ [신규] 턴 시작 시, 전략적 상황을 계산하여 블랙보드에 업데이트
+        const blackboard = data.behaviorTree.blackboard;
+        const allies = allUnits.filter(u => u.team === unit.team && u.currentHp > 0);
+
+        blackboard.set('healthPercentage', unit.currentHp / unit.finalStats.hp);
+        blackboard.set('isLastAllyAlive', allies.length === 1 && allies[0].uniqueId === unit.uniqueId);
+        // (allyDeathCountSinceLastTurn는 BattleSimulatorEngine에서 처리하는 것이 더 정확하므로 일단 0으로 둡니다)
+        blackboard.set('allyDeathCountSinceLastTurn', 0);
+
         // 턴 시작 시 블랙보드 플래그 초기화
-        data.behaviorTree.blackboard.set('hasMovedThisTurn', false);
-        data.behaviorTree.blackboard.set('usedSkillsThisTurn', new Set());
+        blackboard.set('hasMovedThisTurn', false);
+        blackboard.set('usedSkillsThisTurn', new Set());
 
         console.group(`[AIManager] --- ${data.instance.instanceName} (ID: ${unit.uniqueId}) 턴 시작 ---`);
 

--- a/src/ai/Blackboard.js
+++ b/src/ai/Blackboard.js
@@ -25,6 +25,10 @@ class Blackboard {
         this.set('squadAdvantage', 0);
         this.set('enemyHealerUnit', null);
         this.set('threateningUnit', null);
+        // ✨ [신규] 전략적 상황 판단을 위한 키 추가
+        this.set('healthPercentage', 1.0); // 현재 체력 비율 (1.0 = 100%)
+        this.set('isLastAllyAlive', false); // 자신이 마지막 생존자인지 여부
+        this.set('allyDeathCountSinceLastTurn', 0); // 내 마지막 턴 이후 죽은 아군 수
 
         // --- 🤖 AI 자신의 상태 정보 ---
         this.set('canUseSkill_1', false);

--- a/src/ai/nodes/IsHealthBelowThresholdNode.js
+++ b/src/ai/nodes/IsHealthBelowThresholdNode.js
@@ -1,0 +1,29 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 자신의 체력이 지정된 비율(%) 이하인지 확인하는 조건 노드입니다.
+ */
+class IsHealthBelowThresholdNode extends Node {
+    constructor(threshold) {
+        super();
+        this.threshold = threshold; // 예: 0.35 (35%)
+    }
+
+    async evaluate(unit, blackboard) {
+        const nodeName = `IsHealthBelowThresholdNode (${this.threshold * 100}%)`;
+        debugAIManager.logNodeEvaluation({ constructor: { name: nodeName } }, unit);
+
+        const healthPercentage = blackboard.get('healthPercentage');
+
+        if (healthPercentage <= this.threshold) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `체력이 ${this.threshold * 100}% 이하임`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, `체력이 ${this.threshold * 100}% 보다 많음`);
+        return NodeState.FAILURE;
+    }
+}
+
+export default IsHealthBelowThresholdNode;


### PR DESCRIPTION
## Summary
- extend Blackboard to store more strategic info about health and ally status
- update AIManager to populate those values at the start of each turn
- add `IsHealthBelowThresholdNode` for behavior trees to check low HP

## Testing
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688535c5c9c08327b2049b5f2304ecfa