### PR TITLE
Add shared resource UI

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1286,3 +1286,42 @@ body {
     border: 1px solid #555;
     white-space: nowrap;
 }
+
+/* --- 공유 자원 패널 스타일 --- */
+#shared-resource-container {
+    position: absolute;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: auto;
+    background-color: rgba(0, 0, 0, 0.7);
+    border: 1px solid #555;
+    border-radius: 8px;
+    padding: 8px 15px;
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    z-index: 150;
+    pointer-events: none;
+    color: #fff;
+    font-family: sans-serif;
+    font-size: 16px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.5);
+}
+
+.resource-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.resource-name {
+    color: #aaa;
+}
+
+.resource-value {
+    font-weight: bold;
+    color: #f0e68c; /* 밝은 노란색 */
+    min-width: 20px; /* 숫자가 바뀔 때 레이아웃이 흔들리지 않도록 */
+    text-align: left;
+}

--- a/src/game/dom/SharedResourceUIManager.js
+++ b/src/game/dom/SharedResourceUIManager.js
@@ -1,0 +1,88 @@
+import { SHARED_RESOURCE_TYPES, sharedResourceEngine } from '../utils/SharedResourceEngine.js';
+
+/**
+ * 전투 중 공유 자원 현황을 표시하는 상단 UI 매니저
+ */
+export class SharedResourceUIManager {
+    constructor() {
+        this.container = document.getElementById('shared-resource-container');
+        if (!this.container) {
+            this.container = document.createElement('div');
+            this.container.id = 'shared-resource-container';
+            document.getElementById('ui-container').appendChild(this.container);
+        }
+
+        // 각 자원의 숫자 값을 업데이트하기 위해 DOM 요소 참조를 저장합니다.
+        this.resourceValueElements = new Map();
+
+        this._createLayout();
+        this.container.style.display = 'none'; // 초기에는 숨김
+    }
+
+    /**
+     * UI의 기본 레이아웃을 생성합니다.
+     * @private
+     */
+    _createLayout() {
+        this.container.innerHTML = ''; // 초기화
+
+        Object.entries(SHARED_RESOURCE_TYPES).forEach(([key, name]) => {
+            const resourceItem = document.createElement('div');
+            resourceItem.className = 'resource-item';
+
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'resource-name';
+            nameSpan.innerText = `${name} -`;
+
+            const valueSpan = document.createElement('span');
+            valueSpan.className = 'resource-value';
+            valueSpan.id = `resource-value-${key}`;
+            valueSpan.innerText = '0';
+
+            resourceItem.appendChild(nameSpan);
+            resourceItem.appendChild(valueSpan);
+            this.container.appendChild(resourceItem);
+
+            // 나중에 빠르게 접근하기 위해 값(value) span을 맵에 저장합니다.
+            this.resourceValueElements.set(key, valueSpan);
+        });
+    }
+
+    /**
+     * 현재 자원 상태에 맞춰 UI를 업데이트합니다.
+     */
+    update() {
+        const allResources = sharedResourceEngine.getAllResources();
+        for (const [type, value] of Object.entries(allResources)) {
+            const element = this.resourceValueElements.get(type);
+            if (element && element.innerText !== value.toString()) {
+                element.innerText = value;
+            }
+        }
+    }
+
+    /**
+     * UI를 화면에 표시합니다.
+     */
+    show() {
+        this.container.style.display = 'flex';
+        this.update(); // 표시될 때 최신 값으로 갱신
+    }
+
+    /**
+     * UI를 화면에서 숨깁니다.
+     */
+    hide() {
+        this.container.style.display = 'none';
+    }
+
+    /**
+     * UI 요소를 DOM에서 완전히 제거합니다.
+     */
+    destroy() {
+        if (this.container) {
+            this.container.remove();
+            this.container = null;
+        }
+    }
+}

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -27,6 +27,8 @@ import { cooldownManager } from './CooldownManager.js';
 // 전투 중 하단 UI를 관리하는 매니저
 import { CombatUIManager } from '../dom/CombatUIManager.js';
 import { TurnOrderUIManager } from '../dom/TurnOrderUIManager.js';
+import { sharedResourceEngine } from './SharedResourceEngine.js';
+import { SharedResourceUIManager } from '../dom/SharedResourceUIManager.js';
 
 // 그림자 생성을 담당하는 매니저
 import { ShadowManager } from './ShadowManager.js';
