### PR TITLE
Add grade-based hit effects

### DIFF
--- a/src/ai/nodes/AttackTargetNode.js
+++ b/src/ai/nodes/AttackTargetNode.js
@@ -48,13 +48,13 @@ class AttackTargetNode extends Node {
 
         // 데미지 계산 및 적용
         // ✨ 데미지 계산 시 스킬 정보 전달
-        const damage = this.combatEngine.calculateDamage(unit, target, attackSkill);
+        const { damage, hitType } = this.combatEngine.calculateDamage(unit, target, attackSkill);
         target.currentHp -= damage;
 
         // 시각 효과
         this.vfxManager.updateHealthBar(target.healthBar, target.currentHp, target.finalStats.hp);
         this.vfxManager.createBloodSplatter(target.sprite.x, target.sprite.y);
-        this.vfxManager.createDamageNumber(target.sprite.x, target.sprite.y, damage);
+        this.vfxManager.createDamageNumber(target.sprite.x, target.sprite.y, damage, '#ff4d4d', hitType);
 
         // 딜레이
         await this.delayEngine.hold(200);

--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -84,7 +84,7 @@ class UseSkillNode extends Node {
             spriteEngine.changeSpriteForDuration(skillTarget, 'hitted', 300);
 
             if (modifiedSkill.type === 'ACTIVE') {
-                const totalDamage = this.combatEngine.calculateDamage(
+                const { damage: totalDamage, hitType } = this.combatEngine.calculateDamage(
                     unit,
                     skillTarget,
                     baseSkillData,
@@ -102,7 +102,8 @@ class UseSkillNode extends Node {
                         skillTarget.sprite.x,
                         skillTarget.sprite.y - 10,
                         damageToBarrier,
-                        '#ffd700'
+                        '#ffd700',
+                        hitType
                     );
                 }
                 if (damageToHp > 0) {
@@ -111,7 +112,8 @@ class UseSkillNode extends Node {
                         skillTarget.sprite.x,
                         skillTarget.sprite.y + 10,
                         damageToHp,
-                        '#ff4d4d'
+                        '#ff4d4d',
+                        hitType
                     );
                 }
 

--- a/src/game/utils/VFXManager.js
+++ b/src/game/utils/VFXManager.js
@@ -116,7 +116,15 @@ export class VFXManager {
      * @param {number} y - 생성 위치 y
      * @param {number|string} damage - 표시할 데미지 숫자
      */
-    createDamageNumber(x, y, value, color = '#ff4d4d') {
+    /**
+     * 물리 효과가 적용된 데미지 숫자를 생성합니다.
+     * @param {number} x - 생성 위치 x
+     * @param {number} y - 생성 위치 y
+     * @param {number|string} value - 표시할 데미지 값
+     * @param {string} color - 기본 색상
+     * @param {string|null} label - 데미지 옆에 표시할 추가 라벨(예: '치명타')
+     */
+    createDamageNumber(x, y, value, color = '#ff4d4d', label = null) {
         const style = {
             fontFamily: '"Arial Black", Arial, sans-serif',
             fontSize: '32px',
@@ -153,6 +161,23 @@ export class VFXManager {
                 numberText.destroy();
             },
         });
+
+        // ✨ 라벨이 있으면 데미지 숫자 옆에 함께 표시합니다.
+        if (label) {
+            const labelStyle = { ...style, fontSize: '28px', color: '#ffc107' };
+            const labelText = this.scene.add.text(x - 40, y - 20, label, labelStyle).setOrigin(1, 0.5);
+            this.scene.physics.add.existing(labelText);
+            labelText.body.setVelocity(randomX, randomY);
+            labelText.body.setGravityY(400);
+            labelText.body.setAngularVelocity(Math.random() * 200 - 100);
+            this.scene.tweens.add({
+                targets: labelText,
+                alpha: 0,
+                duration: 800,
+                ease: 'Cubic.easeIn',
+                onComplete: () => labelText.destroy(),
+            });
+        }
 
         const logMessage = isHealing
             ? `${value} 회복 숫자를 생성했습니다.`


### PR DESCRIPTION
## Summary
- integrate GradeManager into damage calculations
- support critical/weakness/block labels in VFXManager
- pass hit type info to damage numbers in AI nodes

## Testing
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 & curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6887314edfe88327bf66e624d8cb1f40