### PR TITLE
Add MBTI debug logging

### DIFF
--- a/src/ai/nodes/MBTIActionNode.js
+++ b/src/ai/nodes/MBTIActionNode.js
@@ -1,5 +1,5 @@
 import Node, { NodeState } from './Node.js';
-import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { debugMBTIManager } from '../../game/debug/DebugMBTIManager.js';
 
 /**
  * 용병의 MBTI 성향에 따라 확률적으로 SUCCESS 또는 FAILURE를 반환하는 노드
@@ -14,23 +14,17 @@ class MBTIActionNode extends Node {
     }
 
     async evaluate(unit, blackboard) {
-        const nodeName = `MBTIActionNode (${this.trait})`;
-        debugAIManager.logNodeEvaluation({ constructor: { name: nodeName } }, unit);
-
         if (!unit.mbti || unit.mbti[this.trait] === undefined) {
-            debugAIManager.logNodeResult(NodeState.FAILURE, `MBTI 정보 없음: ${this.trait}`);
             return NodeState.FAILURE;
         }
 
         const score = unit.mbti[this.trait];
         const roll = Math.random() * 100;
-        if (roll <= score) {
-            debugAIManager.logNodeResult(NodeState.SUCCESS, `성공 (score: ${score}, roll: ${roll.toFixed(2)})`);
-            return NodeState.SUCCESS;
-        }
+        const success = roll <= score;
 
-        debugAIManager.logNodeResult(NodeState.FAILURE, `실패 (score: ${score}, roll: ${roll.toFixed(2)})`);
-        return NodeState.FAILURE;
+        debugMBTIManager.logTraitCheck(this.trait, score, roll, success);
+
+        return success ? NodeState.SUCCESS : NodeState.FAILURE;
     }
 }
 

--- a/src/game/debug/DebugMBTIManager.js
+++ b/src/game/debug/DebugMBTIManager.js
@@ -1,0 +1,58 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * AI의 MBTI 기반 의사결정 과정을 추적하고 로그로 남기는 디버그 매니저
+ */
+class DebugMBTIManager {
+    constructor() {
+        this.name = 'DebugMBTI';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 특정 의사결정 과정의 시작을 알리는 로그 그룹을 시작합니다.
+     * @param {string} decisionName - 결정의 이름 (예: "생존 본능", "이동 방식 결정")
+     * @param {object} unit - 해당 유닛
+     */
+    logDecisionStart(decisionName, unit) {
+        const mbtiString = `E:${unit.mbti.E}/I:${unit.mbti.I} S:${unit.mbti.S}/N:${unit.mbti.N} T:${unit.mbti.T}/F:${unit.mbti.F} J:${unit.mbti.J}/P:${unit.mbti.P}`;
+        console.groupCollapsed(
+            `%c[${this.name}]`, `color: #ea580c; font-weight: bold;`,
+            `${unit.instanceName} - ${decisionName} (MBTI: ${mbtiString})`
+        );
+    }
+
+    /**
+     * MBTI 성향 체크 결과를 로그로 남깁니다.
+     * @param {string} trait - 체크한 성향 (예: 'E')
+     * @param {number} score - 해당 성향의 점수
+     * @param {number} roll - 주사위 굴림 값
+     * @param {boolean} success - 성공 여부
+     */
+    logTraitCheck(trait, score, roll, success) {
+        const resultText = success ? '성공' : '실패';
+        const color = success ? '#22c55e' : '#ef4444';
+        debugLogEngine.log(
+            this.name,
+            `'${trait}' 성향 체크: %c${resultText}`, `color: ${color}; font-weight: bold;`,
+            `(점수: ${score}, 주사위: ${roll.toFixed(2)})`
+        );
+    }
+
+    /**
+     * 최종적으로 선택된 행동을 로그로 남깁니다.
+     * @param {string} actionDescription - 선택된 행동에 대한 설명
+     */
+    logAction(actionDescription) {
+        debugLogEngine.log(this.name, `선택된 행동: %c${actionDescription}`, 'color: #3b82f6; font-weight: bold;');
+    }
+
+    /**
+     * 의사결정 로그 그룹을 닫습니다.
+     */
+    logDecisionEnd() {
+        console.groupEnd();
+    }
+}
+
+export const debugMBTIManager = new DebugMBTIManager();


### PR DESCRIPTION
## Summary
- add `DebugMBTIManager` for detailed MBTI decision logs
- hook `MBTIActionNode` into the new debug manager
- instrument melee AI behavior with decision start/end and action logs

## Testing
- `node tests/movement_stat_test.js`
- `for f in tests/*_test.js; do echo "running $f"; node $f; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6889d3d0d0b483278b4da89e98560a2e