### PR TITLE
Add low token response AI

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -24,6 +24,8 @@ import FindAllyClusterNode from '../nodes/FindAllyClusterNode.js';
 import FindBuffedEnemyNode from '../nodes/FindBuffedEnemyNode.js';
 import FindEnemyMedicNode from '../nodes/FindEnemyMedicNode.js';
 import { debugMBTIManager } from '../../game/debug/DebugMBTIManager.js';
+import IsTokenBelowThresholdNode from '../nodes/IsTokenBelowThresholdNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 
 function createMeleeAI(engines = {}) {
     const executeSkillBranch = new SelectorNode([
@@ -92,6 +94,34 @@ function createMeleeAI(engines = {}) {
                 new HasNotMovedNode(),
                 new FleeNode(engines),
                 new MoveToTargetNode(engines)
+            ]),
+            new SuccessNode()
+        ]),
+        { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
+    ]);
+
+    const lowTokenResponse = new SequenceNode([
+        new IsTokenBelowThresholdNode(1),
+        {
+            async evaluate(unit) {
+                debugMBTIManager.logDecisionStart('자원 부족 상황 판단', unit);
+                return NodeState.SUCCESS;
+            }
+        },
+        new SelectorNode([
+            new SequenceNode([
+                new MBTIActionNode('J'),
+                new HasNotMovedNode(),
+                { async evaluate() { debugMBTIManager.logAction('다음 턴을 위해 재배치 (J)'); return NodeState.SUCCESS; } },
+                new FindSafeRepositionNode(engines),
+                new MoveToTargetNode(engines)
+            ]),
+            new SequenceNode([
+                new MBTIActionNode('P'),
+                { async evaluate() { debugMBTIManager.logAction('0코스트 스킬 시도 (P)'); return NodeState.SUCCESS; } },
+                new CanUseSkillBySlotNode(3),
+                new FindTargetBySkillTypeNode(engines),
+                executeSkillBranch
             ]),
             new SuccessNode()
         ]),
@@ -238,6 +268,7 @@ function createMeleeAI(engines = {}) {
     const rootNode = new SelectorNode([
         survivalBehavior,
         postStunRecoveryBehavior,
+        lowTokenResponse,
         enemyBuffResponse,
         enemyMedicResponse,
         allyClusterResponse,

--- a/src/ai/nodes/IsTokenBelowThresholdNode.js
+++ b/src/ai/nodes/IsTokenBelowThresholdNode.js
@@ -1,0 +1,30 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { tokenEngine } from '../../game/utils/TokenEngine.js';
+
+/**
+ * 자신의 토큰이 지정된 개수 이하인지 확인하는 조건 노드입니다.
+ */
+class IsTokenBelowThresholdNode extends Node {
+    constructor(threshold) {
+        super();
+        this.threshold = threshold; // 예: 1 (1개 이하)
+    }
+
+    async evaluate(unit, blackboard) {
+        const nodeName = `IsTokenBelowThresholdNode (${this.threshold}개 이하)`;
+        debugAIManager.logNodeEvaluation({ constructor: { name: nodeName } }, unit);
+
+        const currentTokens = tokenEngine.getTokens(unit.uniqueId);
+
+        if (currentTokens <= this.threshold) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `토큰 부족 (${currentTokens}개)`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, `토큰 충분 (${currentTokens}개)`);
+        return NodeState.FAILURE;
+    }
+}
+
+export default IsTokenBelowThresholdNode;


### PR DESCRIPTION
## Summary
- detect when unit tokens fall below a threshold
- react to low token state for melee and ranged AIs

## Testing
- `node tests/critical_shot_skill_integration_test.js`
- `node tests/flyingmen_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/mighty_shield_skill_test.js`
- `node tests/movement_stat_test.js`
- `node tests/nanomancer_skill_integration_test.js`
- `node tests/proficiency_specialization_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6889dda1fefc8327a637e7e0597290ae