### PR TITLE
Add placeholder utilities and skill tag data

### DIFF
--- a/src/game/data/skill-tags.js
+++ b/src/game/data/skill-tags.js
@@ -1,0 +1,12 @@
+export const skillTags = {
+  attack: ['ACTIVE', 'PHYSICAL', 'MELEE'],
+  charge: ['ACTIVE', 'PHYSICAL', 'MELEE', 'DASH'],
+  stoneSkin: ['BUFF', 'EARTH'],
+  shieldBreak: ['DEBUFF', 'WEAKENING'],
+  ironWill: ['PASSIVE', 'RESOLVE'],
+  knockbackShot: ['ACTIVE', 'RANGED', 'PHYSICAL', 'KINETIC'],
+  rangedAttack: ['ACTIVE', 'RANGED', 'PHYSICAL'],
+  heal: ['AID', 'RANGED', 'HEALING'],
+  summonAncestorPeor: ['SUMMON'],
+  chargeOrder: ['STRATEGY', 'BUFF']
+};

--- a/src/game/dom/CombatUIManager.js
+++ b/src/game/dom/CombatUIManager.js
@@ -4,6 +4,7 @@ import { statusEffects } from '../data/status-effects.js';
 import { ownedSkillsManager } from '../utils/OwnedSkillsManager.js';
 import { skillInventoryManager } from '../utils/SkillInventoryManager.js';
 import { cooldownManager } from '../utils/CooldownManager.js';
+import { placeholderManager } from '../utils/PlaceholderManager.js';
 
 /**
  * 전투 중 활성화된 유닛의 상세 정보를 표시하는 하단 UI 매니저 (최적화 버전)
@@ -213,6 +214,7 @@ export class CombatUIManager {
             const icon = document.createElement('div');
             icon.className = 'combat-skill-icon';
             icon.style.backgroundImage = `url(${skillData.illustrationPath})`;
+            placeholderManager.setBackgroundImage(icon, skillData.illustrationPath);
             
             const overlay = document.createElement('div');
             overlay.className = 'skill-cooldown-overlay';
@@ -255,6 +257,7 @@ export class CombatUIManager {
         const icon = document.createElement('img');
         icon.className = 'effect-icon';
         icon.src = path;
+        placeholderManager.setImageSrc(icon, path);
         iconWrapper.appendChild(icon);
 
         if (duration !== null) {

--- a/src/game/dom/SkillTooltipManager.js
+++ b/src/game/dom/SkillTooltipManager.js
@@ -1,4 +1,5 @@
 import { SKILL_TYPES } from '../utils/SkillEngine.js';
+import { placeholderManager } from '../utils/PlaceholderManager.js';
 
 /**
  * 스킬 카드 위에 마우스를 올렸을 때 TCG 스타일의 큰 툴팁을 표시하는 매니저
@@ -25,6 +26,7 @@ export class SkillTooltipManager {
 
         tooltip.innerHTML = `
             <div class="skill-illustration-large" style="background-image: url(${skillData.illustrationPath})"></div>
+            <div class="skill-illustration-large"></div>
             <div class="skill-info-large">
                 <div class="skill-name-large">${skillNameHTML}</div>
                 <div class="skill-type-cost-large">
@@ -35,6 +37,9 @@ export class SkillTooltipManager {
                 <div class="skill-cost-container-large"></div>
             </div>
         `;
+
+        const illust = tooltip.querySelector('.skill-illustration-large');
+        placeholderManager.setBackgroundImage(illust, skillData.illustrationPath);
 
         // 별 생성 로직 추가
         const gradeMap = { 'NORMAL': 1, 'RARE': 2, 'EPIC': 3, 'LEGENDARY': 4 };

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -2,6 +2,7 @@ import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.es
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { imageSizeManager } from '../utils/ImageSizeManager.js';
 import { statusEffects } from '../data/status-effects.js';
+import { placeholderManager } from '../utils/PlaceholderManager.js';
 
 export class Preloader extends Scene
 {
@@ -54,6 +55,9 @@ export class Preloader extends Scene
     {
         // 게임에 필요한 모든 애셋을 여기서 로드합니다.
         this.load.setPath('assets');
+
+        // 개발 중 누락된 이미지에 대비한 플레이스홀더를 로드합니다.
+        this.load.image('placeholder', 'images/placeholder.png');
 
         // 로고 이미지를 로드합니다.
         this.load.image('logo', 'logo.png');

--- a/src/game/utils/PlaceholderManager.js
+++ b/src/game/utils/PlaceholderManager.js
@@ -1,0 +1,29 @@
+class PlaceholderManager {
+  constructor() {
+    this.placeholderPath = 'assets/images/placeholder.png';
+  }
+
+  setBackgroundImage(element, path) {
+    const img = new Image();
+    img.onload = () => {
+      element.style.backgroundImage = `url(${path})`;
+    };
+    img.onerror = () => {
+      element.style.backgroundImage = `url(${this.placeholderPath})`;
+    };
+    img.src = path;
+  }
+
+  setImageSrc(element, path) {
+    const img = new Image();
+    img.onload = () => {
+      element.src = path;
+    };
+    img.onerror = () => {
+      element.src = this.placeholderPath;
+    };
+    img.src = path;
+  }
+}
+
+export const placeholderManager = new PlaceholderManager();

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -1,0 +1,21 @@
+import { skillTags } from '../data/skill-tags.js';
+
+class SkillTagManager {
+  constructor() {
+    this.skillTags = { ...skillTags };
+  }
+
+  getTags(skillId) {
+    return this.skillTags[skillId] || [];
+  }
+
+  hasTag(skillId, tag) {
+    return this.getTags(skillId).includes(tag);
+  }
+
+  register(skillId, tags) {
+    this.skillTags[skillId] = tags;
+  }
+}
+
+export const skillTagManager = new SkillTagManager();


### PR DESCRIPTION
## Summary
- add placeholder image management to gracefully handle missing images
- display placeholder icons in combat and skill tooltips
- preload placeholder image in scene loader
- provide initial skill tag data and manager

## Testing
- `node tests/movement_stat_test.js && node tests/warrior_skill_integration_test.js && node tests/summon_skill_integration_test.js && node tests/medic_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68864c1054f0832782668b1f8b0abad6