### PR TITLE
Add warrior Battle Cry buff skill

### DIFF
--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -194,4 +194,93 @@ export const buffSkills = {
             }
         }
     },
+
+    // --- ▼ [신규] 전투의 함성 스킬 추가 ▼ ---
+    battleCry: {
+        NORMAL: {
+            id: 'battleCry',
+            name: '전투의 함성',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.WILL],
+            cost: 2,
+            targetType: 'self',
+            description: '2턴간 자신의 [공격력]을 상승시키고, [근접 공격 등급]을 +1 상승시킵니다. (쿨타임 3턴)',
+            illustrationPath: 'assets/images/skills/battle_cry.png',
+            requiredClass: 'warrior',
+            cooldown: 3,
+            effect: {
+                id: 'battleCryBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 2,
+                modifiers: [
+                    { stat: 'physicalAttack', type: 'percentage', value: 0.15 },
+                    { stat: 'meleeAttack', type: 'flat', value: 1 }
+                ]
+            }
+        },
+        RARE: {
+            id: 'battleCry',
+            name: '전투의 함성 [R]',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.WILL],
+            cost: 1,
+            targetType: 'self',
+            description: '2턴간 자신의 [공격력]을 상승시키고, [근접 공격 등급]을 +1 상승시킵니다. (쿨타임 3턴)',
+            illustrationPath: 'assets/images/skills/battle_cry.png',
+            requiredClass: 'warrior',
+            cooldown: 3,
+            effect: {
+                id: 'battleCryBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 2,
+                modifiers: [
+                    { stat: 'physicalAttack', type: 'percentage', value: 0.15 },
+                    { stat: 'meleeAttack', type: 'flat', value: 1 }
+                ]
+            }
+        },
+        EPIC: {
+            id: 'battleCry',
+            name: '전투의 함성 [E]',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.WILL],
+            cost: 1,
+            targetType: 'self',
+            description: '3턴간 자신의 [공격력]을 상승시키고, [근접 공격 등급]을 +1 상승시킵니다. (쿨타임 3턴)',
+            illustrationPath: 'assets/images/skills/battle_cry.png',
+            requiredClass: 'warrior',
+            cooldown: 3,
+            effect: {
+                id: 'battleCryBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 3,
+                modifiers: [
+                    { stat: 'physicalAttack', type: 'percentage', value: 0.15 },
+                    { stat: 'meleeAttack', type: 'flat', value: 1 }
+                ]
+            }
+        },
+        LEGENDARY: {
+            id: 'battleCry',
+            name: '전투의 함성 [L]',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.WILL],
+            cost: 1,
+            targetType: 'self',
+            description: '3턴간 자신의 [공격력]을 상승시키고, [근접 공격 등급]을 +1 상승시킵니다. (쿨타임 3턴)',
+            illustrationPath: 'assets/images/skills/battle_cry.png',
+            requiredClass: 'warrior',
+            cooldown: 3,
+            effect: {
+                id: 'battleCryBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 3,
+                modifiers: [
+                    { stat: 'physicalAttack', type: 'percentage', value: 0.15 },
+                    { stat: 'meleeAttack', type: 'flat', value: 1 }
+                ]
+            }
+        }
+    }
+    // --- ▲ [신규] 전투의 함성 스킬 추가 ▲ ---
 };

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -38,6 +38,8 @@ class SkillInventoryManager {
                 this.addSkillById('suppressShot', grade);
                 // ✨ 낙인 카드 추가
                 this.addSkillById('stigma', grade);
+                // ✨ [신규] 전투의 함성 카드 지급
+                this.addSkillById('battleCry', grade);
             }
         });
 

--- a/src/game/utils/SkillModifierEngine.js
+++ b/src/game/utils/SkillModifierEngine.js
@@ -21,7 +21,9 @@ class SkillModifierEngine {
             'rangedAttack': [1.3, 1.2, 1.1, 1.0],
             // ✨ [신규] 힐 순위별 회복 계수 추가
             'heal': [1.3, 1.2, 1.1, 1.0],
-            'grindstone': [0.25, 0.20, 0.15, 0.10]
+            'grindstone': [0.25, 0.20, 0.15, 0.10],
+            // ✨ [신규] 전투의 함성 공격력 증가 계수
+            'battleCry': [0.30, 0.25, 0.20, 0.15]
         };
         debugLogEngine.log('SkillModifierEngine', '스킬 보정 엔진이 초기화되었습니다.');
     }
