### PR TITLE
Add attribute specialization buffs

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1454,6 +1454,18 @@ body {
     cursor: help;
 }
 
+/* ✨ [신규] 개별 속성 특화 태그 스타일 */
+.attribute-tag {
+    background-color: rgba(220, 38, 38, 0.2);
+    border: 1px solid rgba(220, 38, 38, 0.6);
+    color: #ef4444;
+    font-size: 12px;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 12px;
+    cursor: help;
+}
+
 .unit-grades {
     display: flex;
     flex-direction: column;
@@ -1532,9 +1544,30 @@ body {
     transition: opacity 0.2s;
 }
 
+/* ✨ [신규] 속성 태그 툴팁 스타일 */
+.attribute-tag:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 125%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #1a1817;
+    color: #e0e0e0;
+    padding: 8px 12px;
+    border-radius: 4px;
+    border: 1px solid #555;
+    font-size: 14px;
+    white-space: nowrap;
+    z-index: 10;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
 
 .grade-item:hover::after,
 .grade-item:hover::before,
-.specialization-tag:hover::after {
+.specialization-tag:hover::after,
+.attribute-tag:hover::after {
     opacity: 1;
 }

--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -99,6 +99,19 @@ class UseSkillNode extends Node {
             }
         });
 
+        // ✨ [신규] 속성 특화 보너스 적용 로직
+        if (unit.attributeSpec) {
+            const spec = unit.attributeSpec;
+            if (skillToUse.tags.includes(spec.tag)) {
+                const bonusEffectSkill = {
+                    name: `속성 특화: ${spec.tag}`,
+                    effect: spec.effect
+                };
+                statusEffectManager.addEffect(unit, bonusEffectSkill);
+                debugLogEngine.log('UseSkillNode', `${unit.instanceName}가 속성 특화 태그 [${spec.tag}] 보너스 획득!`);
+            }
+        }
+
         // ✨ 2. 스킬 사용이 확정된 이 시점에 BattleTagManager에 정보를 기록합니다.
         battleTagManager.recordSkillUse(unit, skillTarget, modifiedSkill);
 

