### PR TITLE
Implement flyingman AI and pathfinder update

### DIFF
--- a/src/ai/behaviors/createFlyingmanAI.js
+++ b/src/ai/behaviors/createFlyingmanAI.js
@@ -1,0 +1,84 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import SuccessNode from '../nodes/SuccessNode.js';
+
+// 신규 및 기존 노드 import
+import CanUseSkillBySlotNode from '../nodes/CanUseSkillBySlotNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+
+/**
+ * 플라잉맨을 위한 행동 트리 (암살자 역할)
+ * 1. 스킬 사용: 우선순위 타겟(딜러/힐러)에게 사용 가능한 스킬이 있다면 이동해서라도 사용합니다.
+ * 2. 이동만 하기: 사용할 스킬이 없다면, 우선순위 타겟을 향해 이동하고 턴을 마칩니다.
+ */
+function createFlyingmanAI(engines = {}) {
+
+    // 스킬 하나를 실행하는 공통 로직 (이동 포함)
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 1번 슬롯 스킬
+        new SequenceNode([
+            new CanUseSkillBySlotNode(0),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        // ... (2, 3번 슬롯도 동일하게 구성)
+        new SequenceNode([
+            new CanUseSkillBySlotNode(1),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        new SequenceNode([
+            new CanUseSkillBySlotNode(2),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        // 4순위: 4번 슬롯 스킬 (기본 공격)
+        new SequenceNode([
+            new CanUseSkillBySlotNode(3),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        // 특수 스킬 슬롯 체크 (5-8)
+        new SequenceNode([ new CanUseSkillBySlotNode(4), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
+        new SequenceNode([ new CanUseSkillBySlotNode(5), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
+        new SequenceNode([ new CanUseSkillBySlotNode(6), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
+        new SequenceNode([ new CanUseSkillBySlotNode(7), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
+
+        // 이동만 실행
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPriorityTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+
+        // 최후의 보루
+        new SuccessNode(),
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createFlyingmanAI };

--- a/src/ai/nodes/FindPriorityTargetNode.js
+++ b/src/ai/nodes/FindPriorityTargetNode.js
@@ -1,0 +1,49 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 우선순위 클래스(메딕, 거너, 나노맨서)를 먼저 탐색하고, 없으면 가장 가까운 적을 찾는 노드
+ */
+class FindPriorityTargetNode extends Node {
+    constructor({ targetManager }) {
+        super();
+        this.targetManager = targetManager;
+        this.priorityClasses = ['medic', 'gunner', 'nanomancer'];
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const enemyUnits = blackboard.get('enemyUnits')?.filter(e => e.currentHp > 0);
+
+        if (!enemyUnits || enemyUnits.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, "적이 없음");
+            return NodeState.FAILURE;
+        }
+
+        // 1. 우선순위 클래스 필터링
+        const priorityTargets = enemyUnits.filter(enemy => this.priorityClasses.includes(enemy.id));
+
+        let target = null;
+        if (priorityTargets.length > 0) {
+            // 2. 우선순위 대상 중 가장 가까운 적 선택
+            target = this.targetManager.findNearestEnemy(unit, priorityTargets);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `우선순위 타겟 [${target.instanceName}] 설정`);
+        } else {
+            // 3. 우선순위 대상이 없으면, 모든 적 중 가장 가까운 적 선택
+            target = this.targetManager.findNearestEnemy(unit, enemyUnits);
+            if (target) {
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `일반 타겟 [${target.instanceName}] 설정`);
+            }
+        }
+
+        if (target) {
+            blackboard.set('movementTarget', target);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, "이동할 타겟을 찾지 못함");
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindPriorityTargetNode;

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -12,6 +12,7 @@ import { createMeleeAI } from '../../ai/behaviors/MeleeAI.js';
 import { createRangedAI } from '../../ai/behaviors/RangedAI.js';
 // ✨ 메딕을 위한 Healer AI를 import 합니다.
 import { createHealerAI } from '../../ai/behaviors/createHealerAI.js';
+import { createFlyingmanAI } from '../../ai/behaviors/createFlyingmanAI.js';
 
 import { targetManager } from './TargetManager.js';
 import { pathfinderEngine } from './PathfinderEngine.js';
@@ -113,6 +114,9 @@ export class BattleSimulatorEngine {
             } else if (unit.name === '메딕') {
                 // ✨ 메딕 AI 등록 로직 추가
                 aiManager.registerUnit(unit, createHealerAI(this.aiEngines));
+            } else if (unit.name === '플라잉맨') {
+                // ✨ 플라잉맨 AI 등록
+                aiManager.registerUnit(unit, createFlyingmanAI(this.aiEngines));
             }
         });
 

--- a/src/game/utils/PathfinderEngine.js
+++ b/src/game/utils/PathfinderEngine.js
@@ -49,9 +49,8 @@ class PathfinderEngine {
                 const cell = grid.getCell(neighbor.col, neighbor.row);
 
                 // ✨ [수정된 부분]
-                // 목표 지점(endNode)이 아니라면, 점유된 셀은 경로에서 제외합니다.
-                // 이를 통해 목표 바로 옆까지는 이동할 수 있게 됩니다.
-                const isOccupied = cell && cell.isOccupied;
+                // 플라잉맨은 다른 유닛을 통과할 수 있으므로, isOccupied 검사를 건너뜁니다.
+                const isOccupied = cell && cell.isOccupied && unit.id !== 'flyingmen';
                 const isEndNode = neighbor.col === endNode.col && neighbor.row === endNode.row;
 
                 if (closedSet.has(key) || (isOccupied && !isEndNode)) {


### PR DESCRIPTION
## Summary
- allow flyingmen units to ignore occupied tiles while pathfinding
- create `FindPriorityTargetNode` for targeting healers and dealers
- add `createFlyingmanAI` behavior using the new targeting node
- register the new AI in the battle simulator

## Testing
- `node tests/movement_stat_test.js`
- `for f in tests/*_integration_test.js; do node "$f" || break; done`
- `node tests/mighty_shield_skill_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6888ffd241d48327ab8c4a4e1cb53862