### PR TITLE
Add suppress shot skill

### DIFF
--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -14,9 +14,10 @@ import { sharedResourceEngine } from '../../game/utils/SharedResourceEngine.js';
 import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 // ✨ 1. 새로 만든 BattleTagManager를 import 합니다.
 import { battleTagManager } from '../../game/utils/BattleTagManager.js';
+import { turnOrderManager } from '../../game/utils/TurnOrderManager.js';
 
 class UseSkillNode extends Node {
-    constructor({ vfxManager, animationEngine, delayEngine, terminationManager, summoningEngine, skillEngine: se } = {}) {
+    constructor({ vfxManager, animationEngine, delayEngine, terminationManager, summoningEngine, skillEngine: se, battleSimulator } = {}) {
         super();
         this.vfxManager = vfxManager;
         this.animationEngine = animationEngine;
@@ -25,6 +26,7 @@ class UseSkillNode extends Node {
         this.summoningEngine = summoningEngine;
         this.skillEngine = se || skillEngine;
         this.combatEngine = combatCalculationEngine;
+        this.battleSimulator = battleSimulator;
     }
 
     async evaluate(unit, blackboard) {
@@ -124,6 +126,10 @@ class UseSkillNode extends Node {
                             `${modifiedSkill.name} 효과`
                         );
                     }
+                }
+
+                if (modifiedSkill.turnOrderEffect === 'pushToBack' && this.battleSimulator) {
+                    this.battleSimulator.turnQueue = turnOrderManager.pushToBack(this.battleSimulator.turnQueue, skillTarget);
                 }
 
                 // ✨ 넉백(push) 효과 처리

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -251,6 +251,80 @@ export const activeSkills = {
             generatesToken: { chance: 1.0, amount: 1 }
         }
     },
+    // --- ▼ [신규] 제압 사격 스킬 추가 ▼ ---
+    suppressShot: {
+        NORMAL: {
+            id: 'suppressShot',
+            name: '제압 사격',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.DELAY, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'enemy',
+            description: '적을 80% 데미지로 제압 사격하여, 턴 순서를 가장 마지막으로 밀어냅니다. (소모 자원: 철 2)',
+            illustrationPath: 'assets/images/skills/suppress-shot.png',
+            requiredClass: 'gunner',
+            cooldown: 3,
+            range: 3,
+            damageMultiplier: 0.8,
+            resourceCost: { type: 'IRON', amount: 2 },
+            turnOrderEffect: 'pushToBack'
+        },
+        RARE: {
+            id: 'suppressShot',
+            name: '제압 사격 [R]',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.DELAY, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'enemy',
+            description: '적을 100% 데미지로 제압 사격하여, 턴 순서를 가장 마지막으로 밀어냅니다. (소모 자원: 철 2)',
+            illustrationPath: 'assets/images/skills/suppress-shot.png',
+            requiredClass: 'gunner',
+            cooldown: 3,
+            range: 3,
+            damageMultiplier: 1.0,
+            resourceCost: { type: 'IRON', amount: 2 },
+            turnOrderEffect: 'pushToBack'
+        },
+        EPIC: {
+            id: 'suppressShot',
+            name: '제압 사격 [E]',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.DELAY, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'enemy',
+            description: '적을 120% 데미지로 제압 사격하여, 턴 순서를 가장 마지막으로 밀어냅니다. (소모 자원: 철 2)',
+            illustrationPath: 'assets/images/skills/suppress-shot.png',
+            requiredClass: 'gunner',
+            cooldown: 3,
+            range: 3,
+            damageMultiplier: 1.2,
+            resourceCost: { type: 'IRON', amount: 2 },
+            turnOrderEffect: 'pushToBack'
+        },
+        LEGENDARY: {
+            id: 'suppressShot',
+            name: '제압 사격 [L]',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.DELAY, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'enemy',
+            description: '적을 120% 데미지로 제압 사격하여, 턴 순서를 가장 마지막으로 밀어내고 1턴간 토큰 하나를 잃게 합니다. (소모 자원: 철 2)',
+            illustrationPath: 'assets/images/skills/suppress-shot.png',
+            requiredClass: 'gunner',
+            cooldown: 3,
+            range: 3,
+            damageMultiplier: 1.2,
+            resourceCost: { type: 'IRON', amount: 2 },
+            turnOrderEffect: 'pushToBack',
+            effect: {
+                id: 'tokenLoss',
+                duration: 1,
+                applyOnce: true,
+                tokenLoss: 1
+            }
+        }
+    },
+    // --- ▲ [신규] 제압 사격 스킬 추가 ▲ ---
     throwingAxe: {
         NORMAL: {
             id: 'throwingAxe',

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -110,6 +110,7 @@ export class Preloader extends Scene
         this.load.image('summon-scene-background', 'images/territory/summon-scene.png');
         // --- ✨ [추가] 스킬 슬롯 이미지를 로드합니다. ---
         this.load.image('skill-slot', 'images/skills/skill-slot.png');
+        this.load.image('suppress-shot', 'images/skills/suppress-shot.png');
         // 공통 패널 배경 이미지
         this.load.image('panel-background', 'images/ui-panel.png');
         this.load.image('battle-stage-arena', 'images/battle/battle-stage-arena.png');

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -70,6 +70,7 @@ export class BattleSimulatorEngine {
             cameraControl: this.scene.cameraControl,
             // ✨ AI가 소환 엔진을 사용할 수 있도록 패키지에 포함합니다.
             summoningEngine: this.summoningEngine,
+            battleSimulator: this,
         };
 
         this.turnQueue = [];

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -34,6 +34,8 @@ class SkillInventoryManager {
                 this.addSkillById('heal', grade);
                 // ✨ 넉백샷 카드 추가
                 this.addSkillById('knockbackShot', grade);
+                // ✨ 제압 사격 카드 추가
+                this.addSkillById('suppressShot', grade);
             }
         });
 

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -24,6 +24,7 @@ export const SKILL_TAGS = {
     KINETIC: '관성',
     WEAKEN: '쇠약',
     HEAL: '치유',
+    DELAY: '지연',
 
     // 원소/개념 속성
     EARTH: '대지',

--- a/src/game/utils/StatusEffectManager.js
+++ b/src/game/utils/StatusEffectManager.js
@@ -93,6 +93,20 @@ class StatusEffectManager {
     }
 
     /**
+     * 대상 유닛의 토큰을 즉시 감소시키는 효과를 적용합니다.
+     * @param {object} targetUnit
+     * @param {object} effectData
+     */
+    applyTokenLoss(targetUnit, effectData) {
+        if (effectData.tokenLoss > 0) {
+            tokenEngine.spendTokens(targetUnit.uniqueId, effectData.tokenLoss, '제압 사격 효과');
+            if (this.battleSimulator && this.battleSimulator.vfxManager) {
+                this.battleSimulator.vfxManager.showEffectName(targetUnit.sprite, '토큰 감소!', '#ef4444');
+            }
+        }
+    }
+
+    /**
      * 대상 유닛에게 새로운 상태 효과를 적용합니다.
      * @param {object} targetUnit - 효과를 받을 유닛
      * @param {object} sourceSkill - 효과를 발생시킨 스킬 데이터
@@ -115,6 +129,12 @@ class StatusEffectManager {
     applySingleEffect(targetUnit, sourceSkill) {
         const effectId = sourceSkill.effect.id;
         const effectDefinition = statusEffects[effectId];
+
+        // 즉시 발동하는 토큰 감소 효과 처리
+        if (sourceSkill.effect.applyOnce && sourceSkill.effect.tokenLoss) {
+            this.applyTokenLoss(targetUnit, sourceSkill.effect);
+            return;
+        }
 
         if (!effectDefinition) {
             debugLogEngine.warn('StatusEffectManager', `정의되지 않은 효과 ID: ${effectId}`);

--- a/src/game/utils/TurnOrderManager.js
+++ b/src/game/utils/TurnOrderManager.js
@@ -23,6 +23,22 @@ class TurnOrderManager {
 
         return turnQueue;
     }
+
+    /**
+     * 특정 유닛을 턴 큐의 가장 마지막으로 이동시킵니다.
+     * @param {Array<object>} turnQueue - 현재 턴 큐
+     * @param {object} targetUnit - 순서를 변경할 대상 유닛
+     * @returns {Array<object>} - 변경된 턴 큐
+     */
+    pushToBack(turnQueue, targetUnit) {
+        const index = turnQueue.findIndex(u => u.uniqueId === targetUnit.uniqueId);
+        if (index > -1) {
+            const [unit] = turnQueue.splice(index, 1);
+            turnQueue.push(unit);
+            debugLogEngine.log('TurnOrderManager', `'${targetUnit.instanceName}'의 턴 순서가 마지막으로 변경되었습니다.`);
+        }
+        return turnQueue;
+    }
 }
 
 export const turnOrderManager = new TurnOrderManager();

--- a/tests/gunner_skill_integration_test.js
+++ b/tests/gunner_skill_integration_test.js
@@ -1,0 +1,40 @@
+import assert from 'assert';
+import { skillModifierEngine } from '../src/game/utils/SkillModifierEngine.js';
+import { turnOrderManager } from '../src/game/utils/TurnOrderManager.js';
+import { tokenEngine } from '../src/game/utils/TokenEngine.js';
+
+const suppressShotBase = {
+    NORMAL: { id: 'suppressShot', damageMultiplier: 0.8, turnOrderEffect: 'pushToBack' },
+    RARE: { id: 'suppressShot', damageMultiplier: 1.0, turnOrderEffect: 'pushToBack' },
+    EPIC: { id: 'suppressShot', damageMultiplier: 1.2, turnOrderEffect: 'pushToBack' },
+    LEGENDARY: { id: 'suppressShot', damageMultiplier: 1.2, turnOrderEffect: 'pushToBack', effect: { tokenLoss: 1 } }
+};
+
+const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
+
+// 1. 데미지 계수 테스트
+for (const grade of grades) {
+    const skill = skillModifierEngine.getModifiedSkill(suppressShotBase[grade], 1, grade);
+    assert.strictEqual(skill.damageMultiplier, suppressShotBase[grade].damageMultiplier, `Damage multiplier failed for grade ${grade}`);
+}
+
+// 2. 턴 순서 변경 테스트
+let testQueue = [
+    { uniqueId: 1, instanceName: 'A' },
+    { uniqueId: 2, instanceName: 'B' },
+    { uniqueId: 3, instanceName: 'C' }
+];
+const target = testQueue[1];
+testQueue = turnOrderManager.pushToBack(testQueue, target);
+assert.deepStrictEqual(testQueue.map(u => u.instanceName), ['A', 'C', 'B'], 'Turn order pushToBack failed');
+
+// 3. 토큰 감소 효과 테스트
+const testUnit = { uniqueId: 10, instanceName: 'TestDummy' };
+tokenEngine.initializeUnits([testUnit]);
+tokenEngine.addTokensForNewTurn();
+assert.strictEqual(tokenEngine.getTokens(testUnit.uniqueId), 3, 'Initial token setup failed');
+
+tokenEngine.spendTokens(testUnit.uniqueId, 1, '제압 사격 효과');
+assert.strictEqual(tokenEngine.getTokens(testUnit.uniqueId), 2, 'Token loss effect failed');
+
+console.log('Gunner skill [Suppress Shot] integration test passed.');


### PR DESCRIPTION
## Summary
- add Suppress Shot active skill with grade variations
- implement TurnOrderManager.pushToBack
- support token loss effects in StatusEffectManager
- allow AI to modify turn order via suppress shot
- include suppress shot cards in skill inventory
- preload suppress shot icon
- add DELAY skill tag
- provide integration test for gunner skills

## Testing
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68871e48110083278eaf274bbb1b0d21