@@ -85,6 +87,19 @@ class SkillModifierEngine {
             const bonusModifiers = this.rankModifiers['grindstone'];
             if (bonusModifiers && bonusModifiers[rankIndex] !== undefined) {
                 modifiedSkill.effect.modifiers.value = bonusModifiers[rankIndex];
+            }
+        }
+
+        // ✨ '전투의 함성' 스킬의 공격력 증가 보정
+        if (baseSkillData.id === 'battleCry' && modifiedSkill.effect) {
+            const attackModifiers = this.rankModifiers['battleCry'];
+            if (attackModifiers && attackModifiers[rankIndex] !== undefined) {
+                if (Array.isArray(modifiedSkill.effect.modifiers)) {
+                    const attackMod = modifiedSkill.effect.modifiers.find(m => m.stat === 'physicalAttack');
+                    if (attackMod) attackMod.value = attackModifiers[rankIndex];
+                } else if (modifiedSkill.effect.modifiers && modifiedSkill.effect.modifiers.stat === 'physicalAttack') {
+                    modifiedSkill.effect.modifiers.value = attackModifiers[rankIndex];
+                }
             }
         }
 

--- a/tests/warrior_skill_integration_test.js
+++ b/tests/warrior_skill_integration_test.js
@@ -125,6 +125,55 @@ const ironWillBase = {
     LEGENDARY: { maxReduction: 0.30, hpRegen: 0.06 }
 };
 
+// --- ▼ [신규] 전투의 함성 테스트 데이터 추가 ▼ ---
+const battleCryBase = {
+    NORMAL: {
+        id: 'battleCry',
+        cost: 2,
+        effect: {
+            duration: 2,
+            modifiers: [
+                { stat: 'physicalAttack', type: 'percentage', value: 0.15 },
+                { stat: 'meleeAttack', type: 'flat', value: 1 }
+            ]
+        }
+    },
+    RARE: {
+        id: 'battleCry',
+        cost: 1,
+        effect: {
+            duration: 2,
+            modifiers: [
+                { stat: 'physicalAttack', type: 'percentage', value: 0.15 },
+                { stat: 'meleeAttack', type: 'flat', value: 1 }
+            ]
+        }
+    },
+    EPIC: {
+        id: 'battleCry',
+        cost: 1,
+        effect: {
+            duration: 3,
+            modifiers: [
+                { stat: 'physicalAttack', type: 'percentage', value: 0.15 },
+                { stat: 'meleeAttack', type: 'flat', value: 1 }
+            ]
+        }
+    },
+    LEGENDARY: {
+        id: 'battleCry',
+        cost: 1,
+        effect: {
+            duration: 3,
+            modifiers: [
+                { stat: 'physicalAttack', type: 'percentage', value: 0.15 },
+                { stat: 'meleeAttack', type: 'flat', value: 1 }
+            ]
+        }
+    }
+};
+// --- ▲ [신규] 전투의 함성 테스트 데이터 추가 ▲ ---
+
 // ------- Grade/Rank Tests -------
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
@@ -226,6 +275,24 @@ for (const grade of grades) {
         assert(Math.abs(value - grindstoneExpected[rank - 1]) < 1e-6);
     }
 }
+
+// --- ▼ [신규] 전투의 함성 테스트 로직 추가 ▼ ---
+const battleCryExpectedDamage = [0.30, 0.25, 0.20, 0.15];
+for (const grade of grades) {
+    for (let rank = 1; rank <= 4; rank++) {
+        const skill = skillModifierEngine.getModifiedSkill(battleCryBase[grade], rank, grade);
+        const mods = skill.effect.modifiers;
+        const attackMod = Array.isArray(mods) ? mods.find(m => m.stat === 'physicalAttack') : mods;
+
+        assert.strictEqual(skill.cost, battleCryBase[grade].cost, `Battle Cry cost failed for grade ${grade}`);
+        assert.strictEqual(skill.effect.duration, battleCryBase[grade].effect.duration, `Battle Cry duration failed for grade ${grade}`);
+        assert(Math.abs(attackMod.value - battleCryExpectedDamage[rank - 1]) < 1e-6, `Battle Cry modifier value failed for grade ${grade} rank ${rank}`);
+
+        const meleeMod = Array.isArray(mods) ? mods.find(m => m.stat === 'meleeAttack') : null;
+        assert(meleeMod && meleeMod.value === 1, `meleeAttack modifier missing or incorrect for grade ${grade}`);
+    }
+}
+// --- ▲ [신규] 전투의 함성 테스트 로직 추가 ▲ ---
 
 // Throwing Axe
 const throwingAxeExpected = [1.2, 1.2, 1.2, 1.2];


### PR DESCRIPTION
## Summary
- implement Battle Cry buff skill across all grades
- wire skill into SkillModifierEngine for rank bonuses
- give starting inventory Battle Cry cards
- expand warrior integration tests for Battle Cry skill
- fix Battle Cry buff so all grades grant +1 meleeAttack

## Testing
- `node tests/warrior_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68873f9344688327b2eb21e935315226