--- a/src/game/data/attributeSpecializations.js
+++ b/src/game/data/attributeSpecializations.js
@@ -1,0 +1,69 @@
+import { SKILL_TAGS } from '../utils/SkillTagManager.js';
+import { EFFECT_TYPES } from '../utils/StatusEffectManager.js';
+
+/**
+ * 용병에게 무작위로 부여되는 '속성 특화' 목록입니다.
+ * 각 속성은 고유한 태그와 중첩 가능한 보너스 효과를 가집니다.
+ */
+export const attributeSpecializations = [
+    {
+        tag: SKILL_TAGS.FIRE,
+        description: "'불' 태그 스킬 사용 시, 1턴간 최종 데미지 3% 증가 (중첩 가능)",
+        effect: {
+            id: 'fireAttributeBonus',
+            type: EFFECT_TYPES.BUFF,
+            duration: 1,
+            modifiers: { stat: 'damageIncrease', type: 'percentage', value: 0.03 }
+        }
+    },
+    {
+        tag: SKILL_TAGS.WATER,
+        description: "'물' 태그 스킬 사용 시, 1턴간 최대 체력 4% 증가 (중첩 가능)",
+        effect: {
+            id: 'waterAttributeBonus',
+            type: EFFECT_TYPES.BUFF,
+            duration: 1,
+            modifiers: { stat: 'hp', type: 'percentage', value: 0.04 }
+        }
+    },
+    {
+        tag: SKILL_TAGS.EARTH,
+        description: "'대지' 태그 스킬 사용 시, 1턴간 받는 데미지 2% 감소 (중첩 가능)",
+        effect: {
+            id: 'earthAttributeBonus',
+            type: EFFECT_TYPES.BUFF,
+            duration: 1,
+            modifiers: { stat: 'damageReduction', type: 'percentage', value: 0.02 }
+        }
+    },
+    {
+        tag: SKILL_TAGS.WIND,
+        description: "'바람' 태그 스킬 사용 시, 1턴간 회피율 3% 증가 (중첩 가능)",
+        effect: {
+            id: 'windAttributeBonus',
+            type: EFFECT_TYPES.BUFF,
+            duration: 1,
+            modifiers: { stat: 'physicalEvadeChance', type: 'percentage', value: 0.03 }
+        }
+    },
+    {
+        tag: SKILL_TAGS.LIGHT,
+        description: "'빛' 태그 스킬 사용 시, 1턴간 치유량 5% 증가 (중첩 가능)",
+        effect: {
+            id: 'lightAttributeBonus',
+            type: EFFECT_TYPES.BUFF,
+            duration: 1,
+            modifiers: { stat: 'healMultiplier', type: 'percentage', value: 0.05 }
+        }
+    },
+    {
+        tag: SKILL_TAGS.DARK,
+        description: "'어둠' 태그 스킬 사용 시, 1턴간 상태이상 적용 확률 5% 증가 (중첩 가능)",
+        effect: {
+            id: 'darkAttributeBonus',
+            type: EFFECT_TYPES.BUFF,
+            duration: 1,
+            modifiers: { stat: 'statusEffectApplication', type: 'percentage', value: 0.05 }
+        }
+    }
+];

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -23,6 +23,8 @@ export class UnitDetailDOM {
         const proficiencies = classProficiencies[unitData.id] || [];
         // ✨ 특화 태그 목록을 가져옵니다.
         const specializations = classSpecializations[unitData.id] || [];
+        // ✨ 1. 용병의 고유 속성 특화 정보를 가져옵니다.
+        const attributeSpec = unitData.attributeSpec;
 
         const overlay = document.createElement('div');
         // ✨ [수정] ID 대신 클래스를 사용합니다.
@@ -68,6 +70,7 @@ export class UnitDetailDOM {
                     <div class="proficiency-tags-container">
                         ${proficiencies.map(tag => `<span class="proficiency-tag">${tag}</span>`).join('')}
                         ${specializations.map(spec => `<span class="specialization-tag" data-tooltip="${spec.description}">${spec.tag}</span>`).join('')}
+                        ${attributeSpec ? `<span class="attribute-tag" data-tooltip="${attributeSpec.description}">${attributeSpec.tag}</span>` : ''}
                     </div>
                 </div>
                 <div class="unit-grades right">

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -7,6 +7,9 @@ import { uniqueIDManager } from './UniqueIDManager.js';
 import { skillEngine } from './SkillEngine.js';
 import { ownedSkillsManager } from './OwnedSkillsManager.js';
 import { skillInventoryManager } from './SkillInventoryManager.js';
+// ✨ 1. 속성 특화 데이터와 주사위 엔진을 가져옵니다.
+import { attributeSpecializations } from '../data/attributeSpecializations.js';
+import { diceEngine } from './DiceEngine.js';
 
 /**
  * 용병의 생성, 저장, 관리를 전담하는 엔진 (싱글턴)
@@ -39,8 +42,14 @@ class MercenaryEngine {
             // ✨ 1. 스킬 슬롯 생성을 클래스별로 분기 처리하기 위해 초기화 위치를 변경합니다.
             skillSlots: []
         };
-        
-        // ✨ 2. '전사', '거너', '메딕' 클래스에 대한 특별 처리
+
+        // ✨ 2. [신규] 용병 생성 시 무작위 속성 특화 태그를 부여합니다.
+        const randomAttribute = diceEngine.getRandomElement(attributeSpecializations);
+        if (randomAttribute) {
+            newInstance.attributeSpec = randomAttribute;
+        }
+
+        // ✨ 3. '전사', '거너', '메딕' 클래스에 대한 특별 처리
         // 전사와 거너의 랜덤 스킬 풀에서 'AID'를 제외합니다.
         const nonAidSkillTypes = ['ACTIVE', 'BUFF', 'DEBUFF', 'PASSIVE'];
 

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -34,6 +34,11 @@ export const SKILL_TAGS = {
     EARTH: '대지',      // '대지' 자원 관련
     IRON: '철',         // '철' 자원 관련
     LIGHT: '빛',        // '빛' 자원 관련
+    // ✨ [신규] 속성 태그 추가
+    FIRE: '불',
+    WATER: '물',
+    WIND: '바람',
+    DARK: '어둠',
     PRODUCTION: '생산', // 공유 자원을 생성하는 스킬
     THROWING: '투척',   // 무기나 물체를 던지는 컨셉
     SPECIAL: '특수 스킬',// 특수 슬롯 전용 스킬


### PR DESCRIPTION
## Summary
- introduce `attributeSpecializations` data with per-tag buffs
- extend `SKILL_TAGS` with element tags
- assign random attribute specialization on mercenary hire
- render the attribute specialization tag in unit detail panel
- style attribute tags and tooltips
- apply attribute specialization bonus when using skills

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68891f0b8a608327ac2c711f4192a522