### PR TITLE
Add class grade data and manager

### DIFF
--- a/src/game/data/classGrades.js
+++ b/src/game/data/classGrades.js
@@ -1,0 +1,50 @@
+/**
+ * 각 클래스의 공격/방어 등급을 정의합니다.
+ * 등급: 3 (강함), 2 (보통), 1 (약함)
+ */
+export const ATTACK_TYPE = {
+    MELEE: 'melee',
+    RANGED: 'ranged',
+    MAGIC: 'magic',
+};
+
+export const CLASS_GRADE_TYPE = {
+    ATTACK: 'Attack',
+    DEFENSE: 'Defense',
+};
+
+export const classGrades = {
+    warrior: {
+        meleeAttack: 3,
+        rangedAttack: 1,
+        magicAttack: 1,
+        meleeDefense: 3,
+        rangedDefense: 2,
+        magicDefense: 1,
+    },
+    gunner: {
+        meleeAttack: 1,
+        rangedAttack: 3,
+        magicAttack: 1,
+        meleeDefense: 2,
+        rangedDefense: 3,
+        magicDefense: 1,
+    },
+    medic: {
+        meleeAttack: 1,
+        rangedAttack: 1,
+        magicAttack: 2,
+        meleeDefense: 1,
+        rangedDefense: 2,
+        magicDefense: 3,
+    },
+    // --- 다른 클래스 추가 예정 ---
+    zombie: {
+        meleeAttack: 2,
+        rangedAttack: 1,
+        magicAttack: 1,
+        meleeDefense: 1,
+        rangedDefense: 1,
+        magicDefense: 1,
+    }
+};

--- a/src/game/utils/GradeManager.js
+++ b/src/game/utils/GradeManager.js
@@ -1,0 +1,49 @@
+import { debugLogEngine } from './DebugLogEngine.js'
+import { classGrades, ATTACK_TYPE, CLASS_GRADE_TYPE } from '../data/classGrades.js'
+
+/**
+ * 클래스 간의 등급 상성을 계산하고 전투 결과를 결정하는 매니저
+ */
+class GradeManager {
+    constructor() {
+        this.name = 'GradeManager'
+        debugLogEngine.register(this)
+    }
+
+    /**
+     * 공격자와 방어자의 등급을 비교하여 최종 전투 등급 티어를 계산합니다.
+     * @param {object} attacker - 공격자 유닛 데이터
+     * @param {object} defender - 방어자 유닛 데이터
+     * @param {string} attackType - ATTACK_TYPE에 정의된 공격 타입
+     * @returns {number} - 최종 등급 티어 (예: 2, 1, 0, -1, -2)
+     */
+    calculateCombatGrade(attacker, defender, attackType) {
+        const attackerClass = attacker.id
+        const defenderClass = defender.id
+
+        const attackerGradeData = classGrades[attackerClass]
+        const defenderGradeData = classGrades[defenderClass]
+
+        if (!attackerGradeData || !defenderGradeData) {
+            debugLogEngine.warn(this.name, `'${attackerClass}' 또는 '${defenderClass}'의 등급 데이터를 찾을 수 없습니다.`)
+            return 0
+        }
+
+        const attackGradeKey = `${attackType}${CLASS_GRADE_TYPE.ATTACK}`
+        const defenseGradeKey = `${attackType}${CLASS_GRADE_TYPE.DEFENSE}`
+
+        const attackerTier = attackerGradeData[attackGradeKey] || 1
+        const defenderTier = defenderGradeData[defenseGradeKey] || 1
+
+        const resultTier = attackerTier - defenderTier
+
+        debugLogEngine.log(
+            this.name,
+            `[${attacker.instanceName}(${attackerTier}티어)] vs [${defender.instanceName}(${defenderTier}티어)] = 최종 ${resultTier}티어`
+        )
+
+        return resultTier
+    }
+}
+
+export const gradeManager = new GradeManager()


### PR DESCRIPTION
## Summary
- set up `classGrades` data table describing attack and defense tiers for each class
- implement `GradeManager` to compare class tiers and compute combat grade

## Testing
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68872e4126688327ac8510b79b94a6cd