### PR TITLE
Add stat pagination UI

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1584,3 +1584,106 @@ body {
     border-color: #60a5fa;
     background-color: rgba(59, 130, 246, 0.15);
 }
+
+/* --- 유닛 상세 정보창 스탯 페이지네이션 --- */
+.stats-container {
+    display: flex;
+    flex-direction: column;
+}
+
+.stats-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.stats-header .section-title {
+    margin-bottom: 0;
+    flex-grow: 1;
+}
+
+.stats-pagination {
+    display: flex;
+    border: 1px solid #555;
+    border-radius: 5px;
+    overflow: hidden;
+}
+
+.stats-page-btn {
+    background-color: transparent;
+    border: none;
+    color: #888;
+    padding: 4px 12px;
+    cursor: pointer;
+    font-size: 14px;
+    border-left: 1px solid #555;
+}
+
+.stats-page-btn:first-child {
+    border-left: none;
+}
+
+.stats-page-btn.active {
+    background-color: #f0e68c;
+    color: #222;
+    font-weight: bold;
+}
+
+.stats-page {
+    display: none; /* 기본적으로 모든 페이지 숨김 */
+}
+
+.stats-page.active {
+    display: grid; /* 활성화된 페이지만 보이도록 함 */
+}
+
+/* --- 기본 스탯 툴팁 스타일 --- */
+.stat-item {
+    position: relative; /* 툴팁의 기준점 */
+}
+
+.stat-item:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #1a1817;
+    color: #e0e0e0;
+    padding: 8px 12px;
+    border-radius: 4px;
+    border: 1px solid #555;
+    font-size: 14px;
+    white-space: nowrap;
+    z-index: 10;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s;
+    margin-bottom: 8px; /* 툴팁과 항목 사이 간격 */
+}
+
+.stat-item:hover::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: #1a1817 transparent transparent transparent;
+    opacity: 0;
+    transition: opacity 0.2s;
+    margin-bottom: 2px;
+}
+
+.stat-item:hover::after,
+.stat-item:hover::before {
+    opacity: 1; /* 마우스를 올렸을 때만 보이도록 */
+}
+
+/* 툴팁 내용이 없는 항목은 효과 비활성화 */
+.stat-item:not([data-tooltip]):hover::after,
+.stat-item:not([data-tooltip]):hover::before {
+    display: none;
+}

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -81,19 +81,45 @@ export class UnitDetailDOM {
             </div>
         `;
 
+        // --- ▼ [핵심 변경] 스탯 표시 영역 구조 변경 ---
+        const statsContainerHTML = `
+            <div class="stats-container">
+                <div class="stats-header">
+                    <div class="section-title">스탯</div>
+                    <div class="stats-pagination">
+                        <button class="stats-page-btn active" data-page="1">기본</button>
+                        <button class="stats-page-btn" data-page="2">반영</button>
+                    </div>
+                </div>
+                <div id="stats-page-1" class="stats-grid stats-page active">
+                    <div class="stat-item" data-tooltip="체력. 0이 되면 전투에서 패배합니다."><span>HP</span><span>${finalStats.hp}</span></div>
+                    <div class="stat-item" data-tooltip="전투 시작 시 용맹 수치에 비례하는 '배리어'를 생성하며, 배리어가 높을수록 공격력이 증가합니다."><span>용맹</span><span>${finalStats.valor}</span></div>
+                    <div class="stat-item" data-tooltip="물리 공격력에 영향을 줍니다."><span>힘</span><span>${finalStats.strength}</span></div>
+                    <div class="stat-item" data-tooltip="물리 방어력과 상태이상 저항력에 영향을 줍니다."><span>인내</span><span>${finalStats.endurance}</span></div>
+                    <div class="stat-item" data-tooltip="물리 공격 회피율과 명중률에 영향을 줍니다."><span>민첩</span><span>${finalStats.agility}</span></div>
+                    <div class="stat-item" data-tooltip="마법 공격력과 상태이상 적용 확률에 영향을 줍니다."><span>지능</span><span>${finalStats.intelligence}</span></div>
+                    <div class="stat-item" data-tooltip="마법 방어력과 치유량에 영향을 줍니다."><span>지혜</span><span>${finalStats.wisdom}</span></div>
+                    <div class="stat-item" data-tooltip="마법 회피율과 치명타 확률에 영향을 줍니다."><span>행운</span><span>${finalStats.luck}</span></div>
+                </div>
+                <div id="stats-page-2" class="stats-grid stats-page">
+                    <div class="stat-item"><span>최대 배리어</span><span>${finalStats.maxBarrier}</span></div>
+                    <div class="stat-item"><span>총 무게</span><span>${finalStats.totalWeight}</span></div>
+                    <div class="stat-item"><span>물리 공격력</span><span>${finalStats.physicalAttack.toFixed(1)}</span></div>
+                    <div class="stat-item"><span>물리 방어력</span><span>${finalStats.physicalDefense.toFixed(1)}</span></div>
+                    <div class="stat-item"><span>마법 공격력</span><span>${finalStats.magicAttack.toFixed(1)}</span></div>
+                    <div class="stat-item"><span>마법 방어력</span><span>${finalStats.magicDefense.toFixed(1)}</span></div>
+                    <div class="stat-item"><span>치명타 확률</span><span>${(finalStats.criticalChance).toFixed(1)}%</span></div>
+                    <div class="stat-item"><span>물리 회피율</span><span>${(finalStats.physicalEvadeChance).toFixed(1)}%</span></div>
+                    <div class="stat-item"><span>상태이상 저항</span><span>${(finalStats.statusEffectResistance).toFixed(1)}%</span></div>
+                    <div class="stat-item"><span>상태이상 적용</span><span>${(finalStats.statusEffectApplication).toFixed(1)}%</span></div>
+                </div>
+            </div>
+        `;
+        // --- ▲ [핵심 변경] 스탯 표시 영역 구조 변경 ---
+
         leftSection.innerHTML = `
             ${gradeDisplayHTML}
-            <div class="stats-grid">
-                <div class="section-title">스탯</div>
-                <div class="stat-item"><span>HP</span><span>${finalStats.hp}</span></div>
-                <div class="stat-item"><span>용맹</span><span>${finalStats.valor}</span></div>
-                <div class="stat-item"><span>힘</span><span>${finalStats.strength}</span></div>
-                <div class="stat-item"><span>인내</span><span>${finalStats.endurance}</span></div>
-                <div class="stat-item"><span>민첩</span><span>${finalStats.agility}</span></div>
-                <div class="stat-item"><span>지능</span><span>${finalStats.intelligence}</span></div>
-                <div class="stat-item"><span>지혜</span><span>${finalStats.wisdom}</span></div>
-                <div class="stat-item"><span>행운</span><span>${finalStats.luck}</span></div>
-            </div>
+            ${statsContainerHTML}
         `;
 
         const rightSection = document.createElement('div');
@@ -176,6 +202,23 @@ export class UnitDetailDOM {
             overlay.classList.remove('visible');
             overlay.addEventListener('transitionend', () => overlay.remove(), { once: true });
         };
+
+        // --- ▼ [핵심 변경] 페이지네이션 버튼 이벤트 리스너 추가 ---
+        const pageButtons = leftSection.querySelectorAll('.stats-page-btn');
+        pageButtons.forEach(button => {
+            button.onclick = () => {
+                const pageNumber = button.dataset.page;
+
+                // 모든 페이지와 버튼에서 active 클래스 제거
+                leftSection.querySelectorAll('.stats-page').forEach(p => p.classList.remove('active'));
+                leftSection.querySelectorAll('.stats-page-btn').forEach(b => b.classList.remove('active'));
+
+                // 클릭된 버튼과 해당 페이지에 active 클래스 추가
+                leftSection.querySelector(`#stats-page-${pageNumber}`).classList.add('active');
+                button.classList.add('active');
+            };
+        });
+        // --- ▲ [핵심 변경] 페이지네이션 버튼 이벤트 리스너 추가 ---
 
         return overlay;
     }


### PR DESCRIPTION
## Summary
- update UnitDetailDOM to show stats across two pages
- add pagination buttons and tooltip text for each stat
- style the new pagination and stat tooltips

## Testing
- `node tests/critical_shot_skill_integration_test.js`
- `node tests/flyingmen_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/mighty_shield_skill_test.js`
- `node tests/movement_stat_test.js`
- `node tests/nanomancer_skill_integration_test.js`
- `node tests/proficiency_specialization_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6889bc6c99ec832788e4ed0f3c84a088