### PR TITLE
Add Hunt Sense skill

### DIFF
--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -281,6 +281,95 @@ export const buffSkills = {
                 ]
             }
         }
-    }
+    },
     // --- ▲ [신규] 전투의 함성 스킬 추가 ▲ ---
+
+    // --- ▼ [신규] 사냥꾼의 감각 스킬 추가 ▼ ---
+    huntSense: {
+        NORMAL: {
+            id: 'huntSense',
+            name: '사냥꾼의 감각',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.WILL],
+            cost: 2,
+            targetType: 'self',
+            description: '3턴간 자신의 [원거리 공격 등급]을 +1, [치명타 확률]을 {{critChance}}% 상승시킵니다. (쿨타임 4턴)',
+            illustrationPath: 'assets/images/skills/hunt-sense.png',
+            requiredClass: 'gunner',
+            cooldown: 4,
+            effect: {
+                id: 'huntSenseBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 3,
+                modifiers: [
+                    { stat: 'rangedAttack', type: 'flat', value: 1 },
+                    { stat: 'criticalChance', type: 'percentage', value: 0.15 }
+                ]
+            }
+        },
+        RARE: {
+            id: 'huntSense',
+            name: '사냥꾼의 감각 [R]',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.WILL],
+            cost: 1,
+            targetType: 'self',
+            description: '3턴간 자신의 [원거리 공격 등급]을 +1, [치명타 확률]을 {{critChance}}% 상승시킵니다. (쿨타임 4턴)',
+            illustrationPath: 'assets/images/skills/hunt-sense.png',
+            requiredClass: 'gunner',
+            cooldown: 4,
+            effect: {
+                id: 'huntSenseBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 3,
+                modifiers: [
+                    { stat: 'rangedAttack', type: 'flat', value: 1 },
+                    { stat: 'criticalChance', type: 'percentage', value: 0.15 }
+                ]
+            }
+        },
+        EPIC: {
+            id: 'huntSense',
+            name: '사냥꾼의 감각 [E]',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.WILL],
+            cost: 1,
+            targetType: 'self',
+            description: '3턴간 자신의 [원거리 공격 등급]을 +1, [치명타 확률]을 {{critChance}}% 상승시킵니다. (쿨타임 3턴)',
+            illustrationPath: 'assets/images/skills/hunt-sense.png',
+            requiredClass: 'gunner',
+            cooldown: 3,
+            effect: {
+                id: 'huntSenseBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 3,
+                modifiers: [
+                    { stat: 'rangedAttack', type: 'flat', value: 1 },
+                    { stat: 'criticalChance', type: 'percentage', value: 0.15 }
+                ]
+            }
+        },
+        LEGENDARY: {
+            id: 'huntSense',
+            name: '사냥꾼의 감각 [L]',
+            type: 'BUFF',
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.WILL],
+            cost: 1,
+            targetType: 'self',
+            description: '4턴간 자신의 [원거리 공격 등급]을 +1, [치명타 확률]을 {{critChance}}% 상승시킵니다. (쿨타임 3턴)',
+            illustrationPath: 'assets/images/skills/hunt-sense.png',
+            requiredClass: 'gunner',
+            cooldown: 3,
+            effect: {
+                id: 'huntSenseBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 4,
+                modifiers: [
+                    { stat: 'rangedAttack', type: 'flat', value: 1 },
+                    { stat: 'criticalChance', type: 'percentage', value: 0.15 }
+                ]
+            }
+        }
+    }
+    // --- ▲ [신규] 사냥꾼의 감각 스킬 추가 ▲ ---
 };

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -40,6 +40,8 @@ class SkillInventoryManager {
                 this.addSkillById('stigma', grade);
                 // ✨ [신규] 전투의 함성 카드 지급
                 this.addSkillById('battleCry', grade);
+                // ✨ [신규] 사냥꾼의 감각 카드 지급
+                this.addSkillById('huntSense', grade);
             }
         });
 

--- a/src/game/utils/SkillModifierEngine.js
+++ b/src/game/utils/SkillModifierEngine.js
@@ -23,7 +23,9 @@ class SkillModifierEngine {
             'heal': [1.3, 1.2, 1.1, 1.0],
             'grindstone': [0.25, 0.20, 0.15, 0.10],
             // ✨ [신규] 전투의 함성 공격력 증가 계수
-            'battleCry': [0.30, 0.25, 0.20, 0.15]
+            'battleCry': [0.30, 0.25, 0.20, 0.15],
+            // ✨ [신규] 사냥꾼의 감각 치명타 확률 계수
+            'huntSense': [0.30, 0.25, 0.20, 0.15]
         };
         debugLogEngine.log('SkillModifierEngine', '스킬 보정 엔진이 초기화되었습니다.');
     }
@@ -103,6 +105,19 @@ class SkillModifierEngine {
             }
         }
 
