### PR TITLE
Add extra skill slots for mercenaries

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -450,9 +450,17 @@ body {
 .unit-skills {
     flex-grow: 1;
 }
+.unit-skills-container {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    width: 100%;
+}
+
 .unit-skills .skill-grid {
     display: flex;
     gap: 10px;
+    justify-content: center;
     margin-top: 10px;
 }
 .unit-skills .skill-slot {
@@ -474,6 +482,7 @@ body {
 
 /* --- ✨ [신규] AID 타입 스타일 추가 --- */
 .unit-skills .skill-slot.aid-slot { border-color: #F5F5F5; }
+.unit-skills .skill-slot.empty-slot { border-color: #555; }
 
 .skill-slot .slot-rank {
     position: absolute;
@@ -743,6 +752,22 @@ body {
     padding-top: 20px;
 }
 
+.merc-skill-slots-container-vertical {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.section-title-small {
+    font-size: 16px;
+    font-weight: bold;
+    text-align: center;
+    color: #ccc;
+    margin-bottom: 10px;
+    border-bottom: 1px solid #555;
+    padding-bottom: 5px;
+}
+
 .merc-skill-slot {
     width: 80px;
     height: 80px;
@@ -764,6 +789,10 @@ body {
 .merc-skill-slot.summon-slot {
     border-color: #9966CC;
     border-width: 4px;
+}
+.merc-skill-slot.empty-slot {
+    border-color: #555;
+    cursor: default;
 }
 .merc-skill-slot span {
     background-color: rgba(0,0,0,0.7);

--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -114,13 +114,32 @@ export class SkillManagementDOMEngine {
         this.mercenaryDetailsContent.appendChild(portrait);
 
         const slotsContainer = document.createElement('div');
-        slotsContainer.className = 'merc-skill-slots-container';
+        slotsContainer.className = 'merc-skill-slots-container-vertical';
+
+        const mainSkillsSection = document.createElement('div');
+        mainSkillsSection.innerHTML = `<div class="section-title-small">주스킬</div>`;
+        const mainSlotsContainer = document.createElement('div');
+        mainSlotsContainer.className = 'merc-skill-slots-container';
+        mainSkillsSection.appendChild(mainSlotsContainer);
+
+        const specialSkillsSection = document.createElement('div');
+        specialSkillsSection.innerHTML = `<div class="section-title-small">특수스킬</div>`;
+        const specialSlotsContainer = document.createElement('div');
+        specialSlotsContainer.className = 'merc-skill-slots-container';
+        specialSkillsSection.appendChild(specialSlotsContainer);
+
+        slotsContainer.appendChild(mainSkillsSection);
+        slotsContainer.appendChild(specialSkillsSection);
 
         const equipped = ownedSkillsManager.getEquippedSkills(mercData.uniqueId);
 
         mercData.skillSlots.forEach((slotType, idx) => {
             const slot = this.createSkillSlotElement(slotType, idx, equipped[idx]);
-            slotsContainer.appendChild(slot);
+            if (idx < 4) {
+                mainSlotsContainer.appendChild(slot);
+            } else {
+                specialSlotsContainer.appendChild(slot);
+            }
         });
 
         this.mercenaryDetailsContent.appendChild(slotsContainer);
@@ -128,7 +147,8 @@ export class SkillManagementDOMEngine {
 
     createSkillSlotElement(slotType, index, instanceId) {
         const slot = document.createElement('div');
-        slot.className = `merc-skill-slot ${slotType.toLowerCase()}-slot`;
+        const typeClass = slotType ? `${slotType.toLowerCase()}-slot` : 'empty-slot';
+        slot.className = `merc-skill-slot ${typeClass}`;
         slot.dataset.slotIndex = index;
         slot.dataset.slotType = slotType;
 
@@ -226,7 +246,8 @@ export class SkillManagementDOMEngine {
             alert(`이 스킬은 ${draggedSkillData.requiredClass} 전용입니다.`);
             return;
         }
-        if (draggedSkillData.type !== targetSlotType) {
+        // 특수 스킬 슬롯(index 4 이상)은 타입 검사를 하지 않습니다.
+        if (targetSlotIndex < 4 && draggedSkillData.type !== targetSlotType) {
             alert('스킬과 슬롯의 타입이 일치하지 않습니다.');
             return;
         }

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -66,19 +66,33 @@ export class UnitDetailDOM {
         const rightSection = document.createElement('div');
         rightSection.className = 'detail-section right';
         
+        // --- 스킬 컨테이너 구조 변경 ---
         const skillsContainer = document.createElement('div');
-        skillsContainer.className = 'unit-skills';
-        skillsContainer.innerHTML = `<div class="section-title">스킬 슬롯</div>`;
+        skillsContainer.className = 'unit-skills-container';
 
-        const skillGrid = document.createElement('div');
-        skillGrid.className = 'skill-grid';
+        const mainSkillsSection = document.createElement('div');
+        mainSkillsSection.className = 'unit-skills';
+        mainSkillsSection.innerHTML = `<div class="section-title">주스킬</div>`;
+        const mainSkillGrid = document.createElement('div');
+        mainSkillGrid.className = 'skill-grid';
+        mainSkillsSection.appendChild(mainSkillGrid);
+
+        const specialSkillsSection = document.createElement('div');
+        specialSkillsSection.className = 'unit-skills';
+        specialSkillsSection.innerHTML = `<div class="section-title">특수스킬</div>`;
+        const specialSkillGrid = document.createElement('div');
+        specialSkillGrid.className = 'skill-grid';
+        specialSkillsSection.appendChild(specialSkillGrid);
+
+        skillsContainer.appendChild(mainSkillsSection);
+        skillsContainer.appendChild(specialSkillsSection);
 
         const equippedSkills = ownedSkillsManager.getEquippedSkills(unitData.uniqueId);
         const gradeMap = { NORMAL: 1, RARE: 2, EPIC: 3, LEGENDARY: 4 };
 
         if (unitData.skillSlots && unitData.skillSlots.length > 0) {
             unitData.skillSlots.forEach((slotType, index) => {
-                const typeClass = `${slotType.toLowerCase()}-slot`;
+                const typeClass = slotType ? `${slotType.toLowerCase()}-slot` : 'empty-slot';
                 const instanceId = equippedSkills[index];
 
                 const slot = document.createElement('div');
@@ -110,11 +124,14 @@ export class UnitDetailDOM {
                 slot.style.backgroundImage = bgImage;
 
                 slot.innerHTML += `<span class="slot-rank">${index + 1} 순위</span>`;
-                skillGrid.appendChild(slot);
+                if (index < 4) {
+                    mainSkillGrid.appendChild(slot);
+                } else {
+                    specialSkillGrid.appendChild(slot);
+                }
             });
         }
 
-        skillsContainer.appendChild(skillGrid);
         rightSection.appendChild(skillsContainer);
 
         detailContent.appendChild(leftSection);

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -87,8 +87,8 @@ class MercenaryEngine {
             newInstance.skillSlots.push(null);
         }
 
-        // ✨ [신규] 5번째 슬롯은 소환 스킬 전용으로 고정합니다.
-        newInstance.skillSlots.push('SUMMON');
+        // 5~8번째 특수 스킬 슬롯을 추가합니다. (현재는 비어있음)
+        newInstance.skillSlots.push(null, null, null, null);
 
         newInstance.finalStats = statEngine.calculateStats(newInstance, newInstance.baseStats, newInstance.equippedItems);
 

--- a/src/game/utils/OwnedSkillsManager.js
+++ b/src/game/utils/OwnedSkillsManager.js
@@ -13,8 +13,8 @@ class OwnedSkillsManager {
 
     initializeSlots(unitId) {
         if (!this.equippedSkills.has(unitId)) {
-            // ✨ [수정] 기본 장착 슬롯을 5개로 확장합니다.
-            this.equippedSkills.set(unitId, [null, null, null, null, null]);
+            // 기본 장착 슬롯을 8개로 확장합니다.
+            this.equippedSkills.set(unitId, [null, null, null, null, null, null, null, null]);
         }
     }
 


### PR DESCRIPTION
## Summary
- expand mercenary skill slot count to eight
- update skill management and detail UI to separate main/special slots
- handle new slot type logic in managers and DOM
- tweak styles for new slot layout

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688662b8ab7883279e736cef580e9ca7