### PR TITLE
Add modal animations & global font

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="public/style.css">
     <title>Phaser - Template</title>
 </head>

--- a/public/style.css
+++ b/public/style.css
@@ -1,8 +1,55 @@
+/* ✨ [추가] Cinzel 폰트를 body에 적용하여 전역 폰트로 설정합니다. */
 body {
     margin: 0;
     padding: 0;
     color: rgba(255, 255, 255, 0.87);
     background-color: #000000;
+  font-family: 'Cinzel', serif; /* ✨ 폰트 적용 */
+}
+
+/* ✨ [추가] 부드러운 전환 효과를 위한 기본 스타일 */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+    pointer-events: auto;
+    opacity: 0; /* ✨ 초기에는 투명하게 */
+    visibility: hidden; /* ✨ 초기에는 보이지 않고 상호작용도 안 되게 */
+    transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out; /* ✨ 전환 효과 */
+}
+
+/* ✨ [수정] 모달이 표시될 때 적용할 클래스 */
+.modal-overlay.visible {
+    opacity: 1;
+    visibility: visible; /* ✨ 보이면서 상호작용 가능하게 */
+}
+
+/* ✨ [추가] 활성 턴 UI 강조를 위한 애니메이션 */
+@keyframes active-turn-glow {
+    0% {
+        border-color: #4a4a4a;
+        box-shadow: 0 0 15px rgba(0,0,0,0.5);
+    }
+    50% {
+        border-color: #f0e68c; /* 밝은 노란색 */
+        box-shadow: 0 0 20px rgba(240, 230, 140, 0.7);
+    }
+    100% {
+        border-color: #4a4a4a;
+        box-shadow: 0 0 15px rgba(0,0,0,0.5);
+    }
+}
+
+/* ✨ [추가] 활성 턴 UI에 적용될 클래스 */
+#combat-ui-container.active-turn-ui {
+    animation: active-turn-glow 2s infinite;
 }
 
 #app {
@@ -208,19 +255,7 @@ body {
 }
 
 /* --- 용병 고용 모달 스타일 (수정) --- */
-#hire-modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.8);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
-    pointer-events: auto;
-}
+/* ✨ ID 선택자 대신 공통 클래스를 사용합니다. */
 
 #hire-modal-content {
     position: relative;
@@ -277,19 +312,7 @@ body {
 }
 
 /* --- 유닛 상세 정보창 스타일 --- */
-#unit-detail-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.7);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 2000;
-    pointer-events: auto;
-}
+/* ✨ ID 선택자 대신 공통 클래스를 사용합니다. */
 
 #unit-detail-pane {
     /* 가로형 레이아웃을 위해 크기 조정 */

--- a/src/game/dom/PartyDOMEngine.js
+++ b/src/game/dom/PartyDOMEngine.js
@@ -141,6 +141,12 @@ export class PartyDOMEngine {
 
         this.unitDetailView = UnitDetailDOM.create(unitData);
         this.container.appendChild(this.unitDetailView);
+
+        // ✨ [추가] DOM에 추가한 후 'visible' 클래스를 추가하여 fade-in 애니메이션을 트리거합니다.
+        // requestAnimationFrame을 사용하여 브라우저가 요소를 렌더링할 시간을 줍니다.
+        requestAnimationFrame(() => {
+            this.unitDetailView.classList.add('visible');
+        });
     }
 
     hideUnitDetails() {

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -195,7 +195,8 @@ export class TerritoryDOMEngine {
         if (this.hireModal) return;
 
         this.hireModal = document.createElement('div');
-        this.hireModal.id = 'hire-modal-overlay';
+        // ✨ [수정] ID 대신 클래스를 사용합니다.
+        this.hireModal.className = 'modal-overlay';
         
         const modalContent = document.createElement('div');
         modalContent.id = 'hire-modal-content';
@@ -249,6 +250,11 @@ export class TerritoryDOMEngine {
         this.hireModal.appendChild(modalContent);
         this.container.appendChild(this.hireModal);
 
+        // ✨ [추가] fade-in 애니메이션을 트리거합니다.
+        requestAnimationFrame(() => {
+            this.hireModal.classList.add('visible');
+        });
+
         this.hireModal.addEventListener('wheel', (event) => {
             event.preventDefault();
             this.changeMercenary(event.deltaY > 0 ? 1 : -1);
@@ -259,8 +265,12 @@ export class TerritoryDOMEngine {
     
     hideHireModal() {
         if (this.hireModal) {
-            this.hireModal.remove();
-            this.hireModal = null;
+            // ✨ [수정] fade-out 애니메이션을 트리거하고, 끝나면 DOM에서 제거합니다.
+            this.hireModal.classList.remove('visible');
+            this.hireModal.addEventListener('transitionend', () => {
+                if (this.hireModal) this.hireModal.remove();
+                this.hireModal = null;
+            }, { once: true });
         }
     }
 
@@ -299,6 +309,11 @@ export class TerritoryDOMEngine {
 
         this.unitDetailView = UnitDetailDOM.create(unitData);
         this.container.appendChild(this.unitDetailView);
+
+        // ✨ [추가] fade-in 애니메이션을 트리거합니다.
+        requestAnimationFrame(() => {
+            this.unitDetailView.classList.add('visible');
+        });
     }
 
     hideUnitDetails() {

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -17,10 +17,14 @@ export class UnitDetailDOM {
         const grades = classGrades[unitData.id] || {};
 
         const overlay = document.createElement('div');
-        overlay.id = 'unit-detail-overlay';
+        // ✨ [수정] ID 대신 클래스를 사용합니다.
+        overlay.className = 'modal-overlay';
         overlay.onclick = (e) => {
-            if (e.target.id === 'unit-detail-overlay') {
-                overlay.remove();
+            // ✨ [수정] fade-out 애니메이션을 위해 클래스를 제거하는 방식으로 변경합니다.
+            if (e.target === overlay) {
+                overlay.classList.remove('visible');
+                // 애니메이션이 끝난 후 DOM에서 완전히 제거합니다.
+                overlay.addEventListener('transitionend', () => overlay.remove(), { once: true });
             }
         };
 
@@ -34,7 +38,7 @@ export class UnitDetailDOM {
                 <span class="unit-class">${unitData.name}</span>
                 <span class="unit-level">Lv. ${unitData.level}</span>
             </div>
-            <div id="unit-detail-close" onclick="this.closest('#unit-detail-overlay').remove()">X</div>
+            <div id="unit-detail-close">X</div>
         `;
         detailPane.innerHTML = headerHTML;
 
@@ -151,6 +155,13 @@ export class UnitDetailDOM {
         detailContent.appendChild(rightSection);
         detailPane.appendChild(detailContent);
         overlay.appendChild(detailPane);
+
+        // ✨ [추가] 닫기 버튼에 이벤트 리스너를 추가합니다.
+        const closeButton = detailPane.querySelector('#unit-detail-close');
+        closeButton.onclick = () => {
+            overlay.classList.remove('visible');
+            overlay.addEventListener('transitionend', () => overlay.remove(), { once: true });
+        };
 
         return overlay;
     }


### PR DESCRIPTION
## Summary
- apply Google font to all pages
- add modal overlay class with fade transitions and add active-turn glow animation
- refactor UnitDetailDOM to use new overlay class and animated closing
- animate opening of unit details in party and territory views
- animate hire modal with fade-in/out

## Testing
- `for f in tests/*.js; do node $f; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6888cdd5c94c832793565f361ffcaa11