+        // ✨ '사냥꾼의 감각' 스킬의 치명타 확률 보정
+        if (baseSkillData.id === 'huntSense' && modifiedSkill.effect) {
+            const critModifiers = this.rankModifiers['huntSense'];
+            if (critModifiers && critModifiers[rankIndex] !== undefined) {
+                if (Array.isArray(modifiedSkill.effect.modifiers)) {
+                    const critMod = modifiedSkill.effect.modifiers.find(m => m.stat === 'criticalChance');
+                    if (critMod) critMod.value = critModifiers[rankIndex];
+                } else if (modifiedSkill.effect.modifiers && modifiedSkill.effect.modifiers.stat === 'criticalChance') {
+                    modifiedSkill.effect.modifiers.value = critModifiers[rankIndex];
+                }
+            }
+        }
+
         // 차지 스킬의 경우 슬롯 순위에 따라 기절 턴 수를 보정합니다.
         if (baseSkillData.id === 'charge' && modifiedSkill.effect) {
             modifiedSkill.effect.duration = (rank === 1)
@@ -143,6 +158,11 @@ class SkillModifierEngine {
             if (baseSkillData.id === 'grindstone') {
                 const bonusValue = (this.rankModifiers.grindstone[rankIndex] || 0) * 100;
                 modifiedSkill.description = modifiedSkill.description.replace('{{attackBonus}}%', `${bonusValue.toFixed(0)}%`);
+            }
+            // ✨ [신규] 사냥꾼의 감각 치명타 확률 치환
+            if (baseSkillData.id === 'huntSense') {
+                const critValue = (this.rankModifiers.huntSense[rankIndex] || 0) * 100;
+                modifiedSkill.description = modifiedSkill.description.replace('{{critChance}}%', `${critValue.toFixed(0)}%`);
             }
         }
 

--- a/tests/gunner_skill_integration_test.js
+++ b/tests/gunner_skill_integration_test.js
@@ -10,6 +10,35 @@ const suppressShotBase = {
     LEGENDARY: { id: 'suppressShot', damageMultiplier: 1.2, turnOrderEffect: 'pushToBack', effect: { tokenLoss: 1 } }
 };
 
+// --- ▼ [신규] 사냥꾼의 감각 테스트 데이터 추가 ▼ ---
+const huntSenseBase = {
+    NORMAL: {
+        id: 'huntSense',
+        cost: 2,
+        cooldown: 4,
+        effect: { duration: 3, modifiers: [ { stat: 'rangedAttack', type: 'flat', value: 1 }, { stat: 'criticalChance', type: 'percentage', value: 0.15 } ] }
+    },
+    RARE: {
+        id: 'huntSense',
+        cost: 1,
+        cooldown: 4,
+        effect: { duration: 3, modifiers: [ { stat: 'rangedAttack', type: 'flat', value: 1 }, { stat: 'criticalChance', type: 'percentage', value: 0.15 } ] }
+    },
+    EPIC: {
+        id: 'huntSense',
+        cost: 1,
+        cooldown: 3,
+        effect: { duration: 3, modifiers: [ { stat: 'rangedAttack', type: 'flat', value: 1 }, { stat: 'criticalChance', type: 'percentage', value: 0.15 } ] }
+    },
+    LEGENDARY: {
+        id: 'huntSense',
+        cost: 1,
+        cooldown: 3,
+        effect: { duration: 4, modifiers: [ { stat: 'rangedAttack', type: 'flat', value: 1 }, { stat: 'criticalChance', type: 'percentage', value: 0.15 } ] }
+    }
+};
+// --- ▲ [신규] 사냥꾼의 감각 테스트 데이터 추가 ▲ ---
+
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 // 1. 데미지 계수 테스트
@@ -37,4 +66,21 @@ assert.strictEqual(tokenEngine.getTokens(testUnit.uniqueId), 3, 'Initial token s
 tokenEngine.spendTokens(testUnit.uniqueId, 1, '제압 사격 효과');
 assert.strictEqual(tokenEngine.getTokens(testUnit.uniqueId), 2, 'Token loss effect failed');
 
-console.log('Gunner skill [Suppress Shot] integration test passed.');
+// --- ▼ [신규] 사냥꾼의 감각 테스트 로직 추가 ▼ ---
+const huntSenseExpectedCrit = [0.30, 0.25, 0.20, 0.15];
+for (const grade of grades) {
+    for (let rank = 1; rank <= 4; rank++) {
+        const skill = skillModifierEngine.getModifiedSkill(huntSenseBase[grade], rank, grade);
+        const critMod = skill.effect.modifiers.find(m => m.stat === 'criticalChance');
+        const rangedMod = skill.effect.modifiers.find(m => m.stat === 'rangedAttack');
+
+        assert.strictEqual(skill.cost, huntSenseBase[grade].cost, `Hunt Sense cost failed for grade ${grade}`);
+        assert.strictEqual(skill.cooldown, huntSenseBase[grade].cooldown, `Hunt Sense cooldown failed for grade ${grade}`);
+        assert.strictEqual(skill.effect.duration, huntSenseBase[grade].effect.duration, `Hunt Sense duration failed for grade ${grade}`);
+        assert(rangedMod && rangedMod.value === 1, `Ranged attack modifier failed for grade ${grade}`);
+        assert(Math.abs(critMod.value - huntSenseExpectedCrit[rank - 1]) < 1e-6, `Crit chance modifier failed for grade ${grade} rank ${rank}`);
+    }
+}
+// --- ▲ [신규] 사냥꾼의 감각 테스트 로직 추가 ▲ ---
+
+console.log('Gunner skills integration test passed.');


### PR DESCRIPTION
## Summary
- add Hunt Sense buff skill for gunners
- support dynamic crit bonuses in `SkillModifierEngine`
- grant Hunt Sense skill cards in the inventory
- test Hunt Sense across grades and ranks

## Testing
- `node tests/gunner_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68874681d2d08327897d1a57bc47acf5