### PR TITLE
Add proficiency display

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1414,6 +1414,32 @@ body {
     border-radius: 5px;
     border: 2px solid #555;
     flex-shrink: 0; /* 컨테이너 크기가 줄어도 초상화는 줄어들지 않음 */
+    position: relative; /* ✨ 숙련도 태그의 부모 기준이 되도록 추가 */
+    display: flex; /* ✨ Flexbox를 사용하여 하단 정렬 */
+    align-items: flex-end; /* ✨ 자식 요소를 아래로 정렬 */
+    justify-content: center; /* ✨ 자식 요소를 가운데로 정렬 */
+}
+
+/* ✨ [신규] 숙련도 태그 컨테이너 스타일 */
+.proficiency-tags-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: center;
+    padding: 6px;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%);
+    width: 100%;
+}
+
+/* ✨ [신규] 개별 숙련도 태그 스타일 */
+.proficiency-tag {
+    background-color: rgba(240, 230, 140, 0.2);
+    border: 1px solid rgba(240, 230, 140, 0.6);
+    color: #f0e68c;
+    font-size: 12px;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 12px;
 }
 
 .unit-grades {

--- a/src/game/data/classProficiencies.js
+++ b/src/game/data/classProficiencies.js
@@ -1,0 +1,40 @@
+import { SKILL_TAGS } from '../utils/SkillTagManager.js';
+
+/**
+ * 각 클래스별 숙련된 스킬 태그 목록입니다.
+ * 여기에 포함된 태그와 일치하는 스킬을 사용할 때
+ * 향후 구현될 '숙련도 보너스'를 받게 됩니다.
+ */
+export const classProficiencies = {
+    warrior: [
+        SKILL_TAGS.MELEE,
+        SKILL_TAGS.PHYSICAL,
+        SKILL_TAGS.CHARGE,
+        SKILL_TAGS.WILL,
+    ],
+    gunner: [
+        SKILL_TAGS.RANGED,
+        SKILL_TAGS.PHYSICAL,
+        SKILL_TAGS.KINETIC,
+        SKILL_TAGS.FIXED,
+    ],
+    medic: [
+        SKILL_TAGS.AID,
+        SKILL_TAGS.HEAL,
+        SKILL_TAGS.BUFF,
+        SKILL_TAGS.WILL_GUARD,
+    ],
+    nanomancer: [
+        SKILL_TAGS.MAGIC,
+        SKILL_TAGS.RANGED,
+        SKILL_TAGS.DEBUFF,
+        SKILL_TAGS.PRODUCTION,
+    ],
+    flyingmen: [
+        SKILL_TAGS.MELEE,
+        SKILL_TAGS.PHYSICAL,
+        SKILL_TAGS.CHARGE,
+        SKILL_TAGS.THROWING,
+    ],
+    // '좀비'와 같은 몬스터는 숙련도 보너스를 받지 않으므로 정의하지 않습니다.
+};

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -6,6 +6,8 @@ import { SkillTooltipManager } from './SkillTooltipManager.js';
 import { skillModifierEngine } from '../utils/SkillModifierEngine.js';
 // ✨ 등급 데이터를 가져오기 위해 classGrades를 import합니다.
 import { classGrades } from '../data/classGrades.js';
+// ✨ 1. 새로 만든 숙련도 태그 데이터를 가져옵니다.
+import { classProficiencies } from '../data/classProficiencies.js';
 
 /**
  * 용병 상세 정보 창의 DOM을 생성하고 관리하는 유틸리티 클래스
@@ -15,6 +17,8 @@ export class UnitDetailDOM {
         const finalStats = statEngine.calculateStats(unitData, unitData.baseStats, []);
         // ✨ 해당 유닛의 등급 데이터를 가져옵니다.
         const grades = classGrades[unitData.id] || {};
+        // ✨ 2. 현재 유닛의 숙련도 태그 목록을 가져옵니다.
+        const proficiencies = classProficiencies[unitData.id] || [];
 
         const overlay = document.createElement('div');
         // ✨ [수정] ID 대신 클래스를 사용합니다.
@@ -56,7 +60,11 @@ export class UnitDetailDOM {
                     <div class="grade-item" data-tooltip="원거리 공격 등급: 원거리 공격 시 유불리를 나타냅니다. 원거리 딜러에게 중요합니다.">🏹 ${grades.rangedAttack || 1}</div>
                     <div class="grade-item" data-tooltip="마법 공격 등급: 마법 공격 시 효율을 나타냅니다. 마법사 클래스의 핵심 능력치입니다.">🔮 ${grades.magicAttack || 1}</div>
                 </div>
-                <div class="unit-portrait" style="background-image: url(${unitData.uiImage})"></div>
+                <div class="unit-portrait" style="background-image: url(${unitData.uiImage})">
+                    <div class="proficiency-tags-container">
+                        ${proficiencies.map(tag => `<span class="proficiency-tag">${tag}</span>`).join('')}
+                    </div>
+                </div>
                 <div class="unit-grades right">
                     <div class="grade-item" data-tooltip="근접 방어 등급: 근접 공격을 받았을 때 얼마나 잘 버티는지 나타냅니다. 탱커에게 필수적입니다.">🛡️ ${grades.meleeDefense || 1}</div>
                     <div class="grade-item" data-tooltip="원거리 방어 등급: 화살이나 총탄 등 원거리 공격에 대한 저항력입니다.">🎯 ${grades.rangedDefense || 1}</div>


### PR DESCRIPTION
## Summary
- define `classProficiencies` data for class skill tags
- show proficiency tags under mercenary portraits
- style tags with new CSS rules

## Testing
- `for f in tests/*_test.js; do node $f || break; done`
- `python3 -m http.server 8000 &`; `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6889185989548327ad5380dcc86be2b2