### PR TITLE
Fix skill type check for strategy skills

### DIFF
--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -311,8 +311,8 @@ export class SkillManagementDOMEngine {
             alert(`이 스킬은 ${draggedSkillData.requiredClass} 전용입니다.`);
             return;
         }
-        // 1~4번 슬롯은 타입이 일치해야 함
-        if (targetSlotIndex < 4 && draggedSkillData.type !== targetSlotType) {
+        // ✨ [수정] 전략 스킬이 아닐 경우에만 타입 일치를 검사합니다.
+        if (targetSlotIndex < 4 && draggedSkillData.type !== 'STRATEGY' && draggedSkillData.type !== targetSlotType) {
             alert('스킬과 슬롯의 타입이 일치하지 않습니다.');
             return;
         }


### PR DESCRIPTION
## Summary
- allow strategy skills to bypass slot type restrictions in SkillManagementDOMEngine

## Testing
- `node tests/warrior_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/critical_shot_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/movement_stat_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/mighty_shield_skill_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6888c2dd8c748327bef2384638ca9b7a