### PR TITLE
Apply 9‑slice UI panels

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -709,12 +709,13 @@ body {
 
 .skill-panel {
     background-color: rgba(0, 0, 0, 0.6);
-    border: 2px solid #555;
-    border-radius: 8px;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
     pointer-events: auto; /* ✨ 마우스 이벤트 활성화 */
+    border: 16px solid transparent;
+    border-image: url('../assets/images/ui-panel.png') 16 fill stretch;
+    background-clip: padding-box;
 }
 
 #skill-list-panel { flex-basis: 20%; }
@@ -1063,8 +1064,6 @@ body {
     width: 700px;
     height: 110px;
     background-color: rgba(0, 0, 0, 0.75);
-    border: 2px solid #4a4a4a;
-    border-radius: 10px;
     box-shadow: 0 0 15px rgba(0,0,0,0.5);
     display: flex;
     justify-content: space-between;
@@ -1073,6 +1072,9 @@ body {
     z-index: 200;
     pointer-events: none;
     box-sizing: border-box;
+    border: 16px solid transparent;
+    border-image: url('../assets/images/ui-panel.png') 16 fill stretch;
+    background-clip: padding-box;
 }
 
 .combat-info-panel {


### PR DESCRIPTION
## Summary
- use `assets/images/ui-panel.png` for a 9‑slice look on skill panels
- give combat UI container the same scalable panel style

## Testing
- `node tests/movement_stat_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6887b9f5f64083279a36b0e8d3552e7f