### PR TITLE
Remove rank-based multipliers

### DIFF
--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -45,15 +45,13 @@ class UseSkillNode extends Node {
         const instanceData = skillInventoryManager.getInstanceData(instanceId);
         const baseSkillData = skillInventoryManager.getSkillData(instanceData.skillId, instanceData.grade);
 
-        const equippedSkills = ownedSkillsManager.getEquippedSkills(unit.uniqueId);
-        const rank = equippedSkills.indexOf(instanceId) + 1;
-        const modifiedSkill = skillModifierEngine.getModifiedSkill(baseSkillData, rank, instanceData.grade);
+        const modifiedSkill = skillModifierEngine.getModifiedSkill(baseSkillData, instanceData.grade);
         if (!modifiedSkill) {
             debugAIManager.logNodeResult(NodeState.FAILURE, '스킬 데이터 처리 오류');
             return NodeState.FAILURE;
         }
 
-        debugSkillExecutionManager.logSkillExecution(unit, baseSkillData, modifiedSkill, rank, instanceData.grade);
+        debugSkillExecutionManager.logSkillExecution(unit, baseSkillData, modifiedSkill, instanceData.grade);
 
         // ✨ 숙련도에 따른 주사위 굴림으로 최종 계수 결정
         let finalDamageMultiplier = modifiedSkill.damageMultiplier;

--- a/src/game/debug/DebugSkillExecutionManager.js
+++ b/src/game/debug/DebugSkillExecutionManager.js
@@ -18,7 +18,7 @@ class DebugSkillExecutionManager {
      * @param {number} rank - 사용된 스킬 슬롯 순위 (1-4)
      * @param {string} grade - 사용된 스킬 등급
      */
-    logSkillExecution(unit, baseSkill, modifiedSkill, rank, grade) {
+    logSkillExecution(unit, baseSkill, modifiedSkill, grade) {
         const skillColor = SKILL_TYPES[baseSkill.type].color;
 
         console.groupCollapsed(
@@ -27,7 +27,6 @@ class DebugSkillExecutionManager {
         );
 
         debugLogEngine.log(this.name, `--- 스킬 기본 정보 ---`);
-        debugLogEngine.log(this.name, `사용 순위: ${rank}순위`);
         debugLogEngine.log(this.name, `스킬 등급: ${grade}`);
 
         console.groupCollapsed(`%c[${this.name}] 등급별 효과`, `color: #4ade80; font-weight: bold;`);
@@ -38,9 +37,9 @@ class DebugSkillExecutionManager {
         });
         console.groupEnd();
         
-        console.groupCollapsed(`%c[${this.name}] 순위 보정 효과`, `color: #4ade80; font-weight: bold;`);
+        console.groupCollapsed(`%c[${this.name}] 최종 보정 효과`, `color: #4ade80; font-weight: bold;`);
         console.table({
-            '데미지 계수': { Base: baseSkill.damageMultiplier, Modified: modifiedSkill.damageMultiplier, Rank: `${rank}순위` }
+            '데미지 계수': { Base: baseSkill.damageMultiplier, Modified: modifiedSkill.damageMultiplier }
         });
         console.groupEnd();
 

--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -225,9 +225,6 @@ export class SkillManagementDOMEngine {
         slot.ondragover = e => e.preventDefault();
         slot.ondrop = e => this.onDropOnSlot(e);
 
-        const rank = document.createElement('span');
-        rank.innerText = `${index + 1} 순위`;
-        slot.appendChild(rank);
 
         return slot;
     }

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -155,8 +155,6 @@ export class UnitDetailDOM {
                     }
                 }
                 slot.style.backgroundImage = bgImage;
-
-                slot.innerHTML += `<span class="slot-rank">${index + 1} 순위</span>`;
                 if (index < 4) {
                     mainSkillGrid.appendChild(slot);
                 } else {

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -60,11 +60,7 @@ class CombatCalculationEngine {
 
         let finalSkill = skill;
         if (instanceId) {
-            const equippedSkills = ownedSkillsManager.getEquippedSkills(attacker.uniqueId);
-            const rank = equippedSkills.indexOf(instanceId) + 1;
-            if (rank > 0) {
-                finalSkill = skillModifierEngine.getModifiedSkill(skill, rank, grade);
-            }
+            finalSkill = skillModifierEngine.getModifiedSkill(skill, grade);
         }
 
         // ✨ [신규] 방어력 관통 효과 적용
@@ -201,16 +197,12 @@ class CombatCalculationEngine {
         const equipped = ownedSkillsManager.getEquippedSkills(unit.uniqueId);
         let reduction = 0;
 
-        equipped.forEach((instId, index) => {
+        equipped.forEach((instId) => {
             if (!instId) return;
             const inst = skillInventoryManager.getInstanceData(instId);
             if (inst && inst.skillId === 'ironWill') {
-                const skillData = passiveSkills.ironWill;
-                const rank = index + 1;
-                const rankIndex = rank - 1;
-
-                // 순위에 맞는 최대 감소율 가져오기
-                const maxReduction = skillData.rankModifiers[rankIndex] || skillData.NORMAL.maxReduction;
+                const gradeData = passiveSkills.ironWill[inst.grade] || passiveSkills.ironWill.NORMAL;
+                const maxReduction = gradeData.maxReduction;
 
                 // 잃은 체력 비율 계산 (0 ~ 1)
                 const lostHpRatio = 1 - (unit.currentHp / unit.finalStats.hp);

--- a/tests/critical_shot_skill_integration_test.js
+++ b/tests/critical_shot_skill_integration_test.js
@@ -13,15 +13,13 @@ const expectedDamage = [1.3, 1.2, 1.1, 1.0];
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(criticalShotBase[grade], rank, grade);
-        assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
-        assert.strictEqual(skill.cost, criticalShotBase[grade].cost, `Cost failed for ${grade}`);
-        assert.strictEqual(skill.cooldown, criticalShotBase[grade].cooldown, `Cooldown failed for ${grade}`);
-        assert.strictEqual(skill.fixedDamage, 'CRITICAL', `Fixed damage property missing for ${grade}`);
-        if (grade === 'LEGENDARY') {
-            assert.strictEqual(skill.armorPenetration, 0.15, 'Armor penetration failed for LEGENDARY');
-        }
+    const skill = skillModifierEngine.getModifiedSkill(criticalShotBase[grade], grade);
+    assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
+    assert.strictEqual(skill.cost, criticalShotBase[grade].cost, `Cost failed for ${grade}`);
+    assert.strictEqual(skill.cooldown, criticalShotBase[grade].cooldown, `Cooldown failed for ${grade}`);
+    assert.strictEqual(skill.fixedDamage, 'CRITICAL', `Fixed damage property missing for ${grade}`);
+    if (grade === 'LEGENDARY') {
+        assert.strictEqual(skill.armorPenetration, 0.15, 'Armor penetration failed for LEGENDARY');
     }
 }
 

--- a/tests/flyingmen_skill_integration_test.js
+++ b/tests/flyingmen_skill_integration_test.js
@@ -12,16 +12,13 @@ const expectedDamage = [1.3, 1.2, 1.1, 1.0];
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(axeStrikeBase[grade], rank, grade);
-        assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
-        if (grade === 'NORMAL') {
-            assert.strictEqual(skill.cost, 1);
-        } else {
-            assert.strictEqual(skill.cost, 0);
-        }
+    const skill = skillModifierEngine.getModifiedSkill(axeStrikeBase[grade], grade);
+    assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
+    if (grade === 'NORMAL') {
+        assert.strictEqual(skill.cost, 1);
+    } else {
+        assert.strictEqual(skill.cost, 0);
     }
-    const skill = skillModifierEngine.getModifiedSkill(axeStrikeBase[grade], 1, grade);
     if (grade === 'NORMAL' || grade === 'RARE') {
         assert.strictEqual(skill.restoresBarrierPercent, 0.05);
     } else if (grade === 'EPIC') {

--- a/tests/gunner_skill_integration_test.js
+++ b/tests/gunner_skill_integration_test.js
@@ -59,7 +59,7 @@ const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 // 1. 데미지 계수 테스트
 for (const grade of grades) {
-    const skill = skillModifierEngine.getModifiedSkill(suppressShotBase[grade], 1, grade);
+    const skill = skillModifierEngine.getModifiedSkill(suppressShotBase[grade], grade);
     assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
 }
 
@@ -83,61 +83,52 @@ tokenEngine.spendTokens(testUnit.uniqueId, 1, '제압 사격 효과');
 assert.strictEqual(tokenEngine.getTokens(testUnit.uniqueId), 2, 'Token loss effect failed');
 
 // --- ▼ [신규] 넉백샷 테스트 로직 추가 ▼ ---
-const knockbackExpectedDamage = [1.4, 1.2, 1.0, 0.8];
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(knockbackShotBase[grade], rank, grade);
-        assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
+    const skill = skillModifierEngine.getModifiedSkill(knockbackShotBase[grade], grade);
+    assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
 
-        const expectedCost = (grade === 'EPIC' || grade === 'LEGENDARY') ? 1 : 2;
-        const expectedCooldown = grade === 'NORMAL' ? 2 : 1;
-        const expectedPush = grade === 'LEGENDARY' ? 2 : 1;
+    const expectedCost = (grade === 'EPIC' || grade === 'LEGENDARY') ? 1 : 2;
+    const expectedCooldown = grade === 'NORMAL' ? 2 : 1;
+    const expectedPush = grade === 'LEGENDARY' ? 2 : 1;
 
-        assert.strictEqual(skill.cost, expectedCost, `Knockback cost failed for ${grade}`);
-        assert.strictEqual(skill.cooldown, expectedCooldown, `Knockback cooldown failed for ${grade}`);
-        assert.strictEqual(skill.push, expectedPush, `Knockback push failed for ${grade}`);
-    }
+    assert.strictEqual(skill.cost, expectedCost, `Knockback cost failed for ${grade}`);
+    assert.strictEqual(skill.cooldown, expectedCooldown, `Knockback cooldown failed for ${grade}`);
+    assert.strictEqual(skill.push, expectedPush, `Knockback push failed for ${grade}`);
 }
 // --- ▲ [신규] 넉백샷 테스트 로직 추가 ▲ ---
 
 // --- ▼ [신규] 원거리 공격 테스트 로직 추가 ▼ ---
-const rangedAttackExpectedDamage = [1.3, 1.2, 1.1, 1.0];
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(rangedAttackBase[grade], rank, grade);
-        assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
+    const skill = skillModifierEngine.getModifiedSkill(rangedAttackBase[grade], grade);
+    assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
 
-        if (grade === 'NORMAL') {
-            assert.strictEqual(skill.cost, 1, `Ranged attack cost failed for ${grade}`);
-        } else {
-            assert.strictEqual(skill.cost, 0, `Ranged attack cost failed for ${grade}`);
-        }
+    if (grade === 'NORMAL') {
+        assert.strictEqual(skill.cost, 1, `Ranged attack cost failed for ${grade}`);
+    } else {
+        assert.strictEqual(skill.cost, 0, `Ranged attack cost failed for ${grade}`);
+    }
 
-        if (grade === 'EPIC') {
-            assert(skill.generatesToken && skill.generatesToken.chance === 0.5, `Token generation failed for ${grade}`);
-        } else if (grade === 'LEGENDARY') {
-            assert(skill.generatesToken && skill.generatesToken.chance === 1.0, `Token generation failed for ${grade}`);
-        } else {
-            assert(!skill.generatesToken, `Unexpected token generation for ${grade}`);
-        }
+    if (grade === 'EPIC') {
+        assert(skill.generatesToken && skill.generatesToken.chance === 0.5, `Token generation failed for ${grade}`);
+    } else if (grade === 'LEGENDARY') {
+        assert(skill.generatesToken && skill.generatesToken.chance === 1.0, `Token generation failed for ${grade}`);
+    } else {
+        assert(!skill.generatesToken, `Unexpected token generation for ${grade}`);
     }
 }
 // --- ▲ [신규] 원거리 공격 테스트 로직 추가 ▲ ---
 
 // --- ▼ [신규] 사냥꾼의 감각 테스트 로직 추가 ▼ ---
-const huntSenseExpectedCrit = [0.30, 0.25, 0.20, 0.15];
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(huntSenseBase[grade], rank, grade);
-        const critMod = skill.effect.modifiers.find(m => m.stat === 'criticalChance');
-        const rangedMod = skill.effect.modifiers.find(m => m.stat === 'rangedAttack');
+    const skill = skillModifierEngine.getModifiedSkill(huntSenseBase[grade], grade);
+    const critMod = skill.effect.modifiers.find(m => m.stat === 'criticalChance');
+    const rangedMod = skill.effect.modifiers.find(m => m.stat === 'rangedAttack');
 
-        assert.strictEqual(skill.cost, huntSenseBase[grade].cost, `Hunt Sense cost failed for grade ${grade}`);
-        assert.strictEqual(skill.cooldown, huntSenseBase[grade].cooldown, `Hunt Sense cooldown failed for grade ${grade}`);
-        assert.strictEqual(skill.effect.duration, huntSenseBase[grade].effect.duration, `Hunt Sense duration failed for grade ${grade}`);
-        assert(rangedMod && rangedMod.value === 1, `Ranged attack modifier failed for grade ${grade}`);
-        assert(Math.abs(critMod.value - huntSenseExpectedCrit[rank - 1]) < 1e-6, `Crit chance modifier failed for grade ${grade} rank ${rank}`);
-    }
+    assert.strictEqual(skill.cost, huntSenseBase[grade].cost, `Hunt Sense cost failed for grade ${grade}`);
+    assert.strictEqual(skill.cooldown, huntSenseBase[grade].cooldown, `Hunt Sense cooldown failed for grade ${grade}`);
+    assert.strictEqual(skill.effect.duration, huntSenseBase[grade].effect.duration, `Hunt Sense duration failed for grade ${grade}`);
+    assert(rangedMod && rangedMod.value === 1, `Ranged attack modifier failed for grade ${grade}`);
+    assert(Math.abs(critMod.value - 0.15) < 1e-6, `Crit chance modifier failed for grade ${grade}`);
 }
 // --- ▲ [신규] 사냥꾼의 감각 테스트 로직 추가 ▲ ---
 

--- a/tests/medic_skill_integration_test.js
+++ b/tests/medic_skill_integration_test.js
@@ -12,14 +12,12 @@ const expectedHeals = [1.3, 1.2, 1.1, 1.0];
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(healBase[grade], rank, grade);
-        assert(skill.healMultiplier && typeof skill.healMultiplier === 'object');
-        if (grade === 'NORMAL') {
-            assert.strictEqual(skill.cost, 1);
-        } else {
-            assert.strictEqual(skill.cost, 0);
-        }
+    const skill = skillModifierEngine.getModifiedSkill(healBase[grade], grade);
+    assert(skill.healMultiplier && typeof skill.healMultiplier === 'object');
+    if (grade === 'NORMAL') {
+        assert.strictEqual(skill.cost, 1);
+    } else {
+        assert.strictEqual(skill.cost, 0);
     }
 }
 
@@ -34,7 +32,7 @@ const stigmaBase = {
 const expectedCooldowns = { NORMAL: 5, RARE: 4, EPIC: 3, LEGENDARY: 3 };
 
 for (const grade of grades) {
-    const skill = skillModifierEngine.getModifiedSkill(stigmaBase[grade], 1, grade);
+    const skill = skillModifierEngine.getModifiedSkill(stigmaBase[grade], grade);
     assert.strictEqual(skill.cooldown, expectedCooldowns[grade]);
     if (grade === 'LEGENDARY') {
         assert.strictEqual(skill.numberOfTargets, 2);
@@ -52,17 +50,12 @@ const willGuardBase = {
 const expectedWillGuardHeals = [0.8, 0.7, 0.6, 0.5];
 
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(willGuardBase[grade], rank, grade);
+    const skill = skillModifierEngine.getModifiedSkill(willGuardBase[grade], grade);
+    assert(skill.healMultiplier && typeof skill.healMultiplier === 'object');
 
-        // 순위별 치유 계수 확인
-        assert(skill.healMultiplier && typeof skill.healMultiplier === 'object');
-
-        // 등급별 스탯 확인
-        assert.strictEqual(skill.cost, willGuardBase[grade].cost, `Will Guard cost failed for ${grade}`);
-        assert.strictEqual(skill.cooldown, willGuardBase[grade].cooldown, `Will Guard cooldown failed for ${grade}`);
-        assert.strictEqual(skill.effect.stack.amount, willGuardBase[grade].effect.stack.amount, `Will Guard stack amount failed for ${grade}`);
-    }
+    assert.strictEqual(skill.cost, willGuardBase[grade].cost, `Will Guard cost failed for ${grade}`);
+    assert.strictEqual(skill.cooldown, willGuardBase[grade].cooldown, `Will Guard cooldown failed for ${grade}`);
+    assert.strictEqual(skill.effect.stack.amount, willGuardBase[grade].effect.stack.amount, `Will Guard stack amount failed for ${grade}`);
 }
 // --- ▲ [신규] 윌 가드 테스트 로직 추가 ▲ ---
 

--- a/tests/mighty_shield_skill_test.js
+++ b/tests/mighty_shield_skill_test.js
@@ -13,8 +13,7 @@ const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 // 2. 모든 등급에 대해 테스트 실행
 for (const grade of grades) {
-    // 특수 스킬은 순위 보정이 없으므로 rank는 1로 고정
-    const skill = skillModifierEngine.getModifiedSkill(mightyShieldBase[grade], 1, grade);
+    const skill = skillModifierEngine.getModifiedSkill(mightyShieldBase[grade], grade);
 
     // 3. 각 등급별 속성 값이 예상과 일치하는지 확인
     assert.strictEqual(skill.cooldown, mightyShieldBase[grade].cooldown, `Cooldown failed for ${grade}`);

--- a/tests/nanomancer_skill_integration_test.js
+++ b/tests/nanomancer_skill_integration_test.js
@@ -12,21 +12,19 @@ const expectedDamage = [1.3, 1.2, 1.1, 1.0];
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(nanobeamBase[grade], rank, grade);
-        assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
-        if (grade === 'NORMAL') {
-            assert.strictEqual(skill.cost, 1);
-        } else {
-            assert.strictEqual(skill.cost, 0);
-        }
-        if (grade === 'EPIC') {
-            assert(skill.generatesToken && skill.generatesToken.chance === 0.5);
-        } else if (grade === 'LEGENDARY') {
-            assert(skill.generatesToken && skill.generatesToken.chance === 1.0);
-        } else {
-            assert(!skill.generatesToken);
-        }
+    const skill = skillModifierEngine.getModifiedSkill(nanobeamBase[grade], grade);
+    assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
+    if (grade === 'NORMAL') {
+        assert.strictEqual(skill.cost, 1);
+    } else {
+        assert.strictEqual(skill.cost, 0);
+    }
+    if (grade === 'EPIC') {
+        assert(skill.generatesToken && skill.generatesToken.chance === 0.5);
+    } else if (grade === 'LEGENDARY') {
+        assert(skill.generatesToken && skill.generatesToken.chance === 1.0);
+    } else {
+        assert(!skill.generatesToken);
     }
 }
 

--- a/tests/warrior_skill_integration_test.js
+++ b/tests/warrior_skill_integration_test.js
@@ -180,86 +180,83 @@ const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 // Attack
 const attackExpectedDamage = [1.3, 1.2, 1.1, 1.0];
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(attackBase[grade], rank, grade);
-        assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
-        if (grade === 'NORMAL') {
-            assert.strictEqual(skill.cost, 1);
-        } else {
-            assert.strictEqual(skill.cost, 0);
-        }
-        if (grade === 'EPIC') {
-            assert(skill.generatesToken && skill.generatesToken.chance === 0.5);
-        } else if (grade === 'LEGENDARY') {
-            assert(skill.generatesToken && skill.generatesToken.chance === 1.0);
-        } else {
-            assert(!skill.generatesToken);
-        }
+    const skill = skillModifierEngine.getModifiedSkill(attackBase[grade], grade);
+    assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
+    if (grade === 'NORMAL') {
+        assert.strictEqual(skill.cost, 1);
+    } else {
+        assert.strictEqual(skill.cost, 0);
+    }
+    if (grade === 'EPIC') {
+        assert(skill.generatesToken && skill.generatesToken.chance === 0.5);
+    } else if (grade === 'LEGENDARY') {
+        assert(skill.generatesToken && skill.generatesToken.chance === 1.0);
+    } else {
+        assert(!skill.generatesToken);
     }
 }
 
 // Charge
-const chargeExpectedDamage = [1.5, 1.2, 1.0, 0.8];
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(chargeBase[grade], rank, grade);
-        assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
-        const expectedDuration = rank === 1 ? 1 : (grade === 'LEGENDARY' ? 2 : 1);
-        assert.strictEqual(skill.effect.duration, expectedDuration);
-    }
+    const skill = skillModifierEngine.getModifiedSkill(chargeBase[grade], grade);
+    assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
+    const expectedDuration = grade === 'LEGENDARY' ? 2 : 1;
+    assert.strictEqual(skill.effect.duration, expectedDuration);
 }
 
 // Stone Skin
-const stoneSkinExpectedReduction = [0.24, 0.21, 0.18, 0.15];
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(stoneSkinBase[grade], rank, grade);
-        const mods = skill.effect.modifiers;
-        const reduction = Array.isArray(mods) ? mods.find(m => m.stat === 'damageReduction').value : mods.value;
-        assert(Math.abs(reduction - stoneSkinExpectedReduction[rank - 1]) < 1e-6);
-        if (grade === 'EPIC') {
-            const pd = mods.find(m => m.stat === 'physicalDefense');
-            assert(pd && Math.abs(pd.value - 0.10) < 1e-6);
-        } else if (grade === 'LEGENDARY') {
-            const pd = mods.find(m => m.stat === 'physicalDefense');
-            assert(pd && Math.abs(pd.value - 0.15) < 1e-6);
-        } else if (Array.isArray(mods)) {
-            assert(!mods.some(m => m.stat === 'physicalDefense'));
-        }
+    const skill = skillModifierEngine.getModifiedSkill(stoneSkinBase[grade], grade);
+    const mods = skill.effect.modifiers;
+    const reduction = Array.isArray(mods) ? mods.find(m => m.stat === 'damageReduction').value : mods.value;
+    if (grade === 'NORMAL') {
+        assert(Math.abs(reduction - 0.15) < 1e-6);
+    } else if (grade === 'RARE') {
+        assert(Math.abs(reduction - 0.15) < 1e-6);
+    } else if (grade === 'EPIC') {
+        assert(Math.abs(reduction - 0.15) < 1e-6);
+    } else {
+        assert(Math.abs(reduction - 0.15) < 1e-6);
+    }
+    if (grade === 'EPIC') {
+        const pd = mods.find(m => m.stat === 'physicalDefense');
+        assert(pd && Math.abs(pd.value - 0.10) < 1e-6);
+    } else if (grade === 'LEGENDARY') {
+        const pd = mods.find(m => m.stat === 'physicalDefense');
+        assert(pd && Math.abs(pd.value - 0.15) < 1e-6);
+    } else if (Array.isArray(mods)) {
+        assert(!mods.some(m => m.stat === 'physicalDefense'));
     }
 }
 
 // Shield Break
-const shieldBreakExpectedIncrease = [0.24, 0.21, 0.18, 0.15];
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(shieldBreakBase[grade], rank, grade);
-        const mods = skill.effect.modifiers;
-        const increase = Array.isArray(mods) ? mods.find(m => m.stat === 'damageIncrease').value : mods.value;
-        assert(Math.abs(increase - shieldBreakExpectedIncrease[rank - 1]) < 1e-6);
-        if (grade === 'EPIC') {
-            const pd = mods.find(m => m.stat === 'physicalDefense');
-            assert(pd && Math.abs(pd.value + 0.05) < 1e-6);
-        } else if (grade === 'LEGENDARY') {
-            const pd = mods.find(m => m.stat === 'physicalDefense');
-            assert(pd && Math.abs(pd.value + 0.10) < 1e-6);
-        } else if (Array.isArray(mods)) {
-            assert(!mods.some(m => m.stat === 'physicalDefense'));
-        }
+    const skill = skillModifierEngine.getModifiedSkill(shieldBreakBase[grade], grade);
+    const mods = skill.effect.modifiers;
+    const increase = Array.isArray(mods) ? mods.find(m => m.stat === 'damageIncrease').value : mods.value;
+    assert(Math.abs(increase - 0.15) < 1e-6);
+    if (grade === 'EPIC') {
+        const pd = mods.find(m => m.stat === 'physicalDefense');
+        assert(pd && Math.abs(pd.value + 0.05) < 1e-6);
+    } else if (grade === 'LEGENDARY') {
+        const pd = mods.find(m => m.stat === 'physicalDefense');
+        assert(pd && Math.abs(pd.value + 0.10) < 1e-6);
+    } else if (Array.isArray(mods)) {
+        assert(!mods.some(m => m.stat === 'physicalDefense'));
     }
 }
 
 // Iron Will
-function computeIronWillReduction(unit, rank) {
-    const maxReduction = ironWillBase.rankModifiers[rank - 1] || ironWillBase.NORMAL.maxReduction;
+function computeIronWillReduction(unit, grade) {
+    const maxReduction = ironWillBase[grade].maxReduction;
     const lostRatio = 1 - (unit.currentHp / unit.finalStats.hp);
     return maxReduction * lostRatio;
 }
 
-for (let rank = 1; rank <= 4; rank++) {
+for (const grade of grades) {
     const testUnit = { finalStats: { hp: 100 }, currentHp: 50 };
-    const reduction = computeIronWillReduction(testUnit, rank);
-    assert(Math.abs(reduction - ironWillBase.rankModifiers[rank - 1] * 0.5) < 1e-6);
+    const reduction = computeIronWillReduction(testUnit, grade);
+    assert(Math.abs(reduction - ironWillBase[grade].maxReduction * 0.5) < 1e-6);
 }
 
 for (const grade of grades) {
@@ -267,40 +264,31 @@ for (const grade of grades) {
 }
 
 // Grindstone
-const grindstoneExpected = [0.25, 0.20, 0.15, 0.10];
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(grindstoneBase[grade], rank, grade);
-        const value = skill.effect.modifiers.value;
-        assert(Math.abs(value - grindstoneExpected[rank - 1]) < 1e-6);
-    }
+    const skill = skillModifierEngine.getModifiedSkill(grindstoneBase[grade], grade);
+    const value = skill.effect.modifiers.value;
+    assert(Math.abs(value - 0.10) < 1e-6);
 }
 
 // --- ▼ [신규] 전투의 함성 테스트 로직 추가 ▼ ---
-const battleCryExpectedDamage = [0.30, 0.25, 0.20, 0.15];
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(battleCryBase[grade], rank, grade);
-        const mods = skill.effect.modifiers;
-        const attackMod = Array.isArray(mods) ? mods.find(m => m.stat === 'physicalAttack') : mods;
+    const skill = skillModifierEngine.getModifiedSkill(battleCryBase[grade], grade);
+    const mods = skill.effect.modifiers;
+    const attackMod = Array.isArray(mods) ? mods.find(m => m.stat === 'physicalAttack') : mods;
 
-        assert.strictEqual(skill.cost, battleCryBase[grade].cost, `Battle Cry cost failed for grade ${grade}`);
-        assert.strictEqual(skill.effect.duration, battleCryBase[grade].effect.duration, `Battle Cry duration failed for grade ${grade}`);
-        assert(Math.abs(attackMod.value - battleCryExpectedDamage[rank - 1]) < 1e-6, `Battle Cry modifier value failed for grade ${grade} rank ${rank}`);
+    assert.strictEqual(skill.cost, battleCryBase[grade].cost, `Battle Cry cost failed for grade ${grade}`);
+    assert.strictEqual(skill.effect.duration, battleCryBase[grade].effect.duration, `Battle Cry duration failed for grade ${grade}`);
+    assert(Math.abs(attackMod.value - 0.15) < 1e-6, `Battle Cry modifier value failed for grade ${grade}`);
 
-        const meleeMod = Array.isArray(mods) ? mods.find(m => m.stat === 'meleeAttack') : null;
-        assert(meleeMod && meleeMod.value === 1, `meleeAttack modifier missing or incorrect for grade ${grade}`);
-    }
+    const meleeMod = Array.isArray(mods) ? mods.find(m => m.stat === 'meleeAttack') : null;
+    assert(meleeMod && meleeMod.value === 1, `meleeAttack modifier missing or incorrect for grade ${grade}`);
 }
 // --- ▲ [신규] 전투의 함성 테스트 로직 추가 ▲ ---
 
 // Throwing Axe
-const throwingAxeExpected = [1.2, 1.2, 1.2, 1.2];
 for (const grade of grades) {
-    for (let rank = 1; rank <= 4; rank++) {
-        const skill = skillModifierEngine.getModifiedSkill(throwingAxeBase[grade], rank, grade);
-        assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
-    }
+    const skill = skillModifierEngine.getModifiedSkill(throwingAxeBase[grade], grade);
+    assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
 }
 
 // ------- Skill Usage Integration Test -------
@@ -323,10 +311,9 @@ const baseSkills = [
     { data: ironWillBase, target: soldier }
 ];
 
-const rankedSkills = baseSkills.map((entry, idx) => {
-    const rank = idx + 1;
-    const modified = skillModifierEngine.getModifiedSkill(entry.data, rank, 'NORMAL');
-    return { ...modified, target: entry.target, rank };
+const rankedSkills = baseSkills.map((entry) => {
+    const modified = skillModifierEngine.getModifiedSkill(entry.data, 'NORMAL');
+    return { ...modified, target: entry.target };
 });
 
 const usedOrder = [];
@@ -367,7 +354,7 @@ for (let turn = 1; turn <= 5; turn++) {
 assert.deepStrictEqual(usedOrder, ['charge', 'stoneSkin', 'shieldBreak', 'charge', 'stoneSkin']);
 assert(tokenHistory.every(t => t === 1));
 
-assert(firstStoneSkin && Math.abs((firstStoneSkin.modifiers.value ?? firstStoneSkin.modifiers.find(m => m.stat === 'damageReduction').value) - 0.21) < 1e-6);
-assert(firstShieldBreak && Math.abs((firstShieldBreak.modifiers.value ?? firstShieldBreak.modifiers.find(m => m.stat === 'damageIncrease').value) - 0.18) < 1e-6);
+assert(firstStoneSkin && Math.abs((firstStoneSkin.modifiers.value ?? firstStoneSkin.modifiers.find(m => m.stat === 'damageReduction').value) - 0.15) < 1e-6);
+assert(firstShieldBreak && Math.abs((firstShieldBreak.modifiers.value ?? firstShieldBreak.modifiers.find(m => m.stat === 'damageIncrease').value) - 0.15) < 1e-6);
 
 console.log('Warrior skill integration test passed.');


### PR DESCRIPTION
## Summary
- simplify `SkillModifierEngine` to ignore slot rank
- drop rank references in skill logs and AI skill usage
- clean up DOM rank labels
- adjust combat calculation and iron will passive
- update all tests for the new grade-only system

## Testing
- `node tests/critical_shot_skill_integration_test.js && node tests/flyingmen_skill_integration_test.js && node tests/gunner_skill_integration_test.js && node tests/medic_skill_integration_test.js && node tests/nanomancer_skill_integration_test.js && node tests/warrior_skill_integration_test.js && node tests/movement_stat_test.js && node tests/summon_skill_integration_test.js && node tests/mighty_shield_skill_test.js`
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68892313cba48327bd705fb274e8f10d