### PR TITLE
Implement skill scoring data module

### DIFF
--- a/src/ai/nodes/FindBestSkillByScoreNode.js
+++ b/src/ai/nodes/FindBestSkillByScoreNode.js
@@ -20,6 +20,8 @@ class FindBestSkillByScoreNode extends Node {
 
         const equippedSkillInstances = ownedSkillsManager.getEquippedSkills(unit.uniqueId);
         const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
+        const allies = blackboard.get('allyUnits') || [];
+        const enemies = blackboard.get('enemyUnits') || [];
 
         let bestSkill = null;
         let maxScore = -1;
@@ -31,7 +33,8 @@ class FindBestSkillByScoreNode extends Node {
             const skillData = skillInventoryManager.getSkillData(instData.skillId, instData.grade);
 
             if (this.skillEngine.canUseSkill(unit, skillData)) {
-                const currentScore = this.skillScoreEngine.calculateScore(skillData, unit, blackboard);
+                // ✨ 스코어 계산 시 unit, allies, enemies 정보를 함께 전달합니다.
+                const currentScore = this.skillScoreEngine.calculateScore(unit, skillData, allies, enemies);
                 if (currentScore > maxScore) {
                     maxScore = currentScore;
                     bestSkill = { skillData, instanceId };

--- a/src/game/data/skillScores.js
+++ b/src/game/data/skillScores.js
@@ -1,0 +1,27 @@
+/**
+ * AI의 스킬 선택 가중치를 결정하는 점수 데이터입니다.
+ * 이 값을 조정하여 AI의 행동 경향을 쉽게 변경할 수 있습니다.
+ */
+
+// 스킬 타입별 기본 점수
+export const SCORE_BY_TYPE = {
+    ACTIVE: 2,
+    BUFF: 3,
+    DEBUFF: 2,
+    AID: 4,
+    SUMMON: 3,
+    STRATEGY: 3
+    // PASSIVE는 AI가 직접 사용하는 스킬이 아니므로 점수 계산에서 제외됩니다.
+};
+
+// 스킬 태그별 추가 점수
+export const SCORE_BY_TAG = {
+    FIXED: 10,       // 확정 효과
+    WILL_GUARD: 9,   // 피해 무효화 및 방어 스택
+    DELAY: 8,        // 행동 지연
+    PROHIBITION: 7,  // 행동 금지
+    HEAL: 5,         // 치유
+    CHARGE: 4,       // 돌진
+    KINETIC: 4       // 넉백
+    // 기타 태그는 필요에 따라 추가할 수 있습니다.
+};

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -2,6 +2,8 @@ import { debugLogEngine } from './DebugLogEngine.js';
 import { SKILL_TYPES } from './SkillEngine.js';
 import { SKILL_TAGS } from './SkillTagManager.js';
 import { statusEffectManager } from './StatusEffectManager.js';
+// 새로 만든 점수 데이터 파일을 import 합니다.
+import { SCORE_BY_TYPE, SCORE_BY_TAG } from '../data/skillScores.js';
 
 /**
  * AI의 스킬 선택을 위해 각 스킬의 전략적 가치를 계산하는 엔진
@@ -10,60 +12,39 @@ class SkillScoreEngine {
     constructor() {
         this.name = 'SkillScoreEngine';
 
-        // 1. 스킬 유형별 기본 점수
-        this.skillTypeScores = {
-            [SKILL_TYPES.ACTIVE.name]: 2,
-            [SKILL_TYPES.BUFF.name]: 3,
-            [SKILL_TYPES.DEBUFF.name]: 2,
-            [SKILL_TYPES.AID.name]: 4,
-            [SKILL_TYPES.SUMMON.name]: 3,
-            [SKILL_TYPES.STRATEGY.name]: 3,
-        };
-
-        // 2. 스킬 태그별 추가 점수
-        this.skillTagScores = {
-            [SKILL_TAGS.FIXED]: 10,
-            [SKILL_TAGS.WILL_GUARD]: 9,
-            [SKILL_TAGS.DELAY]: 8,
-            [SKILL_TAGS.PROHIBITION]: 7,
-            [SKILL_TAGS.HEAL]: 5,
-            [SKILL_TAGS.CHARGE]: 4,
-            [SKILL_TAGS.KINETIC]: 4,
-        };
-
         debugLogEngine.register(this);
     }
 
     /**
-     * 주어진 스킬 데이터와 전투 상황을 바탕으로 총점을 계산합니다.
-     * @param {object} skillData - 점수를 계산할 스킬의 데이터
+     * 주어진 스킬 데이터와 현재 전투 상황을 바탕으로 총점을 계산합니다.
      * @param {object} unit - 스킬 사용 주체 유닛
-     * @param {object} blackboard - AI 블랙보드
+     * @param {object} skillData - 점수를 계산할 스킬의 데이터
+     * @param {Array<object>} allies - 모든 아군 유닛 목록
+     * @param {Array<object>} enemies - 모든 적군 유닛 목록
      * @returns {number} - 계산된 최종 점수
      */
-    calculateScore(skillData, unit, blackboard) {
+    calculateScore(unit, skillData, allies, enemies) {
         if (!skillData || skillData.type === 'PASSIVE') {
             return 0;
         }
 
-        // 1. 스킬 유형 기본 점수
-        const skillTypeName = SKILL_TYPES[skillData.type]?.name;
-        let totalScore = this.skillTypeScores[skillTypeName] || 0;
+        let totalScore = 0;
         const situationLogs = [];
 
-        // 2. 스킬 태그 추가 점수
-        if (skillData.tags && skillData.tags.length > 0) {
-            skillData.tags.forEach(tag => {
-                totalScore += this.skillTagScores[tag] || 0;
-            });
+        // 1. 스킬 타입별 기본 점수 추가
+        totalScore += SCORE_BY_TYPE[skillData.type] || 0;
+
+        // 2. 스킬 태그별 점수 추가 (누적)
+        if (skillData.tags) {
+            for (const tag of skillData.tags) {
+                totalScore += SCORE_BY_TAG[tag] || 0;
+            }
         }
 
-        // 3. 상황별 보너스/패널티
-        const allies = blackboard.get('allyUnits') || [];
-        const enemies = blackboard.get('enemyUnits') || [];
+        // 3. 상황별 점수 보정
 
         const lowHealthAllies = allies.filter(a => a.currentHp / a.finalStats.hp <= 0.5).length;
-        if (lowHealthAllies > 0 && (skillData.tags.includes(SKILL_TAGS.HEAL) || skillData.tags.includes(SKILL_TAGS.AID))) {
+        if (lowHealthAllies > 0 && skillData.tags?.includes(SKILL_TAGS.HEAL)) {
             const bonus = lowHealthAllies * 15;
             totalScore += bonus;
             situationLogs.push(`체력 낮은 아군 ${lowHealthAllies}명 발견, +${bonus}점`);
@@ -84,11 +65,11 @@ class SkillScoreEngine {
             }
         }
 
-        const healthPercentage = unit.currentHp / unit.finalStats.hp;
-        if (healthPercentage <= 0.4) {
-            if (skillData.type === 'BUFF' || skillData.tags.includes(SKILL_TAGS.WILL_GUARD)) {
-                totalScore += 12;
-                situationLogs.push('자신 체력 낮음, 방어/지원 스킬에 +12점');
+        // 3-3. 방어/버프 스킬: 자신의 체력이 낮을 때 가산
+        if (skillData.tags?.includes(SKILL_TAGS.WILL_GUARD) || skillData.type === 'BUFF') {
+            if (unit.currentHp < unit.finalStats.hp * 0.3) {
+                totalScore += 10;
+                situationLogs.push(`자신 체력 30% 미만, 생존 스킬에 +10점`);
             }
         }
 


### PR DESCRIPTION
## Summary
- add `skillScores.js` for AI skill score tuning
- refactor `SkillScoreEngine` to import the new data file and pass allies/enemies directly
- update `FindBestSkillByScoreNode` to send ally/enemy info when scoring skills

## Testing
- `node tests/critical_shot_skill_integration_test.js`
- `node tests/flyingmen_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/mighty_shield_skill_test.js`
- `node tests/movement_stat_test.js`
- `node tests/nanomancer_skill_integration_test.js`
- `node tests/proficiency_specialization_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6889ed80261883279af2c33df5d834d4