### PR TITLE
Add missing gunner skill tests

### DIFF
--- a/tests/gunner_skill_integration_test.js
+++ b/tests/gunner_skill_integration_test.js
@@ -10,6 +10,22 @@ const suppressShotBase = {
     LEGENDARY: { id: 'suppressShot', damageMultiplier: 1.2, turnOrderEffect: 'pushToBack', effect: { tokenLoss: 1 } }
 };
 
+// --- ▼ [신규] 넉백샷 및 원거리 공격 테스트 데이터 추가 ▼ ---
+const knockbackShotBase = {
+    NORMAL: { id: 'knockbackShot', cost: 2, cooldown: 2, damageMultiplier: 0.8, push: 1 },
+    RARE: { id: 'knockbackShot', cost: 2, cooldown: 1, damageMultiplier: 0.8, push: 1 },
+    EPIC: { id: 'knockbackShot', cost: 1, cooldown: 1, damageMultiplier: 0.8, push: 1 },
+    LEGENDARY: { id: 'knockbackShot', cost: 1, cooldown: 1, damageMultiplier: 0.8, push: 2 }
+};
+
+const rangedAttackBase = {
+    NORMAL: { id: 'rangedAttack', cost: 1, cooldown: 0, damageMultiplier: 1.0 },
+    RARE: { id: 'rangedAttack', cost: 0, cooldown: 0, damageMultiplier: 1.0 },
+    EPIC: { id: 'rangedAttack', cost: 0, cooldown: 0, damageMultiplier: 1.0, generatesToken: { chance: 0.5, amount: 1 } },
+    LEGENDARY: { id: 'rangedAttack', cost: 0, cooldown: 0, damageMultiplier: 1.0, generatesToken: { chance: 1.0, amount: 1 } }
+};
+// --- ▲ [신규] 넉백샷 및 원거리 공격 테스트 데이터 추가 ▲ ---
+
 // --- ▼ [신규] 사냥꾼의 감각 테스트 데이터 추가 ▼ ---
 const huntSenseBase = {
     NORMAL: {
@@ -65,6 +81,48 @@ assert.strictEqual(tokenEngine.getTokens(testUnit.uniqueId), 3, 'Initial token s
 
 tokenEngine.spendTokens(testUnit.uniqueId, 1, '제압 사격 효과');
 assert.strictEqual(tokenEngine.getTokens(testUnit.uniqueId), 2, 'Token loss effect failed');
+
+// --- ▼ [신규] 넉백샷 테스트 로직 추가 ▼ ---
+const knockbackExpectedDamage = [1.4, 1.2, 1.0, 0.8];
+for (const grade of grades) {
+    for (let rank = 1; rank <= 4; rank++) {
+        const skill = skillModifierEngine.getModifiedSkill(knockbackShotBase[grade], rank, grade);
+        assert.strictEqual(skill.damageMultiplier, knockbackExpectedDamage[rank - 1], `Knockback damage failed for ${grade} rank ${rank}`);
+
+        const expectedCost = (grade === 'EPIC' || grade === 'LEGENDARY') ? 1 : 2;
+        const expectedCooldown = grade === 'NORMAL' ? 2 : 1;
+        const expectedPush = grade === 'LEGENDARY' ? 2 : 1;
+
+        assert.strictEqual(skill.cost, expectedCost, `Knockback cost failed for ${grade}`);
+        assert.strictEqual(skill.cooldown, expectedCooldown, `Knockback cooldown failed for ${grade}`);
+        assert.strictEqual(skill.push, expectedPush, `Knockback push failed for ${grade}`);
+    }
+}
+// --- ▲ [신규] 넉백샷 테스트 로직 추가 ▲ ---
+
+// --- ▼ [신규] 원거리 공격 테스트 로직 추가 ▼ ---
+const rangedAttackExpectedDamage = [1.3, 1.2, 1.1, 1.0];
+for (const grade of grades) {
+    for (let rank = 1; rank <= 4; rank++) {
+        const skill = skillModifierEngine.getModifiedSkill(rangedAttackBase[grade], rank, grade);
+        assert.strictEqual(skill.damageMultiplier, rangedAttackExpectedDamage[rank - 1], `Ranged attack dmg failed for ${grade} rank ${rank}`);
+
+        if (grade === 'NORMAL') {
+            assert.strictEqual(skill.cost, 1, `Ranged attack cost failed for ${grade}`);
+        } else {
+            assert.strictEqual(skill.cost, 0, `Ranged attack cost failed for ${grade}`);
+        }
+
+        if (grade === 'EPIC') {
+            assert(skill.generatesToken && skill.generatesToken.chance === 0.5, `Token generation failed for ${grade}`);
+        } else if (grade === 'LEGENDARY') {
+            assert(skill.generatesToken && skill.generatesToken.chance === 1.0, `Token generation failed for ${grade}`);
+        } else {
+            assert(!skill.generatesToken, `Unexpected token generation for ${grade}`);
+        }
+    }
+}
+// --- ▲ [신규] 원거리 공격 테스트 로직 추가 ▲ ---
 
 // --- ▼ [신규] 사냥꾼의 감각 테스트 로직 추가 ▼ ---
 const huntSenseExpectedCrit = [0.30, 0.25, 0.20, 0.15];


### PR DESCRIPTION
## Summary
- cover the new gunner skills in the integration test
- add knockback shot and ranged attack data and assertions

## Testing
- `node tests/gunner_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6887c04b98888327bd83503b2cdd732a