### PR TITLE
Add combo debug logging

### DIFF
--- a/src/game/debug/DebugComboManager.js
+++ b/src/game/debug/DebugComboManager.js
@@ -1,0 +1,33 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * 콤보 시스템의 동작을 추적하고 로그로 남기는 디버그 매니저
+ */
+class DebugComboManager {
+    constructor() {
+        this.name = 'DebugCombo';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 콤보로 인한 데미지 감산 과정을 로그로 남깁니다.
+     * @param {number} comboCount - 현재 콤보 수
+     * @param {number} multiplier - 적용된 데미지 배율
+     * @param {number} originalDamage - 배율 적용 전 데미지
+     * @param {number} finalDamage - 최종 데미지
+     */
+    logComboDamage(comboCount, multiplier, originalDamage, finalDamage) {
+        if (comboCount < 2) return; // 1콤보일 때는 로그를 남기지 않습니다.
+
+        console.groupCollapsed(
+            `%c[${this.name}]`, `color: #ec4899; font-weight: bold;`,
+            `${comboCount} 콤보 데미지 감산 적용`
+        );
+        debugLogEngine.log(this.name, `콤보 배율: ${multiplier.toFixed(2)}배`);
+        debugLogEngine.log(this.name, `감산 전 데미지: ${originalDamage.toFixed(2)}`);
+        debugLogEngine.log(this.name, `최종 데미지: %c${finalDamage.toFixed(2)}`, 'color: #facc15; font-weight: bold;');
+        console.groupEnd();
+    }
+}
+
+export const debugComboManager = new DebugComboManager();

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -14,6 +14,8 @@ import { gradeManager } from './GradeManager.js';
 import { ATTACK_TYPE } from '../data/classGrades.js';
 import { SKILL_TAGS } from './SkillTagManager.js';
 import { comboManager } from './ComboManager.js';
+// 콤보 계산 과정을 상세히 기록하기 위한 디버그 매니저
+import { debugComboManager } from '../debug/DebugComboManager.js';
 
 /**
  * 실제 전투 데미지 계산을 담당하는 엔진
@@ -123,8 +125,11 @@ class CombatCalculationEngine {
 
         // 모든 데미지 감소/증가 효과를 합산
         const finalDamageMultiplier = 1 - damageReductionPercent - ironWillReduction + damageIncreasePercent;
+        const damageBeforeCombo = damageAfterGrade * finalDamageMultiplier;
+        const finalDamage = damageBeforeCombo * comboMultiplier;
 
-        const finalDamage = damageAfterGrade * finalDamageMultiplier * comboMultiplier;
+        // 콤보 배율 적용 과정을 디버그 로그로 남깁니다.
+        debugComboManager.logComboDamage(comboCount, comboMultiplier, damageBeforeCombo, finalDamage);
 
         if (damageReductionPercent > 0 || damageIncreasePercent > 0 || ironWillReduction > 0) {
             const effects = (statusEffectManager.activeEffects.get(defender.uniqueId) || [])

--- a/src/game/utils/ComboManager.js
+++ b/src/game/utils/ComboManager.js
@@ -1,4 +1,6 @@
 import { debugLogEngine } from './DebugLogEngine.js';
+// 디버그용 콤보 매니저를 초기화하여 로그 출력을 활성화합니다.
+import { debugComboManager } from '../debug/DebugComboManager.js';
 
 class ComboManager {
     constructor() {


### PR DESCRIPTION
## Summary
- create `DebugComboManager` for combo damage logs
- integrate combo debug manager into combo and combat engines

## Testing
- `node tests/movement_stat_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6887805b0b8083278ba0c7146bedaa41