### PR TITLE
Apply skill score logic across AI

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -26,6 +26,7 @@ import FindEnemyMedicNode from '../nodes/FindEnemyMedicNode.js';
 import { debugMBTIManager } from '../../game/debug/DebugMBTIManager.js';
 import IsTokenBelowThresholdNode from '../nodes/IsTokenBelowThresholdNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 
 function createMeleeAI(engines = {}) {
     const executeSkillBranch = new SelectorNode([
@@ -247,15 +248,10 @@ function createMeleeAI(engines = {}) {
         ])
     ]);
 
-    const attackSequence = new SelectorNode([
-        new SequenceNode([ new CanUseSkillBySlotNode(0), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(1), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(2), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(3), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(4), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(5), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(6), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(7), new FindTargetBySkillTypeNode(engines), executeSkillBranch ])
+    const attackSequence = new SequenceNode([
+        new FindBestSkillByScoreNode(engines),
+        new FindTargetBySkillTypeNode(engines),
+        executeSkillBranch
     ]);
 
     const basicMovement = new SequenceNode([

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -25,6 +25,7 @@ import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import FindEnemyMedicNode from '../nodes/FindEnemyMedicNode.js';
 import { debugMBTIManager } from '../../game/debug/DebugMBTIManager.js';
 import IsTokenBelowThresholdNode from '../nodes/IsTokenBelowThresholdNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 
 function createRangedAI(engines = {}) {
     const executeSkillBranch = new SelectorNode([
@@ -171,15 +172,10 @@ function createRangedAI(engines = {}) {
         ])
     ]);
 
-    const attackSequence = new SelectorNode([
-        new SequenceNode([ new CanUseSkillBySlotNode(0), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(1), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(2), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(3), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(4), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(5), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(6), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(7), new FindTargetBySkillTypeNode(engines), executeSkillBranch ])
+    const attackSequence = new SequenceNode([
+        new FindBestSkillByScoreNode(engines),
+        new FindTargetBySkillTypeNode(engines),
+        executeSkillBranch
     ]);
 
     const kitingBehavior = new SequenceNode([

--- a/src/ai/behaviors/createFlyingmanAI.js
+++ b/src/ai/behaviors/createFlyingmanAI.js
@@ -13,6 +13,7 @@ import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 
 /**
  * 플라잉맨을 위한 행동 트리 (암살자 역할)
@@ -37,34 +38,11 @@ function createFlyingmanAI(engines = {}) {
     ]);
 
     const rootNode = new SelectorNode([
-        // 1순위: 1번 슬롯 스킬
         new SequenceNode([
-            new CanUseSkillBySlotNode(0),
+            new FindBestSkillByScoreNode(engines),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // ... (2, 3번 슬롯도 동일하게 구성)
-        new SequenceNode([
-            new CanUseSkillBySlotNode(1),
-            new FindTargetBySkillTypeNode(engines),
-            executeSkillBranch
-        ]),
-        new SequenceNode([
-            new CanUseSkillBySlotNode(2),
-            new FindTargetBySkillTypeNode(engines),
-            executeSkillBranch
-        ]),
-        // 4순위: 4번 슬롯 스킬 (기본 공격)
-        new SequenceNode([
-            new CanUseSkillBySlotNode(3),
-            new FindTargetBySkillTypeNode(engines),
-            executeSkillBranch
-        ]),
-        // 특수 스킬 슬롯 체크 (5-8)
-        new SequenceNode([ new CanUseSkillBySlotNode(4), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(5), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(6), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(7), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
 
         // 이동만 실행
         new SequenceNode([
@@ -74,7 +52,6 @@ function createFlyingmanAI(engines = {}) {
             new MoveToTargetNode(engines)
         ]),
 
-        // 최후의 보루
         new SuccessNode(),
     ]);
 

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -20,6 +20,7 @@ import FindPathToAllyNode from '../nodes/FindPathToAllyNode.js';
 import JustRecoveredFromStunNode from '../nodes/JustRecoveredFromStunNode.js';
 import SetTargetToStunnerNode from '../nodes/SetTargetToStunnerNode.js';
 import { debugMBTIManager } from '../../game/debug/DebugMBTIManager.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 
 function createHealerAI(engines = {}) {
     const executeSkillBranch = new SelectorNode([
@@ -90,15 +91,10 @@ function createHealerAI(engines = {}) {
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);
 
-    const supportSequence = new SelectorNode([
-        new SequenceNode([ new CanUseSkillBySlotNode(0), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(1), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(2), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(3), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(4), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(5), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(6), new FindTargetBySkillTypeNode(engines), executeSkillBranch ]),
-        new SequenceNode([ new CanUseSkillBySlotNode(7), new FindTargetBySkillTypeNode(engines), executeSkillBranch ])
+    const supportSequence = new SequenceNode([
+        new FindBestSkillByScoreNode(engines),
+        new FindTargetBySkillTypeNode(engines),
+        executeSkillBranch
     ]);
 
     const repositionSequence = new SequenceNode([


### PR DESCRIPTION
## Summary
- enhance SkillScoreEngine debugging so score breakdown is logged
- pick skills by total score in every AI

## Testing
- `for f in tests/*_test.js; do echo "Running $f"; node "$f" || break; done`
- `python3 -m http.server 8000 &> /tmp/http.log & sleep 1 && curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6889f142c4f083278dbf90009bbcaffa