### PR TITLE
Add grindstone and throwing axe skills

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -66,9 +66,24 @@ function createMeleeAI(engines = {}) {
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // ✨ [신규] 우선순위 5: 5번 슬롯(소환) 스킬 사용 시도
+        // ✨ 우선순위 5 ~ 8: 특수 스킬 슬롯 체크
         new SequenceNode([
             new CanUseSkillBySlotNode(4),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        new SequenceNode([
+            new CanUseSkillBySlotNode(5),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        new SequenceNode([
+            new CanUseSkillBySlotNode(6),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        new SequenceNode([
+            new CanUseSkillBySlotNode(7),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -76,9 +76,24 @@ function createRangedAI(engines = {}) {
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // ✨ [신규] 5순위 스킬
+        // ✨ 우선순위 5 ~ 8 스킬
         new SequenceNode([
             new CanUseSkillBySlotNode(4),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        new SequenceNode([
+            new CanUseSkillBySlotNode(5),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        new SequenceNode([
+            new CanUseSkillBySlotNode(6),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        new SequenceNode([
+            new CanUseSkillBySlotNode(7),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -63,9 +63,24 @@ function createHealerAI(engines = {}) {
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // ✨ [신규] 우선순위 5: 5번 슬롯(소환) 스킬 사용 시도
+        // ✨ 우선순위 5 ~ 8: 특수 스킬 사용 시도
         new SequenceNode([
             new CanUseSkillBySlotNode(4),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        new SequenceNode([
+            new CanUseSkillBySlotNode(5),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        new SequenceNode([
+            new CanUseSkillBySlotNode(6),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        new SequenceNode([
+            new CanUseSkillBySlotNode(7),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -1,6 +1,6 @@
 import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
-// SkillTagManager에서 태그 정의를 가져옵니다.
 import { SKILL_TAGS } from '../../utils/SkillTagManager.js';
+import { SHARED_RESOURCE_TYPES } from '../../utils/SharedResourceEngine.js';
 
 // 액티브 스킬 데이터 정의
 export const activeSkills = {
@@ -249,6 +249,80 @@ export const activeSkills = {
             cooldown: 0,
             range: 3,
             generatesToken: { chance: 1.0, amount: 1 }
+        }
+    },
+    throwingAxe: {
+        NORMAL: {
+            id: 'throwingAxe',
+            name: '도끼 던지기',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.THROWING],
+            cost: 0,
+            targetType: 'enemy',
+            description: '3타일 거리의 적에게 도끼를 던져 {{damage}}%의 피해를 입힙니다. (소모 자원: 철 1)',
+            illustrationPath: 'assets/images/skills/throwing-axe.png',
+            requiredClass: 'warrior',
+            cooldown: 1,
+            range: 3,
+            damageMultiplier: 1.6,
+            resourceCost: { type: 'IRON', amount: 1 }
+        },
+        RARE: {
+            id: 'throwingAxe',
+            name: '도끼 던지기 [R]',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.THROWING],
+            cost: 0,
+            targetType: 'enemy',
+            description: '3타일 거리의 적에게 도끼를 던져 {{damage}}%의 피해를 입힙니다. (쿨타임 없음, 소모 자원: 철 1)',
+            illustrationPath: 'assets/images/skills/throwing-axe.png',
+            requiredClass: 'warrior',
+            cooldown: 0,
+            range: 3,
+            damageMultiplier: 1.6,
+            resourceCost: { type: 'IRON', amount: 1 }
+        },
+        EPIC: {
+            id: 'throwingAxe',
+            name: '도끼 던지기 [E]',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.THROWING],
+            cost: 0,
+            targetType: 'enemy',
+            description: '3타일 거리의 적에게 도끼를 던져 {{damage}}%의 피해를 입히고, 20% 확률로 기절시킵니다. (소모 자원: 철 1)',
+            illustrationPath: 'assets/images/skills/throwing-axe.png',
+            requiredClass: 'warrior',
+            cooldown: 0,
+            range: 3,
+            damageMultiplier: 1.6,
+            resourceCost: { type: 'IRON', amount: 1 },
+            effect: {
+                type: EFFECT_TYPES.STATUS_EFFECT,
+                id: 'stun',
+                duration: 1,
+                chance: 0.2
+            }
+        },
+        LEGENDARY: {
+            id: 'throwingAxe',
+            name: '도끼 던지기 [L]',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.THROWING],
+            cost: 0,
+            targetType: 'enemy',
+            description: '3타일 거리의 적에게 도끼를 던져 {{damage}}%의 피해를 입히고, 40% 확률로 기절시킵니다. (소모 자원: 철 1)',
+            illustrationPath: 'assets/images/skills/throwing-axe.png',
+            requiredClass: 'warrior',
+            cooldown: 0,
+            range: 3,
+            damageMultiplier: 1.6,
+            resourceCost: { type: 'IRON', amount: 1 },
+            effect: {
+                type: EFFECT_TYPES.STATUS_EFFECT,
+                id: 'stun',
+                duration: 1,
+                chance: 0.4
+            }
         }
     }
 };

--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -96,4 +96,98 @@ export const buffSkills = {
             }
         }
     },
+    grindstone: {
+        NORMAL: {
+            id: 'grindstone',
+            name: '숯돌 갈기',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.IRON, SKILL_TAGS.PRODUCTION],
+            cost: 1,
+            targetType: 'self',
+            description: '날카롭게 벼려낸 칼날이 번뜩입니다. 1턴간 자신의 공격력을 {{attackBonus}}% 상승시키고 공유 자원 [철]을 1개 생산합니다.',
+            illustrationPath: 'assets/images/skills/grindstone.png',
+            requiredClass: 'warrior',
+            cooldown: 2,
+            generatesResource: { type: 'IRON', amount: 1 },
+            effect: {
+                id: 'grindstoneBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: {
+                    stat: 'physicalAttack',
+                    type: 'percentage',
+                    value: 0.10
+                }
+            }
+        },
+        RARE: {
+            id: 'grindstone',
+            name: '숯돌 갈기 [R]',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.IRON, SKILL_TAGS.PRODUCTION],
+            cost: 1,
+            targetType: 'self',
+            description: '숙련된 솜씨로 무기를 손질합니다. 1턴간 자신의 공격력을 {{attackBonus}}% 상승시키고 [철]을 1개 생산합니다. (쿨타임 1턴)',
+            illustrationPath: 'assets/images/skills/grindstone.png',
+            requiredClass: 'warrior',
+            cooldown: 1,
+            generatesResource: { type: 'IRON', amount: 1 },
+            effect: {
+                id: 'grindstoneBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: {
+                    stat: 'physicalAttack',
+                    type: 'percentage',
+                    value: 0.10
+                }
+            }
+        },
+        EPIC: {
+            id: 'grindstone',
+            name: '숯돌 갈기 [E]',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.IRON, SKILL_TAGS.PRODUCTION],
+            cost: 0,
+            targetType: 'self',
+            description: '순식간에 무기를 최상의 상태로 만듭니다. 1턴간 자신의 공격력을 {{attackBonus}}% 상승시키고 [철]을 1개 생산합니다.',
+            illustrationPath: 'assets/images/skills/grindstone.png',
+            requiredClass: 'warrior',
+            cooldown: 1,
+            generatesResource: { type: 'IRON', amount: 1 },
+            effect: {
+                id: 'grindstoneBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: {
+                    stat: 'physicalAttack',
+                    type: 'percentage',
+                    value: 0.10
+                }
+            }
+        },
+        LEGENDARY: {
+            id: 'grindstone',
+            name: '숯돌 갈기 [L]',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.IRON, SKILL_TAGS.PRODUCTION],
+            cost: 0,
+            targetType: 'self',
+            description: '장인의 경지에 이른 연마술입니다. 1턴간 자신의 공격력을 {{attackBonus}}% 상승시키고 [철]을 2개 생산합니다.',
+            illustrationPath: 'assets/images/skills/grindstone.png',
+            requiredClass: 'warrior',
+            cooldown: 1,
+            generatesResource: { type: 'IRON', amount: 2 },
+            effect: {
+                id: 'grindstoneBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: {
+                    stat: 'physicalAttack',
+                    type: 'percentage',
+                    value: 0.10
+                }
+            }
+        }
+    },
 };

--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -2,6 +2,7 @@ import { diceEngine } from './DiceEngine.js';
 import { debugLogEngine } from './DebugLogEngine.js';
 import { tokenEngine } from './TokenEngine.js';
 import { cooldownManager } from './CooldownManager.js';
+import { sharedResourceEngine } from './SharedResourceEngine.js';
 
 // 스킬 종류와 해당 색상, 이름을 상수로 정의합니다.
 export const SKILL_TYPES = {
@@ -53,16 +54,23 @@ class SkillEngine {
             return false;
         }
 
-        // 2. 이번 턴에 해당 유닛이 이미 사용한 스킬인가?
+        // 2. 공유 자원이 충분한가?
+        if (skill.resourceCost) {
+            if (sharedResourceEngine.getResource(skill.resourceCost.type) < skill.resourceCost.amount) {
+                return false;
+            }
+        }
+
+        // 3. 이번 턴에 해당 유닛이 이미 사용한 스킬인가?
         const unitUsed = this.usedSkillsThisTurn.get(unit.uniqueId);
         if (unitUsed && unitUsed.has(skill.id)) {
             return false;
         }
 
-        // 3. 이번 턴에 다른 스킬을 이미 사용했더라도 토큰이 남아 있다면 추가 행동이 가능하다
+        // 4. 이번 턴에 다른 스킬을 이미 사용했더라도 토큰이 남아 있다면 추가 행동이 가능하다
         //    단, 같은 스킬은 한 번만 사용할 수 있도록 위에서 체크했다.
 
-        // 4. 쿨타임이 지났는가?
+        // 5. 쿨타임이 지났는가?
         if (!cooldownManager.isReady(unit.uniqueId, skill.id)) {
             return false;
         }

--- a/src/game/utils/SkillModifierEngine.js
+++ b/src/game/utils/SkillModifierEngine.js
@@ -21,6 +21,8 @@ class SkillModifierEngine {
             'rangedAttack': [1.3, 1.2, 1.1, 1.0],
             // ✨ [신규] 힐 순위별 회복 계수 추가
             'heal': [1.3, 1.2, 1.1, 1.0],
+            'grindstone': [0.25, 0.20, 0.15, 0.10],
+            'throwingAxe': [1.0, 1.2, 1.4, 1.6],
         };
         debugLogEngine.log('SkillModifierEngine', '스킬 보정 엔진이 초기화되었습니다.');
     }
@@ -80,6 +82,13 @@ class SkillModifierEngine {
             }
         }
 
+        if (baseSkillData.id === 'grindstone' && modifiedSkill.effect) {
+            const bonusModifiers = this.rankModifiers['grindstone'];
+            if (bonusModifiers && bonusModifiers[rankIndex] !== undefined) {
+                modifiedSkill.effect.modifiers.value = bonusModifiers[rankIndex];
+            }
+        }
+
         // 차지 스킬의 경우 슬롯 순위에 따라 기절 턴 수를 보정합니다.
         if (baseSkillData.id === 'charge' && modifiedSkill.effect) {
             modifiedSkill.effect.duration = (rank === 1)
@@ -116,6 +125,10 @@ class SkillModifierEngine {
             if (modifiedSkill.healMultiplier) {
                 const healAmount = `지혜 * ${modifiedSkill.healMultiplier.toFixed(2)}`;
                 modifiedSkill.description = modifiedSkill.description.replace('{{heal}}', healAmount);
+            }
+            if (baseSkillData.id === 'grindstone') {
+                const bonusValue = (this.rankModifiers.grindstone[rankIndex] || 0) * 100;
+                modifiedSkill.description = modifiedSkill.description.replace('{{attackBonus}}%', `${bonusValue.toFixed(0)}%`);
             }
         }
 

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -28,6 +28,9 @@ export const SKILL_TAGS = {
     // 원소/개념 속성
     EARTH: '대지',
     WILL: '의지',
+    IRON: '철',
+    PRODUCTION: '생산',
+    THROWING: '투척',
 };
 
 // 실제 코드에서는 위 객체를 직접 import하여 사용하면 됩니다.

--- a/tests/warrior_skill_integration_test.js
+++ b/tests/warrior_skill_integration_test.js
@@ -33,6 +33,36 @@ const shieldBreakBase = {
     LEGENDARY: { id: 'shieldBreak', type: 'DEBUFF', cost: 1, cooldown: 2, effect: { id: 'shieldBreak', type: 'DEBUFF', duration: 3, modifiers: [ { stat: 'damageIncrease', type: 'percentage', value: 0.15 }, { stat: 'physicalDefense', type: 'percentage', value: -0.10 } ] } }
 };
 
+const grindstoneBase = {
+    NORMAL: {
+        id: 'grindstone', type: 'BUFF', cost: 1, cooldown: 2, effect: { id: 'grindstoneBuff', type: 'BUFF', duration: 1, modifiers: { stat: 'physicalAttack', type: 'percentage', value: 0.10 } }, generatesResource: { type: 'IRON', amount: 1 }
+    },
+    RARE: {
+        id: 'grindstone', type: 'BUFF', cost: 1, cooldown: 1, effect: { id: 'grindstoneBuff', type: 'BUFF', duration: 1, modifiers: { stat: 'physicalAttack', type: 'percentage', value: 0.10 } }, generatesResource: { type: 'IRON', amount: 1 }
+    },
+    EPIC: {
+        id: 'grindstone', type: 'BUFF', cost: 0, cooldown: 1, effect: { id: 'grindstoneBuff', type: 'BUFF', duration: 1, modifiers: { stat: 'physicalAttack', type: 'percentage', value: 0.10 } }, generatesResource: { type: 'IRON', amount: 1 }
+    },
+    LEGENDARY: {
+        id: 'grindstone', type: 'BUFF', cost: 0, cooldown: 1, effect: { id: 'grindstoneBuff', type: 'BUFF', duration: 1, modifiers: { stat: 'physicalAttack', type: 'percentage', value: 0.10 } }, generatesResource: { type: 'IRON', amount: 2 }
+    }
+};
+
+const throwingAxeBase = {
+    NORMAL: {
+        id: 'throwingAxe', type: 'ACTIVE', cost: 0, cooldown: 1, damageMultiplier: 1.6, resourceCost: { type: 'IRON', amount: 1 }
+    },
+    RARE: {
+        id: 'throwingAxe', type: 'ACTIVE', cost: 0, cooldown: 0, damageMultiplier: 1.6, resourceCost: { type: 'IRON', amount: 1 }
+    },
+    EPIC: {
+        id: 'throwingAxe', type: 'ACTIVE', cost: 0, cooldown: 0, damageMultiplier: 1.6, resourceCost: { type: 'IRON', amount: 1 }, effect: { type: 'STATUS_EFFECT', id: 'stun', duration: 1, chance: 0.2 }
+    },
+    LEGENDARY: {
+        id: 'throwingAxe', type: 'ACTIVE', cost: 0, cooldown: 0, damageMultiplier: 1.6, resourceCost: { type: 'IRON', amount: 1 }, effect: { type: 'STATUS_EFFECT', id: 'stun', duration: 1, chance: 0.4 }
+    }
+};
+
 const ironWillBase = {
     rankModifiers: [0.39, 0.36, 0.33, 0.30],
     NORMAL: { maxReduction: 0.30, hpRegen: 0 },
@@ -131,6 +161,25 @@ for (let rank = 1; rank <= 4; rank++) {
 
 for (const grade of grades) {
     assert.strictEqual(typeof ironWillBase[grade].hpRegen, 'number');
+}
+
+// Grindstone
+const grindstoneExpected = [0.25, 0.20, 0.15, 0.10];
+for (const grade of grades) {
+    for (let rank = 1; rank <= 4; rank++) {
+        const skill = skillModifierEngine.getModifiedSkill(grindstoneBase[grade], rank, grade);
+        const value = skill.effect.modifiers.value;
+        assert(Math.abs(value - grindstoneExpected[rank - 1]) < 1e-6);
+    }
+}
+
+// Throwing Axe
+const throwingAxeExpected = [1.0, 1.2, 1.4, 1.6];
+for (const grade of grades) {
+    for (let rank = 1; rank <= 4; rank++) {
+        const skill = skillModifierEngine.getModifiedSkill(throwingAxeBase[grade], rank, grade);
+        assert.strictEqual(skill.damageMultiplier, throwingAxeExpected[rank - 1]);
+    }
 }
 
 // ------- Skill Usage Integration Test -------


### PR DESCRIPTION
## Summary
- expand skill tags with iron/production/throwing
- introduce grindstone and throwing axe skills
- update skill engine to check shared resources
- update UseSkillNode for resource use and chance effects
- tune SkillModifierEngine with new modifiers and descriptions
- extend AI behaviours to consider slots 5-8
- add tests for new warrior skills

## Testing
- `node tests/warrior_skill_integration_test.js && node tests/medic_skill_integration_test.js && node tests/summon_skill_integration_test.js && node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6886f05659d48327970a8b6a1226debf