### PR TITLE
Add Nanomancer class and Nanobeam skill

### DIFF
--- a/src/game/data/classGrades.js
+++ b/src/game/data/classGrades.js
@@ -38,6 +38,14 @@ export const classGrades = {
         rangedDefense: 2,
         magicDefense: 3,
     },
+    nanomancer: {
+        meleeAttack: 1,
+        rangedAttack: 2,
+        magicAttack: 3,
+        meleeDefense: 1,
+        rangedDefense: 2,
+        magicDefense: 3,
+    },
     // --- 다른 클래스 추가 예정 ---
     zombie: {
         meleeAttack: 2,

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -66,6 +66,28 @@ export const mercenaryData = {
             movement: 2,
             weight: 18 // ✨ 메딕 무게 추가
         }
-    }
+    },
     // --- ▲ [신규] 메딕 클래스 데이터 추가 ▲ ---
+    nanomancer: {
+        id: 'nanomancer',
+        name: '나노맨서',
+        hireImage: 'assets/images/unit/nanomancer-hire.png',
+        uiImage: 'assets/images/unit/nanomancer-ui.png',
+        battleSprite: 'nanomancer',
+        sprites: {
+            idle: 'nanomancer',
+            attack: 'nanomancer-attack',
+            hitted: 'nanomancer-hitted',
+            cast: 'nanomancer-cast',
+            'status-effects': 'nanomancer-status-effects',
+        },
+        description: '"가장 작은 것이 가장 강력한 힘을 지녔다."',
+        baseStats: {
+            hp: 75, valor: 7, strength: 5, endurance: 5,
+            agility: 12, intelligence: 18, wisdom: 14, luck: 10,
+            attackRange: 2,
+            movement: 2,
+            weight: 14
+        }
+    }
 };

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -251,6 +251,64 @@ export const activeSkills = {
             generatesToken: { chance: 1.0, amount: 1 }
         }
     },
