### PR TITLE
Fix skill tooltip layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -959,18 +959,18 @@ body {
 }
 
 /* --- 스킬 툴팁 스타일 --- */
+/* ✨ [수정] 스킬 툴팁 스타일 수정 */
 #skill-tooltip {
     position: absolute;
-    width: 200px; /* 카드 크기 */
-    height: 280px;
+    width: 200px;
     z-index: 9999;
-    pointer-events: none; /* 툴팁이 마우스 이벤트를 방해하지 않도록 */
+    pointer-events: none;
     display: flex;
     flex-direction: column;
     background-color: #2a2a2a;
     border-radius: 10px;
     border: 2px solid #888;
-    overflow: hidden;
+    min-height: 280px; /* 최소 높이 설정 */
 }
 
 .skill-card-large.active-card { border-color: #FF8C00; }


### PR DESCRIPTION
## Summary
- update `#skill-tooltip` style to use a minimum height

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68875ae039208327a9b0e6c4c811d7ad