### PR TITLE
Implement Mighty Shield skill with damage immunity

### DIFF
--- a/src/game/data/skills/aid.js
+++ b/src/game/data/skills/aid.js
@@ -146,6 +146,88 @@ export const aidSkills = {
                 }
             }
         }
-    }
+    },
     // --- ▲ [신규] 윌 가드 스킬 추가 ▲ ---
+
+    // --- ▼ [신규] 마이티 쉴드 스킬 추가 ▼ ---
+    mightyShield: {
+        NORMAL: {
+            id: 'mightyShield',
+            name: '마이티 쉴드',
+            type: 'AID',
+            tags: [SKILL_TAGS.AID, SKILL_TAGS.WILL_GUARD, SKILL_TAGS.FIXED, SKILL_TAGS.LIGHT, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'ally',
+            description: '아군에게 2회의 공격을 완벽하게 막아내는 빛의 방패를 부여합니다. (쿨타임 10턴, 소모 자원: 빛 5)',
+            illustrationPath: 'assets/images/skills/mighty-shield.png',
+            requiredClass: 'medic',
+            cooldown: 10,
+            range: 3,
+            resourceCost: { type: 'LIGHT', amount: 5 },
+            effect: {
+                id: 'mightyShield',
+                type: EFFECT_TYPES.BUFF,
+                stack: { type: 'DAMAGE_IMMUNITY', amount: 2 }
+            }
+        },
+        RARE: {
+            id: 'mightyShield',
+            name: '마이티 쉴드 [R]',
+            type: 'AID',
+            tags: [SKILL_TAGS.AID, SKILL_TAGS.WILL_GUARD, SKILL_TAGS.FIXED, SKILL_TAGS.LIGHT, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'ally',
+            description: '아군에게 3회의 공격을 완벽하게 막아내는 빛의 방패를 부여합니다. (쿨타임 9턴, 소모 자원: 빛 5)',
+            illustrationPath: 'assets/images/skills/mighty-shield.png',
+            requiredClass: 'medic',
+            cooldown: 9,
+            range: 3,
+            resourceCost: { type: 'LIGHT', amount: 5 },
+            effect: {
+                id: 'mightyShield',
+                type: EFFECT_TYPES.BUFF,
+                stack: { type: 'DAMAGE_IMMUNITY', amount: 3 }
+            }
+        },
+        EPIC: {
+            id: 'mightyShield',
+            name: '마이티 쉴드 [E]',
+            type: 'AID',
+            tags: [SKILL_TAGS.AID, SKILL_TAGS.WILL_GUARD, SKILL_TAGS.FIXED, SKILL_TAGS.LIGHT, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'ally',
+            description: '아군에게 4회의 공격을 완벽하게 막아내는 빛의 방패를 부여합니다. (쿨타임 8턴, 소모 자원: 빛 4)',
+            illustrationPath: 'assets/images/skills/mighty-shield.png',
+            requiredClass: 'medic',
+            cooldown: 8,
+            range: 4,
+            resourceCost: { type: 'LIGHT', amount: 4 },
+            effect: {
+                id: 'mightyShield',
+                type: EFFECT_TYPES.BUFF,
+                stack: { type: 'DAMAGE_IMMUNITY', amount: 4 }
+            }
+        },
+        LEGENDARY: {
+            id: 'mightyShield',
+            name: '마이티 쉴드 [L]',
+            type: 'AID',
+            tags: [SKILL_TAGS.AID, SKILL_TAGS.WILL_GUARD, SKILL_TAGS.FIXED, SKILL_TAGS.LIGHT, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'ally',
+            description: '아군에게 5회의 공격을 완벽하게 막아내는 빛의 방패를 부여하고, 대상의 해로운 효과를 1개 제거합니다. (쿨타임 7턴, 소모 자원: 빛 4)',
+            illustrationPath: 'assets/images/skills/mighty-shield.png',
+            requiredClass: 'medic',
+            cooldown: 7,
+            range: 4,
+            resourceCost: { type: 'LIGHT', amount: 4 },
+            removesDebuff: { chance: 1.0 },
+            effect: {
+                id: 'mightyShield',
+                type: EFFECT_TYPES.BUFF,
+                stack: { type: 'DAMAGE_IMMUNITY', amount: 5 }
+            }
+        }
+    }
+    // --- ▲ [신규] 마이티 쉴드 스킬 추가 ▲ ---
 };

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -83,4 +83,21 @@ export const statusEffects = {
         },
     },
     // --- ▲ [신규] 윌 가드 효과 추가 ▲ ---
+
+    // --- ▼ [신규] 마이티 쉴드 효과 추가 ▼ ---
+    mightyShield: {
+        id: 'mightyShield',
+        name: '마이티 쉴드',
+        description: '다음 공격의 피해를 완전히 무효화합니다.',
+        iconPath: 'assets/images/skills/mighty-shield.png',
+        onApply: (unit, effectData) => {
+            if (effectData && effectData.stack) {
+                stackManager.addStack(unit.uniqueId, FIXED_DAMAGE_TYPES.DAMAGE_IMMUNITY, effectData.stack.amount);
+            }
+        },
+        onRemove: (unit) => {
+            // 스택은 공격받을 때 자동으로 소모되므로 별도 로직 불필요
+        },
+    },
+    // --- ▲ [신규] 마이티 쉴드 효과 추가 ▲ ---
 };

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -34,6 +34,13 @@ class CombatCalculationEngine {
      * @returns {number} 최종 적용될 데미지
      */
     calculateDamage(attacker = {}, defender = {}, skill = {}, instanceId, grade = 'NORMAL') {
+        // ✨ --- [신규] 피해 무효화 효과 최우선 처리 --- ✨
+        if (stackManager.hasStack(defender.uniqueId, FIXED_DAMAGE_TYPES.DAMAGE_IMMUNITY)) {
+            stackManager.consumeStack(defender.uniqueId, FIXED_DAMAGE_TYPES.DAMAGE_IMMUNITY);
+            debugCombatLogManager.logAttackCalculation(attacker, defender, 0, 0, 0);
+            return { damage: 0, hitType: '무효', comboCount: 0 };
+        }
+
         const baseAttack = attacker.finalStats?.physicalAttack || 0;
 
         // 콤보 배율 계산을 위한 정보

--- a/src/game/utils/FixedDamageManager.js
+++ b/src/game/utils/FixedDamageManager.js
@@ -12,6 +12,7 @@ export const FIXED_DAMAGE_TYPES = {
     WEAKNESS: 'WEAKNESS',       // 확정 약점 공격
     BLOCK: 'BLOCK',             // 확정 막기
     MITIGATION: 'MITIGATION',   // 확정 완화
+    DAMAGE_IMMUNITY: 'DAMAGE_IMMUNITY', // ✨ [신규] 피해 무효화
 };
 
 // 최종 판정 결과를 상수로 정의합니다. (CombatCalculationEngine과 호환)

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -46,6 +46,8 @@ class SkillInventoryManager {
                 this.addSkillById('criticalShot', grade);
                 // ✨ [신규] 윌 가드 카드 지급
                 this.addSkillById('willGuard', grade);
+                // ✨ [신규] 마이티 쉴드 카드 지급
+                this.addSkillById('mightyShield', grade);
             }
         });
 

--- a/tests/mighty_shield_skill_test.js
+++ b/tests/mighty_shield_skill_test.js
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import { skillModifierEngine } from '../src/game/utils/SkillModifierEngine.js';
+
+// 1. 테스트를 위한 마이티 쉴드 기본 데이터 정의
+const mightyShieldBase = {
+    NORMAL: { id: 'mightyShield', cooldown: 10, resourceCost: { type: 'LIGHT', amount: 5 }, effect: { stack: { amount: 2 } } },
+    RARE: { id: 'mightyShield', cooldown: 9, resourceCost: { type: 'LIGHT', amount: 5 }, effect: { stack: { amount: 3 } } },
+    EPIC: { id: 'mightyShield', cooldown: 8, resourceCost: { type: 'LIGHT', amount: 4 }, effect: { stack: { amount: 4 } } },
+    LEGENDARY: { id: 'mightyShield', cooldown: 7, resourceCost: { type: 'LIGHT', amount: 4 }, removesDebuff: { chance: 1.0 }, effect: { stack: { amount: 5 } } }
+};
+
+const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
+
+// 2. 모든 등급에 대해 테스트 실행
+for (const grade of grades) {
+    // 특수 스킬은 순위 보정이 없으므로 rank는 1로 고정
+    const skill = skillModifierEngine.getModifiedSkill(mightyShieldBase[grade], 1, grade);
+
+    // 3. 각 등급별 속성 값이 예상과 일치하는지 확인
+    assert.strictEqual(skill.cooldown, mightyShieldBase[grade].cooldown, `Cooldown failed for ${grade}`);
+    assert.deepStrictEqual(skill.resourceCost, mightyShieldBase[grade].resourceCost, `Resource cost failed for ${grade}`);
+    assert.strictEqual(skill.effect.stack.amount, mightyShieldBase[grade].effect.stack.amount, `Stack amount failed for ${grade}`);
+    
+    if (grade === 'LEGENDARY') {
+        assert(skill.removesDebuff && skill.removesDebuff.chance === 1.0, 'Removes debuff effect failed for LEGENDARY');
+    }
+}
+
+// 4. 모든 테스트 통과 시 메시지 출력
+console.log('Mighty Shield skill integration test passed.');


### PR DESCRIPTION
## Summary
- add damage immunity as new fixed damage type
- check DAMAGE_IMMUNITY stack first during combat calculations
- introduce Mighty Shield skill with rank scaling
- grant Mighty Shield card at game start
- implement status effect for Mighty Shield
- add integration tests for Mighty Shield

## Testing
- `for file in tests/*.js; do echo "Running $file"; node $file; done`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6887d2986b048327942a30846e643483