### PR TITLE
Add grade modifier support

### DIFF
--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -17,6 +17,14 @@ export const statusEffects = {
             unit.isStunned = false;
         },
     },
+    // 전투의 함성: 일시적으로 근접 공격 등급을 상승시킵니다.
+    battleCryBuff: {
+        id: 'battleCryBuff',
+        name: '전투의 함성',
+        iconPath: 'assets/images/skills/battle_cry.png',
+        // 등급 보정치 예시: 근접 공격 등급 +1
+        modifiers: { stat: 'meleeAttack', type: 'flat', value: 1 }
+    },
     // ✨ 스톤 스킨 효과 추가
     stoneSkin: {
         id: 'stoneSkin',

--- a/src/game/utils/GradeManager.js
+++ b/src/game/utils/GradeManager.js
@@ -1,5 +1,7 @@
 import { debugLogEngine } from './DebugLogEngine.js'
 import { classGrades, ATTACK_TYPE, CLASS_GRADE_TYPE } from '../data/classGrades.js'
+// 등급 보정치를 얻기 위해 상태 효과 매니저를 가져옵니다.
+import { statusEffectManager } from './StatusEffectManager.js'
 
 /**
  * 클래스 간의 등급 상성을 계산하고 전투 결과를 결정하는 매니저
@@ -32,14 +34,21 @@ class GradeManager {
         const attackGradeKey = `${attackType}${CLASS_GRADE_TYPE.ATTACK}`
         const defenseGradeKey = `${attackType}${CLASS_GRADE_TYPE.DEFENSE}`
 
-        const attackerTier = attackerGradeData[attackGradeKey] || 1
-        const defenderTier = defenderGradeData[defenseGradeKey] || 1
+        const baseAttackerTier = attackerGradeData[attackGradeKey] || 1
+        const baseDefenderTier = defenderGradeData[defenseGradeKey] || 1
 
-        const resultTier = attackerTier - defenderTier
+        // 상태 효과로 인한 등급 보정치를 합산합니다.
+        const attackerBonus = statusEffectManager.getModifierValue(attacker, attackGradeKey)
+        const defenderBonus = statusEffectManager.getModifierValue(defender, defenseGradeKey)
+
+        const finalAttackerTier = baseAttackerTier + attackerBonus
+        const finalDefenderTier = baseDefenderTier + defenderBonus
+
+        const resultTier = finalAttackerTier - finalDefenderTier
 
         debugLogEngine.log(
             this.name,
-            `[${attacker.instanceName}(${attackerTier}티어)] vs [${defender.instanceName}(${defenderTier}티어)] = 최종 ${resultTier}티어`
+            `[${attacker.instanceName}(${baseAttackerTier}+${attackerBonus})] vs [${defender.instanceName}(${baseDefenderTier}+${defenderBonus})] = 최종 ${resultTier}티어`
         )
 
         return resultTier


### PR DESCRIPTION
## Summary
- expand `statusEffects` database with an example grade modifier effect
- allow `GradeManager` to include grade bonuses from status effects

## Testing
- `node tests/warrior_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &` then `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688734b96c3c8327950d493ab96e4765