### PR TITLE
Fix circular dependency in effect types

### DIFF
--- a/src/game/data/attributeSpecializations.js
+++ b/src/game/data/attributeSpecializations.js
@@ -1,5 +1,5 @@
 import { SKILL_TAGS } from '../utils/SkillTagManager.js';
-import { EFFECT_TYPES } from '../utils/StatusEffectManager.js';
+import { EFFECT_TYPES } from '../utils/EffectTypes.js';
 
 /**
  * 용병에게 무작위로 부여되는 '속성 특화' 목록입니다.

--- a/src/game/data/classSpecializations.js
+++ b/src/game/data/classSpecializations.js
@@ -1,5 +1,5 @@
 import { SKILL_TAGS } from '../utils/SkillTagManager.js';
-import { EFFECT_TYPES } from '../utils/StatusEffectManager.js';
+import { EFFECT_TYPES } from '../utils/EffectTypes.js';
 
 /**
  * 각 클래스별 특화 태그와 이에 따른 보너스 효과 정의

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -1,4 +1,4 @@
-import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
+import { EFFECT_TYPES } from '../../utils/EffectTypes.js';
 import { SKILL_TAGS } from '../../utils/SkillTagManager.js';
 import { SHARED_RESOURCE_TYPES } from '../../utils/SharedResourceEngine.js';
 

--- a/src/game/data/skills/aid.js
+++ b/src/game/data/skills/aid.js
@@ -1,4 +1,4 @@
-import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
+import { EFFECT_TYPES } from '../../utils/EffectTypes.js';
 import { SKILL_TAGS } from '../../utils/SkillTagManager.js';
 
 // 지원(AID) 스킬 데이터 정의

--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -1,4 +1,4 @@
-import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
+import { EFFECT_TYPES } from '../../utils/EffectTypes.js';
 import { SKILL_TAGS } from '../../utils/SkillTagManager.js';
 
 // 버프 스킬 데이터 정의

--- a/src/game/data/skills/debuff.js
+++ b/src/game/data/skills/debuff.js
@@ -1,4 +1,4 @@
-import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
+import { EFFECT_TYPES } from '../../utils/EffectTypes.js';
 import { SKILL_TAGS } from '../../utils/SkillTagManager.js';
 
 // 디버프 스킬 데이터 정의

--- a/src/game/data/skills/strategy.js
+++ b/src/game/data/skills/strategy.js
@@ -1,4 +1,4 @@
-import { EFFECT_TYPES } from '../../utils/StatusEffectManager.js';
+import { EFFECT_TYPES } from '../../utils/EffectTypes.js';
 
 export const strategySkills = {
     chargeOrder: {

--- a/src/game/debug/DebugStatusEffectManager.js
+++ b/src/game/debug/DebugStatusEffectManager.js
@@ -1,5 +1,5 @@
 import { debugLogEngine } from '../utils/DebugLogEngine.js';
-import { EFFECT_TYPES } from '../utils/StatusEffectManager.js';
+import { EFFECT_TYPES } from '../utils/EffectTypes.js';
 
 class DebugStatusEffectManager {
     constructor() {

--- a/src/game/utils/EffectTypes.js
+++ b/src/game/utils/EffectTypes.js
@@ -1,0 +1,5 @@
+export const EFFECT_TYPES = {
+    BUFF: 'BUFF',
+    DEBUFF: 'DEBUFF',
+    STATUS_EFFECT: 'STATUS_EFFECT', // 기절, 빙결 등 행동을 제어하는 효과
+};

--- a/src/game/utils/StatusEffectManager.js
+++ b/src/game/utils/StatusEffectManager.js
@@ -7,13 +7,8 @@ import { skillInventoryManager } from './SkillInventoryManager.js';
 import { passiveSkills } from '../data/skills/passive.js';
 // 상태이상 시 스프라이트 교체에 사용
 import { spriteEngine } from './SpriteEngine.js';
-
-// 효과의 종류를 명확히 구분하기 위한 상수
-export const EFFECT_TYPES = {
-    BUFF: 'BUFF',
-    DEBUFF: 'DEBUFF',
-    STATUS_EFFECT: 'STATUS_EFFECT', // 기절, 빙결 등 행동을 제어하는 효과
-};
+// 효과 타입 상수 분리
+import { EFFECT_TYPES } from './EffectTypes.js';
 
 /**
  * 게임 내 모든 상태 효과(버프, 디버프, 상태이상)를 관리하는 중앙 엔진


### PR DESCRIPTION
## Summary
- move EFFECT_TYPES constant to separate module to break circular import
- update all references to new module
- ensure debug page loads

## Testing
- `node tests/critical_shot_skill_integration_test.js`
- `node tests/flyingmen_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/nanomancer_skill_integration_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `node tests/proficiency_specialization_test.js`
- `node tests/mighty_shield_skill_test.js`
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688929aa0da483279bed554c1be2d6e8