@@ -52,6 +54,7 @@ export class BattleSimulatorEngine {
         this.combatUI = new CombatUIManager();
         // 턴 순서 UI 매니저
         this.turnOrderUI = new TurnOrderUIManager();
+        this.sharedResourceUI = new SharedResourceUIManager();
         
         // AI 노드에 주입할 엔진 패키지
         this.aiEngines = {
@@ -82,6 +85,7 @@ export class BattleSimulatorEngine {
         aiManager.clear();
         cooldownManager.reset();
         this.summoningEngine.reset();
+        sharedResourceEngine.initialize();
         statusEffectManager.setBattleSimulator(this);
 
         const allUnits = [...allies, ...enemies];
@@ -116,6 +120,7 @@ export class BattleSimulatorEngine {
 
         // 턴 순서 UI 초기화
         this.turnOrderUI.show(this.turnQueue);
+        this.sharedResourceUI.show();
 
         // --- ✨ 첫 턴 시작 시 토큰 지급 ---
         tokenEngine.addTokensForNewTurn();
@@ -212,6 +217,7 @@ export class BattleSimulatorEngine {
                     this.vfxManager.updateTokenDisplay(unit);
                 }
             });
+            this.sharedResourceUI.update();
 
             // 다음 턴의 유닛 정보를 미리 갱신합니다.
             const nextUnit = this.turnQueue[this.currentTurnIndex];
@@ -231,6 +237,7 @@ export class BattleSimulatorEngine {
         // 전투 종료 시 UI 숨김 처리
         this.combatUI.hide();
         this.turnOrderUI.hide();
+        this.sharedResourceUI.hide();
         console.log('전투 종료!');
     }
 
@@ -256,6 +263,9 @@ export class BattleSimulatorEngine {
         }
         if (this.turnOrderUI) {
             this.turnOrderUI.destroy();
+        }
+        if (this.sharedResourceUI) {
+            this.sharedResourceUI.destroy();
         }
     }
 }

--- a/src/game/utils/SharedResourceEngine.js
+++ b/src/game/utils/SharedResourceEngine.js
@@ -1,0 +1,92 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 게임에서 사용될 공유 자원의 종류를 정의합니다.
+ */
+export const SHARED_RESOURCE_TYPES = {
+    FIRE: '불',
+    WATER: '물',
+    WIND: '바람',
+    EARTH: '대지',
+    LIGHT: '빛',
+    DARK: '어둠',
+    IRON: '철',
+    POISON: '독'
+};
+
+/**
+ * 파티가 공유하는 자원을 관리하는 중앙 엔진 (싱글턴)
+ */
+class SharedResourceEngine {
+    constructor() {
+        this.resources = new Map();
+        this._initializeResourceMap();
+        debugLogEngine.log('SharedResourceEngine', '공유 자원 엔진이 초기화되었습니다.');
+    }
+
+    /**
+     * 자원 맵을 초기화합니다.
+     * @private
+     */
+    _initializeResourceMap() {
+        Object.keys(SHARED_RESOURCE_TYPES).forEach(key => {
+            this.resources.set(key, 0);
+        });
+    }
+
+    /**
+     * 전투 시작 시 모든 자원을 0으로 초기화합니다.
+     */
+    initialize() {
+        this._initializeResourceMap();
+        debugLogEngine.log('SharedResourceEngine', '모든 공유 자원을 초기화했습니다.');
+    }
+
+    /**
+     * 특정 종류의 자원을 추가합니다.
+     * @param {string} type - SHARED_RESOURCE_TYPES에 정의된 자원 키
+     * @param {number} amount - 추가할 양
+     */
+    addResource(type, amount) {
+        if (this.resources.has(type) && amount > 0) {
+            const currentAmount = this.resources.get(type);
+            this.resources.set(type, currentAmount + amount);
+            // TODO: 자원 획득 시 UI 업데이트를 위한 이벤트 발행 로직 추가 가능
+        }
+    }
+
+    /**
+     * 특정 종류의 자원을 소모합니다.
+     * @param {string} type - 소모할 자원 키
+     * @param {number} amount - 소모할 양
+     * @returns {boolean} - 소모 성공 여부
+     */
+    spendResource(type, amount) {
+        if (this.resources.has(type) && this.resources.get(type) >= amount) {
+            const currentAmount = this.resources.get(type);
+            this.resources.set(type, currentAmount - amount);
+            // TODO: 자원 소모 시 UI 업데이트를 위한 이벤트 발행 로직 추가 가능
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 특정 자원의 현재 양을 조회합니다.
+     * @param {string} type - 조회할 자원 키
+     * @returns {number}
+     */
+    getResource(type) {
+        return this.resources.get(type) || 0;
+    }
+
+    /**
+     * 모든 자원의 현재 상태를 담은 객체를 반환합니다.
+     * @returns {object}
+     */
+    getAllResources() {
+        return Object.fromEntries(this.resources);
+    }
+}
+
+export const sharedResourceEngine = new SharedResourceEngine();


### PR DESCRIPTION
## Summary
- add SharedResourceEngine for party resources
- display a shared resource panel with SharedResourceUIManager
- style the new resource UI
- hook SharedResourceEngine and panel into BattleSimulatorEngine

## Testing
- `node tests/movement_stat_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688667309e6883279cddcb7659aeea50