### PR TITLE
Add mercenary-based tag highlight for skill tooltips

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1571,3 +1571,16 @@ body {
 .attribute-tag:hover::after {
     opacity: 1;
 }
+
+/* --- 스킬 툴팁 태그 강조 스타일 --- */
+#skill-tooltip .skill-tag.proficient-tag {
+    color: #f0e68c; /* 밝은 노란색 (숙련) */
+    border-color: #f0e68c;
+    background-color: rgba(240, 230, 140, 0.15);
+}
+
+#skill-tooltip .skill-tag.specialized-tag {
+    color: #60a5fa; /* 밝은 파란색 (특화) */
+    border-color: #60a5fa;
+    background-color: rgba(59, 130, 246, 0.15);
+}

--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -204,7 +204,8 @@ export class SkillManagementDOMEngine {
             slot.dataset.instanceId = instanceId;
             slot.draggable = true;
             slot.ondragstart = e => this.onDragStart(e, { source: 'slot', instanceId, slotIndex: index });
-            slot.onmouseenter = e => SkillTooltipManager.show(modifiedSkill, e, instanceData.grade);
+            // ✨ [핵심 변경] 툴팁 표시에 현재 용병 데이터를 전달합니다.
+            slot.onmouseenter = e => SkillTooltipManager.show(modifiedSkill, e, instanceData.grade, this.selectedMercenaryData);
             slot.onmouseleave = () => SkillTooltipManager.hide();
 
             // 등급에 따른 별 표시
@@ -253,7 +254,8 @@ export class SkillManagementDOMEngine {
             card.draggable = true;
             card.dataset.instanceId = instance.instanceId;
             card.ondragstart = e => this.onDragStart(e, { source: 'inventory', instanceId: instance.instanceId });
-            card.onmouseenter = e => SkillTooltipManager.show(data, e, instance.grade);
+            // ✨ [핵심 변경] 툴팁 표시에 현재 용병 데이터를 전달합니다.
+            card.onmouseenter = e => SkillTooltipManager.show(data, e, instance.grade, this.selectedMercenaryData);
             card.onmouseleave = () => SkillTooltipManager.hide();
 
             const starsContainer = document.createElement('div');

--- a/src/game/dom/SkillTooltipManager.js
+++ b/src/game/dom/SkillTooltipManager.js
@@ -1,13 +1,21 @@
 import { SKILL_TYPES } from '../utils/SkillEngine.js';
+// ✨ 1. 숙련도 및 특화 데이터를 가져옵니다.
+import { classProficiencies } from '../data/classProficiencies.js';
+import { classSpecializations } from '../data/classSpecializations.js';
 
 /**
  * 스킬 카드 위에 마우스를 올렸을 때 TCG 스타일의 큰 툴팁을 표시하는 매니저
  */
 export class SkillTooltipManager {
-    static show(skillData, event, grade = 'NORMAL') {
+    // ✨ [핵심 변경] 4번째 인자로 용병 데이터를 받습니다.
+    static show(skillData, event, grade = 'NORMAL', mercData = null) {
         this.hide();
 
         if (!skillData) return;
+
+        // ✨ 2. 용병 데이터가 있으면 숙련도와 특화 태그 목록을 준비합니다.
+        const proficiencies = mercData ? classProficiencies[mercData.id] || [] : [];
+        const specializations = mercData ? classSpecializations[mercData.id]?.map(s => s.tag) || [] : [];
 
         const tooltip = document.createElement('div');
         tooltip.id = 'skill-tooltip';
@@ -37,19 +45,24 @@ export class SkillTooltipManager {
             </div>
         `;
 
-        // ✨ --- 스킬 태그 표시 로직 추가 --- ✨
+        // ✨ 3. 스킬 태그를 생성할 때 숙련/특화 여부를 확인하고 클래스를 추가합니다.
         if (skillData.tags && skillData.tags.length > 0) {
             const tagsContainer = document.createElement('div');
             tagsContainer.className = 'skill-tags-container-large';
             skillData.tags.forEach(tag => {
                 const tagElement = document.createElement('span');
                 tagElement.className = 'skill-tag';
+                if (proficiencies.includes(tag)) {
+                    tagElement.classList.add('proficient-tag');
+                }
+                if (specializations.includes(tag)) {
+                    tagElement.classList.add('specialized-tag');
+                }
                 tagElement.innerText = tag;
                 tagsContainer.appendChild(tagElement);
             });
             tooltip.querySelector('.skill-info-large').appendChild(tagsContainer);
         }
-        // ✨ --- 로직 추가 끝 --- ✨
 
         const gradeMap = { 'NORMAL': 1, 'RARE': 2, 'EPIC': 3, 'LEGENDARY': 4 };
         const starsContainer = document.createElement('div');


### PR DESCRIPTION
## Summary
- forward selected mercenary data to `SkillTooltipManager` when hovering skills
- highlight tooltip tags for proficient and specialized skills
- style highlighted tags in CSS

## Testing
- `for f in tests/*_test.js; do node $f > /dev/null || exit 1; done`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6889b9c801e483278624222a71cd5912