### PR TITLE
Enhance unit detail view with grade display

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1373,3 +1373,86 @@ body {
     font-weight: bold;
     border-color: #f0e68c;
 }
+
+/* --- ✨ [신규] 유닛 상세 정보창 등급 표시 스타일 --- */
+.unit-grades-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 15px;
+}
+
+.unit-portrait {
+    width: 250px; /* 기존보다 너비 약간 축소 */
+    height: 300px;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center top;
+    border-radius: 5px;
+    border: 2px solid #555;
+    flex-shrink: 0; /* 컨테이너 크기가 줄어도 초상화는 줄어들지 않음 */
+}
+
+.unit-grades {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    font-size: 20px;
+    font-weight: bold;
+}
+
+.unit-grades.left {
+    align-items: flex-start;
+}
+
+.unit-grades.right {
+    align-items: flex-end;
+}
+
+.grade-item {
+    padding: 8px 12px;
+    background-color: rgba(0, 0, 0, 0.4);
+    border: 1px solid #444;
+    border-radius: 5px;
+    cursor: help; /* 마우스 커서를 도움말로 변경 */
+    position: relative; /* 툴팁의 기준점이 됨 */
+}
+
+/* --- ✨ [신규] 등급 툴팁 스타일 --- */
+.grade-item:hover::after {
+    content: attr(data-tooltip); /* data-tooltip 속성 내용을 가져옴 */
+    position: absolute;
+    bottom: 125%; /* 아이템 위쪽에 표시 */
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #1a1817;
+    color: #e0e0e0;
+    padding: 8px 12px;
+    border-radius: 4px;
+    border: 1px solid #555;
+    font-size: 14px;
+    white-space: nowrap; /* 툴팁 내용이 줄바꿈되지 않도록 */
+    z-index: 10;
+    pointer-events: none; /* 툴팁 위로 마우스가 올라가도 이벤트가 막히지 않도록 */
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+.grade-item:hover::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: #1a1817 transparent transparent transparent;
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+
+.grade-item:hover::after,
+.grade-item:hover::before {
+    opacity: 1;
+}

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -2,9 +2,10 @@ import { statEngine } from '../utils/StatEngine.js';
 import { SKILL_TYPES } from '../utils/SkillEngine.js';
 import { ownedSkillsManager } from '../utils/OwnedSkillsManager.js';
 import { skillInventoryManager } from '../utils/SkillInventoryManager.js';
-// ✨ 스킬 툴팁 매니저를 import하여 슬롯에 마우스 오버 기능을 제공합니다.
 import { SkillTooltipManager } from './SkillTooltipManager.js';
 import { skillModifierEngine } from '../utils/SkillModifierEngine.js';
+// ✨ 등급 데이터를 가져오기 위해 classGrades를 import합니다.
+import { classGrades } from '../data/classGrades.js';
 
 /**
  * 용병 상세 정보 창의 DOM을 생성하고 관리하는 유틸리티 클래스
@@ -12,6 +13,8 @@ import { skillModifierEngine } from '../utils/SkillModifierEngine.js';
 export class UnitDetailDOM {
     static create(unitData) {
         const finalStats = statEngine.calculateStats(unitData, unitData.baseStats, []);
+        // ✨ 해당 유닛의 등급 데이터를 가져옵니다.
+        const grades = classGrades[unitData.id] || {};
 
         const overlay = document.createElement('div');
         overlay.id = 'unit-detail-overlay';
@@ -23,7 +26,7 @@ export class UnitDetailDOM {
 
         const detailPane = document.createElement('div');
         detailPane.id = 'unit-detail-pane';
-        
+
         const instanceName = unitData.instanceName || unitData.name;
         let headerHTML = `
             <div class="detail-header">
@@ -34,14 +37,32 @@ export class UnitDetailDOM {
             <div id="unit-detail-close" onclick="this.closest('#unit-detail-overlay').remove()">X</div>
         `;
         detailPane.innerHTML = headerHTML;
-        
+
         const detailContent = document.createElement('div');
         detailContent.className = 'detail-content';
-        
+
         const leftSection = document.createElement('div');
         leftSection.className = 'detail-section left';
+
+        // ✨ --- 등급 표시 로직 추가 ---
+        const gradeDisplayHTML = `
+            <div class="unit-grades-container">
+                <div class="unit-grades left">
+                    <div class="grade-item" data-tooltip="근접 공격 등급: 이 유닛이 근접 공격 시 얼마나 우위를 갖는지 나타냅니다. 높을수록 강력합니다.">⚔️ ${grades.meleeAttack || 1}</div>
+                    <div class="grade-item" data-tooltip="원거리 공격 등급: 원거리 공격 시 유불리를 나타냅니다. 원거리 딜러에게 중요합니다.">🏹 ${grades.rangedAttack || 1}</div>
+                    <div class="grade-item" data-tooltip="마법 공격 등급: 마법 공격 시 효율을 나타냅니다. 마법사 클래스의 핵심 능력치입니다.">🔮 ${grades.magicAttack || 1}</div>
+                </div>
+                <div class="unit-portrait" style="background-image: url(${unitData.uiImage})"></div>
+                <div class="unit-grades right">
+                    <div class="grade-item" data-tooltip="근접 방어 등급: 근접 공격을 받았을 때 얼마나 잘 버티는지 나타냅니다. 탱커에게 필수적입니다.">🛡️ ${grades.meleeDefense || 1}</div>
+                    <div class="grade-item" data-tooltip="원거리 방어 등급: 화살이나 총탄 등 원거리 공격에 대한 저항력입니다.">🎯 ${grades.rangedDefense || 1}</div>
+                    <div class="grade-item" data-tooltip="마법 방어 등급: 마법 공격에 대한 저항력입니다. 적 마법사를 상대할 때 중요합니다.">✨ ${grades.magicDefense || 1}</div>
+                </div>
+            </div>
+        `;
+
         leftSection.innerHTML = `
-            <div class="unit-portrait" style="background-image: url(${unitData.uiImage})"></div>
+            ${gradeDisplayHTML}
             <div class="stats-grid">
                 <div class="section-title">스탯</div>
                 <div class="stat-item"><span>HP</span><span>${finalStats.hp}</span></div>
@@ -52,14 +73,6 @@ export class UnitDetailDOM {
                 <div class="stat-item"><span>지능</span><span>${finalStats.intelligence}</span></div>
                 <div class="stat-item"><span>지혜</span><span>${finalStats.wisdom}</span></div>
                 <div class="stat-item"><span>행운</span><span>${finalStats.luck}</span></div>
-            </div>
-            <div class="traits-section">
-                <div class="section-title">특성 (미구현)</div>
-                <div class="placeholder-box"></div>
-            </div>
-            <div class="synergy-section">
-                <div class="section-title">시너지 (미구현)</div>
-                <div class="placeholder-box"></div>
             </div>
         `;
 


### PR DESCRIPTION
## Summary
- show unit attack/defense grades beside the portrait
- add tooltip styling for grade info

## Testing
- `node tests/movement_stat_test.js && node tests/warrior_skill_integration_test.js && node tests/gunner_skill_integration_test.js && node tests/medic_skill_integration_test.js && node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68875f8a047c83278efc6165f875e264