+    // --- ▼ [신규] 나노빔 스킬 추가 ▼ ---
+    nanobeam: {
+        NORMAL: {
+            id: 'nanobeam',
+            name: '나노빔',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC],
+            cost: 1,
+            description: '나노 입자 빔을 발사하여 적을 {{damage}}% 마법 공격력으로 공격합니다.',
+            illustrationPath: 'assets/images/skills/nanobeam.png',
+            requiredClass: 'nanomancer',
+            damageMultiplier: 1.0,
+            cooldown: 0,
+            range: 2,
+        },
+        RARE: {
+            id: 'nanobeam',
+            name: '나노빔 [R]',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC],
+            cost: 0,
+            description: '나노 입자 빔을 발사하여 적을 {{damage}}% 마법 공격력으로 공격합니다.',
+            illustrationPath: 'assets/images/skills/nanobeam.png',
+            requiredClass: 'nanomancer',
+            damageMultiplier: 1.0,
+            cooldown: 0,
+            range: 2,
+        },
+        EPIC: {
+            id: 'nanobeam',
+            name: '나노빔 [E]',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC],
+            cost: 0,
+            description: '나노 입자 빔을 발사하여 적을 {{damage}}% 마법 공격력으로 공격하고, 50% 확률로 토큰 1개를 생성합니다.',
+            illustrationPath: 'assets/images/skills/nanobeam.png',
+            requiredClass: 'nanomancer',
+            damageMultiplier: 1.0,
+            cooldown: 0,
+            range: 2,
+            generatesToken: { chance: 0.5, amount: 1 }
+        },
+        LEGENDARY: {
+            id: 'nanobeam',
+            name: '나노빔 [L]',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC],
+            cost: 0,
+            description: '나노 입자 빔을 발사하여 적을 {{damage}}% 마법 공격력으로 공격하고, 100% 확률로 토큰 1개를 생성합니다.',
+            illustrationPath: 'assets/images/skills/nanobeam.png',
+            requiredClass: 'nanomancer',
+            damageMultiplier: 1.0,
+            cooldown: 0,
+            range: 2,
+            generatesToken: { chance: 1.0, amount: 1 }
+        }
+    },
+    // --- ▲ [신규] 나노빔 스킬 추가 ▲ ---
     // --- ▼ [신규] 제압 사격 스킬 추가 ▼ ---
     suppressShot: {
         NORMAL: {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -85,6 +85,16 @@ export class Preloader extends Scene
         this.load.image('medic-ui', 'images/territory/medic-ui.png');
         // --- ▲ [신규] 메딕 관련 이미지 로드 추가 ▲ ---
 
+        // --- ▼ [신규] 나노맨서 관련 이미지 로드 추가 ▼ ---
+        this.load.image('nanomancer', 'images/unit/nanomancer.png');
+        this.load.image('nanomancer-attack', 'images/unit/nanomancer-attack.png');
+        this.load.image('nanomancer-hitted', 'images/unit/nanomancer-hitted.png');
+        this.load.image('nanomancer-cast', 'images/unit/nanomancer-cast.png');
+        this.load.image('nanomancer-status-effects', 'images/unit/nanomancer-status-effects.png');
+        this.load.image('nanomancer-hire', 'images/unit/nanomancer-hire.png');
+        this.load.image('nanomancer-ui', 'images/unit/nanomancer-ui.png');
+        // --- ▲ [신규] 나노맨서 관련 이미지 로드 추가 ▲ ---
+
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
 
@@ -112,6 +122,7 @@ export class Preloader extends Scene
         this.load.image('skill-slot', 'images/skills/skill-slot.png');
         this.load.image('suppress-shot', 'images/skills/suppress-shot.png');
         this.load.image('stigma', 'images/skills/stigma.png');
+        this.load.image('nanobeam', 'images/skills/nanobeam.png');
         // 공통 패널 배경 이미지
         this.load.image('panel-background', 'images/ui-panel.png');
         this.load.image('battle-stage-arena', 'images/battle/battle-stage-arena.png');
@@ -136,7 +147,7 @@ export class Preloader extends Scene
     {
         // 전투 씬에서 사용될 주요 이미지들의 텍스처 필터링 모드를 설정하여 품질을 향상시킵니다.
         const battleTextures = [
-            'warrior', 'gunner', 'zombie', 'ancestor-peor',
+            'warrior', 'gunner', 'medic', 'nanomancer', 'zombie', 'ancestor-peor',
             'battle-stage-cursed-forest', 'battle-stage-arena'
         ];
 

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -58,14 +58,15 @@ class MercenaryEngine {
                 // 새로 생성된 인스턴스는 용병 전용이므로 인벤토리 목록에서는 제거합니다.
                 skillInventoryManager.removeSkillFromInventoryList(attackInstance.instanceId);
             }
-        } else if (newInstance.id === 'gunner') {
+        } else if (newInstance.id === 'gunner' || newInstance.id === 'nanomancer') {
             newInstance.skillSlots = skillEngine.generateRandomSkillSlots(nonAidSkillTypes);
-            // 거너를 위한 4번째 슬롯 처리
+            // 거너와 나노맨서를 위한 4번째 슬롯 처리
             newInstance.skillSlots.push('ACTIVE');
 
-            const consumed = skillInventoryManager.findAndRemoveInstanceOfSkill('rangedAttack');
+            const baseAttackSkillId = newInstance.id === 'gunner' ? 'rangedAttack' : 'nanobeam';
+            const consumed = skillInventoryManager.findAndRemoveInstanceOfSkill(baseAttackSkillId);
             if (consumed) {
-                const attackInstance = skillInventoryManager.addSkillById('rangedAttack', consumed.grade);
+                const attackInstance = skillInventoryManager.addSkillById(baseAttackSkillId, consumed.grade);
                 ownedSkillsManager.equipSkill(newInstance.uniqueId, 3, attackInstance.instanceId);
                 skillInventoryManager.removeSkillFromInventoryList(attackInstance.instanceId);
             }

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -28,6 +28,7 @@ class SkillInventoryManager {
                 // ✨ 추가 기본 스킬 카드 지급
                 // 원거리 공격 스킬 카드도 등급별로 지급합니다.
                 this.addSkillById('rangedAttack', grade);
+                this.addSkillById('nanobeam', grade);
                 this.addSkillById('stoneSkin', grade);
                 this.addSkillById('shieldBreak', grade);
                 this.addSkillById('ironWill', grade);

--- a/src/game/utils/SkillModifierEngine.js
+++ b/src/game/utils/SkillModifierEngine.js
@@ -19,6 +19,7 @@ class SkillModifierEngine {
             'knockbackShot': [1.4, 1.2, 1.0, 0.8],
             // ✨ [신규] 원거리 공격 순위별 데미지 계수 추가
             'rangedAttack': [1.3, 1.2, 1.1, 1.0],
+            'nanobeam': [1.3, 1.2, 1.1, 1.0],
             // ✨ [신규] 힐 순위별 회복 계수 추가
             'heal': [1.3, 1.2, 1.1, 1.0],
             'grindstone': [0.25, 0.20, 0.15, 0.10],

--- a/tests/nanomancer_skill_integration_test.js
+++ b/tests/nanomancer_skill_integration_test.js
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import { skillModifierEngine } from '../src/game/utils/SkillModifierEngine.js';
+
+const nanobeamBase = {
+    NORMAL: { id: 'nanobeam', cost: 1, cooldown: 0, damageMultiplier: 1.0 },
+    RARE: { id: 'nanobeam', cost: 0, cooldown: 0, damageMultiplier: 1.0 },
+    EPIC: { id: 'nanobeam', cost: 0, cooldown: 0, damageMultiplier: 1.0, generatesToken: { chance: 0.5, amount: 1 } },
+    LEGENDARY: { id: 'nanobeam', cost: 0, cooldown: 0, damageMultiplier: 1.0, generatesToken: { chance: 1.0, amount: 1 } }
+};
+
+const expectedDamage = [1.3, 1.2, 1.1, 1.0];
+const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
+
+for (const grade of grades) {
+    for (let rank = 1; rank <= 4; rank++) {
+        const skill = skillModifierEngine.getModifiedSkill(nanobeamBase[grade], rank, grade);
+        assert.strictEqual(skill.damageMultiplier, expectedDamage[rank - 1]);
+        if (grade === 'NORMAL') {
+            assert.strictEqual(skill.cost, 1);
+        } else {
+            assert.strictEqual(skill.cost, 0);
+        }
+        if (grade === 'EPIC') {
+            assert(skill.generatesToken && skill.generatesToken.chance === 0.5);
+        } else if (grade === 'LEGENDARY') {
+            assert(skill.generatesToken && skill.generatesToken.chance === 1.0);
+        } else {
+            assert(!skill.generatesToken);
+        }
+    }
+}
+
+console.log('Nanomancer skills integration test passed.');


### PR DESCRIPTION
## Summary
- introduce Nanomancer mercenary with images and stats
- define Nanomancer class grades
- load Nanomancer assets and skill icon in Preloader
- implement Nanobeam skill and modifiers
- equip Nanobeam when creating Nanomancers
- give Nanobeam cards to player inventory
- support Nanobeam in skill modifiers
- add integration test for Nanobeam

## Testing
- `node tests/warrior_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/critical_shot_skill_integration_test.js`
- `node tests/mighty_shield_skill_test.js`
- `node tests/movement_stat_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/nanomancer_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6888faba399083279027d28d0a51f65b