### PR TITLE
Implement class specialization bonuses

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1442,6 +1442,18 @@ body {
     border-radius: 12px;
 }
 
+/* ✨ [신규] 개별 특화 태그 스타일 */
+.specialization-tag {
+    background-color: rgba(59, 130, 246, 0.2);
+    border: 1px solid rgba(59, 130, 246, 0.6);
+    color: #60a5fa;
+    font-size: 12px;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 12px;
+    cursor: help;
+}
+
 .unit-grades {
     display: flex;
     flex-direction: column;
@@ -1500,8 +1512,29 @@ body {
     transition: opacity 0.2s;
 }
 
+/* ✨ [신규] 특화 태그 툴팁 스타일 */
+.specialization-tag:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 125%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #1a1817;
+    color: #e0e0e0;
+    padding: 8px 12px;
+    border-radius: 4px;
+    border: 1px solid #555;
+    font-size: 14px;
+    white-space: nowrap;
+    z-index: 10;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
 
 .grade-item:hover::after,
-.grade-item:hover::before {
+.grade-item:hover::before,
+.specialization-tag:hover::after {
     opacity: 1;
 }

--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -17,6 +17,7 @@ import { battleTagManager } from '../../game/utils/BattleTagManager.js';
 import { turnOrderManager } from '../../game/utils/TurnOrderManager.js';
 import { classProficiencies } from '../../game/data/classProficiencies.js';
 import { diceEngine } from '../../game/utils/DiceEngine.js';
+import { classSpecializations } from '../../game/data/classSpecializations.js';
 
 class UseSkillNode extends Node {
     constructor({ vfxManager, animationEngine, delayEngine, terminationManager, summoningEngine, skillEngine: se, battleSimulator } = {}) {
@@ -86,6 +87,17 @@ class UseSkillNode extends Node {
             debugAIManager.logNodeResult(NodeState.FAILURE, `스킬 [${modifiedSkill.name}] 사용 조건 미충족`);
             return NodeState.FAILURE;
         }
+
+        // ✨ 클래스 특화 태그 보너스 적용
+        const specializations = classSpecializations[unit.id] || [];
+        skillToUse.tags.forEach(tag => {
+            const spec = specializations.find(s => s.tag === tag);
+            if (spec) {
+                const bonusEffectSkill = { name: `특화 보너스: ${spec.tag}`, effect: spec.effect };
+                statusEffectManager.addEffect(unit, bonusEffectSkill);
+                debugLogEngine.log('UseSkillNode', `${unit.instanceName}가 특화 태그 [${spec.tag}] 보너스 획득!`);
+            }
+        });
 
         // ✨ 2. 스킬 사용이 확정된 이 시점에 BattleTagManager에 정보를 기록합니다.
         battleTagManager.recordSkillUse(unit, skillTarget, modifiedSkill);

--- a/src/game/data/classSpecializations.js
+++ b/src/game/data/classSpecializations.js
@@ -1,0 +1,70 @@
+import { SKILL_TAGS } from '../utils/SkillTagManager.js';
+import { EFFECT_TYPES } from '../utils/StatusEffectManager.js';
+
+/**
+ * 각 클래스별 특화 태그와 이에 따른 보너스 효과 정의
+ * 해당 태그의 스킬을 사용하면 지정된 효과가 1턴 동안 부여됩니다.
+ * 중첩 가능하도록 duration은 1로 설정했습니다.
+ */
+export const classSpecializations = {
+    warrior: [
+        {
+            tag: SKILL_TAGS.WILL,
+            description: "'의지' 태그 스킬 사용 시, 1턴간 방어력 5% 증가 (중첩 가능)",
+            effect: {
+                id: 'warriorWillBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: { stat: 'physicalDefense', type: 'percentage', value: 0.05 }
+            }
+        }
+    ],
+    gunner: [
+        {
+            tag: SKILL_TAGS.KINETIC,
+            description: "'관성' 태그 스킬 사용 시, 1턴간 치명타 확률 4% 증가 (중첩 가능)",
+            effect: {
+                id: 'gunnerKineticBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: { stat: 'criticalChance', type: 'percentage', value: 0.04 }
+            }
+        }
+    ],
+    medic: [
+        {
+            tag: SKILL_TAGS.HEAL,
+            description: "'치유' 태그 스킬 사용 시, 1턴간 지혜 5% 증가 (중첩 가능)",
+            effect: {
+                id: 'medicHealBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: { stat: 'wisdom', type: 'percentage', value: 0.05 }
+            }
+        }
+    ],
+    nanomancer: [
+        {
+            tag: SKILL_TAGS.PRODUCTION,
+            description: "'생산' 태그 스킬 사용 시, 1턴간 마법 방어력 8% 증가 (중첩 가능)",
+            effect: {
+                id: 'nanomancerProductionBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: { stat: 'magicDefense', type: 'percentage', value: 0.08 }
+            }
+        }
+    ],
+    flyingmen: [
+        {
+            tag: SKILL_TAGS.CHARGE,
+            description: "'돌진' 태그 스킬 사용 시, 1턴간 회피율 3% 증가 (중첩 가능)",
+            effect: {
+                id: 'flyingmenChargeBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: { stat: 'physicalEvadeChance', type: 'percentage', value: 0.03 }
+            }
+        }
+    ]
+};

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -100,4 +100,32 @@ export const statusEffects = {
         },
     },
     // --- ▲ [신규] 마이티 쉴드 효과 추가 ▲ ---
+
+    // --- ▼ [신규] 클래스 특화 보너스 효과 추가 ▼ ---
+    warriorWillBonus: {
+        id: 'warriorWillBonus',
+        name: '투지',
+        iconPath: 'assets/images/skills/battle_cry.png',
+    },
+    gunnerKineticBonus: {
+        id: 'gunnerKineticBonus',
+        name: '반동 제어',
+        iconPath: 'assets/images/skills/knock-back-shot.png',
+    },
+    medicHealBonus: {
+        id: 'medicHealBonus',
+        name: '집중',
+        iconPath: 'assets/images/skills/heal.png',
+    },
+    nanomancerProductionBonus: {
+        id: 'nanomancerProductionBonus',
+        name: '과부하',
+        iconPath: 'assets/images/skills/nanobeam.png',
+    },
+    flyingmenChargeBonus: {
+        id: 'flyingmenChargeBonus',
+        name: '신속',
+        iconPath: 'assets/images/skills/charge.png',
+    },
+    // --- ▲ [신규] 클래스 특화 보너스 효과 추가 ▲ ---
 };

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -8,6 +8,8 @@ import { skillModifierEngine } from '../utils/SkillModifierEngine.js';
 import { classGrades } from '../data/classGrades.js';
 // ✨ 1. 새로 만든 숙련도 태그 데이터를 가져옵니다.
 import { classProficiencies } from '../data/classProficiencies.js';
+// ✨ 새로 만든 특화 태그 데이터를 가져옵니다.
+import { classSpecializations } from '../data/classSpecializations.js';
 
 /**
  * 용병 상세 정보 창의 DOM을 생성하고 관리하는 유틸리티 클래스
@@ -19,6 +21,8 @@ export class UnitDetailDOM {
         const grades = classGrades[unitData.id] || {};
         // ✨ 2. 현재 유닛의 숙련도 태그 목록을 가져옵니다.
         const proficiencies = classProficiencies[unitData.id] || [];
+        // ✨ 특화 태그 목록을 가져옵니다.
+        const specializations = classSpecializations[unitData.id] || [];
 
         const overlay = document.createElement('div');
         // ✨ [수정] ID 대신 클래스를 사용합니다.
@@ -63,6 +67,7 @@ export class UnitDetailDOM {
                 <div class="unit-portrait" style="background-image: url(${unitData.uiImage})">
                     <div class="proficiency-tags-container">
                         ${proficiencies.map(tag => `<span class="proficiency-tag">${tag}</span>`).join('')}
+                        ${specializations.map(spec => `<span class="specialization-tag" data-tooltip="${spec.description}">${spec.tag}</span>`).join('')}
                     </div>
                 </div>
                 <div class="unit-grades right">


### PR DESCRIPTION
## Summary
- define class specializations for unique skill tag buffs
- register new specialization status effects
- show specialization tags in the unit detail UI
- style specialization tags and tooltip
- grant specialization bonuses when using matching skills

## Testing
- `for f in tests/*_test.js; do echo "Running $f"; node "$f" || break; done`
- `python3 -m http.server 8000 & sleep 1 && curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68891cd7923c83279d23567f1a1fd42d