### PR TITLE
Add MBTI visuals

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -53,13 +53,13 @@ function createMeleeAI(engines = {}) {
         },
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('I'),
+                new MBTIActionNode('I', engines),
                 { async evaluate() { debugMBTIManager.logAction('후퇴 선택'); return NodeState.SUCCESS; } },
                 new FleeNode(engines),
                 new MoveToTargetNode(engines)
             ]),
             new SequenceNode([
-                new MBTIActionNode('E'),
+                new MBTIActionNode('E', engines),
                 { async evaluate() { debugMBTIManager.logAction('최후의 발악 선택'); return NodeState.SUCCESS; } },
                 new CanUseSkillBySlotNode(0),
                 new FindTargetBySkillTypeNode(engines),
@@ -80,7 +80,7 @@ function createMeleeAI(engines = {}) {
         },
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('S'),
+                new MBTIActionNode('S', engines),
                 { async evaluate() { debugMBTIManager.logAction('복수 선택 (S)'); return NodeState.SUCCESS; } },
                 new SetTargetToStunnerNode(),
                 new CanUseSkillBySlotNode(3),
@@ -90,7 +90,7 @@ function createMeleeAI(engines = {}) {
                 new UseSkillNode(engines)
             ]),
             new SequenceNode([
-                new MBTIActionNode('J'),
+                new MBTIActionNode('J', engines),
                 { async evaluate() { debugMBTIManager.logAction('위치 정비 선택 (J)'); return NodeState.SUCCESS; } },
                 new HasNotMovedNode(),
                 new FleeNode(engines),
@@ -111,14 +111,14 @@ function createMeleeAI(engines = {}) {
         },
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('J'),
+                new MBTIActionNode('J', engines),
                 new HasNotMovedNode(),
                 { async evaluate() { debugMBTIManager.logAction('다음 턴을 위해 재배치 (J)'); return NodeState.SUCCESS; } },
                 new FindSafeRepositionNode(engines),
                 new MoveToTargetNode(engines)
             ]),
             new SequenceNode([
-                new MBTIActionNode('P'),
+                new MBTIActionNode('P', engines),
                 { async evaluate() { debugMBTIManager.logAction('0코스트 스킬 시도 (P)'); return NodeState.SUCCESS; } },
                 new CanUseSkillBySlotNode(3),
                 new FindTargetBySkillTypeNode(engines),
@@ -139,7 +139,7 @@ function createMeleeAI(engines = {}) {
         },
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('F'),
+                new MBTIActionNode('F', engines),
                 { async evaluate() { debugMBTIManager.logAction('아군에게 이동'); return NodeState.SUCCESS; } },
                 new HasNotMovedNode(),
                 new FindPathToAllyNode(engines),
@@ -155,14 +155,14 @@ function createMeleeAI(engines = {}) {
         new FindAllyClusterNode(),
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('J'),
+                new MBTIActionNode('J', engines),
                 { async evaluate() { debugMBTIManager.logAction('진형 합류 선택 (J)'); return NodeState.SUCCESS; } },
                 new HasNotMovedNode(),
                 new FindPathToAllyNode(engines),
                 new MoveToTargetNode(engines)
             ]),
             new SequenceNode([
-                new MBTIActionNode('P'),
+                new MBTIActionNode('P', engines),
                 { async evaluate() { debugMBTIManager.logAction('위험 분산 선택 (P)'); return NodeState.SUCCESS; } },
                 new HasNotMovedNode(),
                 new FleeNode(engines),
@@ -177,7 +177,7 @@ function createMeleeAI(engines = {}) {
         new FindBuffedEnemyNode(),
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('S'),
+                new MBTIActionNode('S', engines),
                 { async evaluate(unit, blackboard) {
                     const target = blackboard.get('buffedEnemy');
                     blackboard.set('skillTarget', target);
@@ -188,7 +188,7 @@ function createMeleeAI(engines = {}) {
                 executeSkillBranch
             ]),
             new SequenceNode([
-                new MBTIActionNode('T'),
+                new MBTIActionNode('T', engines),
                 { async evaluate(unit, blackboard) {
                     const target = blackboard.get('buffedEnemy');
                     blackboard.set('skillTarget', target);
@@ -199,14 +199,14 @@ function createMeleeAI(engines = {}) {
                 executeSkillBranch
             ]),
             new SequenceNode([
-                new MBTIActionNode('F'),
+                new MBTIActionNode('F', engines),
                 { async evaluate() { debugMBTIManager.logAction('아군 보호 태세 (F)'); return NodeState.SUCCESS; } },
                 new CanUseSkillBySlotNode(1),
                 new FindTargetBySkillTypeNode(engines),
                 executeSkillBranch
             ]),
             new SequenceNode([
-                new MBTIActionNode('N'),
+                new MBTIActionNode('N', engines),
                 { async evaluate() { debugMBTIManager.logAction('원래 목표 유지 (N)'); return NodeState.SUCCESS; } },
                 { async evaluate() { return NodeState.FAILURE; } }
             ]),
@@ -219,7 +219,7 @@ function createMeleeAI(engines = {}) {
         new FindEnemyMedicNode(),
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('E'),
+                new MBTIActionNode('E', engines),
                 { async evaluate(unit, blackboard) {
                     const target = blackboard.get('enemyMedic');
                     blackboard.set('skillTarget', target);
@@ -230,7 +230,7 @@ function createMeleeAI(engines = {}) {
                 executeSkillBranch
             ]),
             new SequenceNode([
-                new MBTIActionNode('I'),
+                new MBTIActionNode('I', engines),
                 { async evaluate(unit, blackboard) {
                     if (Math.random() < 0.5) {
                         const target = blackboard.get('enemyMedic');

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -52,13 +52,13 @@ function createRangedAI(engines = {}) {
         },
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('I'),
+                new MBTIActionNode('I', engines),
                 { async evaluate() { debugMBTIManager.logAction('후퇴 선택'); return NodeState.SUCCESS; } },
                 new FleeNode(engines),
                 new MoveToTargetNode(engines)
             ]),
             new SequenceNode([
-                new MBTIActionNode('E'),
+                new MBTIActionNode('E', engines),
                 { async evaluate() { debugMBTIManager.logAction('최후의 발악 선택'); return NodeState.SUCCESS; } },
                 new CanUseSkillBySlotNode(3),
                 new FindTargetBySkillTypeNode(engines),
@@ -79,14 +79,14 @@ function createRangedAI(engines = {}) {
         },
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('P'),
+                new MBTIActionNode('P', engines),
                 { async evaluate() { debugMBTIManager.logAction('즉각 반격 선택 (P)'); return NodeState.SUCCESS; } },
                 new CanUseSkillBySlotNode(3),
                 new FindTargetBySkillTypeNode(engines),
                 executeSkillBranch
             ]),
             new SequenceNode([
-                new MBTIActionNode('J'),
+                new MBTIActionNode('J', engines),
                 { async evaluate() { debugMBTIManager.logAction('위치 정비 선택 (J)'); return NodeState.SUCCESS; } },
                 new HasNotMovedNode(),
                 new FindSafeRepositionNode(engines),
@@ -107,14 +107,14 @@ function createRangedAI(engines = {}) {
         },
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('J'),
+                new MBTIActionNode('J', engines),
                 new HasNotMovedNode(),
                 { async evaluate() { debugMBTIManager.logAction('다음 턴을 위해 재배치 (J)'); return NodeState.SUCCESS; } },
                 new FindSafeRepositionNode(engines),
                 new MoveToTargetNode(engines)
             ]),
             new SequenceNode([
-                new MBTIActionNode('P'),
+                new MBTIActionNode('P', engines),
                 { async evaluate() { debugMBTIManager.logAction('0코스트 스킬 시도 (P)'); return NodeState.SUCCESS; } },
                 new CanUseSkillBySlotNode(3),
                 new FindTargetBySkillTypeNode(engines),
@@ -135,7 +135,7 @@ function createRangedAI(engines = {}) {
         },
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('F'),
+                new MBTIActionNode('F', engines),
                 { async evaluate() { debugMBTIManager.logAction('아군 지원 위치로 이동'); return NodeState.SUCCESS; } },
                 new HasNotMovedNode(),
                 new FindPathToAllyNode(engines),
@@ -151,7 +151,7 @@ function createRangedAI(engines = {}) {
         new FindEnemyMedicNode(),
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('P'),
+                new MBTIActionNode('P', engines),
                 { async evaluate(unit, blackboard) {
                     const target = blackboard.get('enemyMedic');
                     blackboard.set('skillTarget', target);
@@ -162,7 +162,7 @@ function createRangedAI(engines = {}) {
                 executeSkillBranch
             ]),
             new SequenceNode([
-                new MBTIActionNode('J'),
+                new MBTIActionNode('J', engines),
                 new HasNotMovedNode(),
                 { async evaluate() { debugMBTIManager.logAction('유리한 위치로 이동 (J)'); return NodeState.SUCCESS; } },
                 new FindSafeRepositionNode(engines),

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -47,13 +47,13 @@ function createHealerAI(engines = {}) {
         },
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('I'),
+                new MBTIActionNode('I', engines),
                 { async evaluate() { debugMBTIManager.logAction('후퇴 선택'); return NodeState.SUCCESS; } },
                 new FleeNode(engines),
                 new MoveToTargetNode(engines)
             ]),
             new SequenceNode([
-                new MBTIActionNode('E'),
+                new MBTIActionNode('E', engines),
                 { async evaluate() { debugMBTIManager.logAction('최후의 발악 선택'); return NodeState.SUCCESS; } },
                 new CanUseSkillBySlotNode(0),
                 { async evaluate(unit, blackboard) { blackboard.set('skillTarget', unit); return NodeState.SUCCESS; } },
@@ -74,13 +74,13 @@ function createHealerAI(engines = {}) {
         },
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('N'),
+                new MBTIActionNode('N', engines),
                 { async evaluate() { debugMBTIManager.logAction('전황 재평가 선택 (N)'); return NodeState.SUCCESS; } },
                 new FindTargetBySkillTypeNode(engines),
                 executeSkillBranch
             ]),
             new SequenceNode([
-                new MBTIActionNode('J'),
+                new MBTIActionNode('J', engines),
                 { async evaluate() { debugMBTIManager.logAction('위치 정비 선택 (J)'); return NodeState.SUCCESS; } },
                 new HasNotMovedNode(),
                 new FindSafeRepositionNode(engines),

--- a/src/ai/nodes/MBTIActionNode.js
+++ b/src/ai/nodes/MBTIActionNode.js
@@ -7,10 +7,12 @@ import { debugMBTIManager } from '../../game/debug/DebugMBTIManager.js';
 class MBTIActionNode extends Node {
     /**
      * @param {string} trait - 확인할 MBTI 특성 (E, I, S, N, T, F, J, P)
+     * @param {object} [engines={}] - AI에 주입될 엔진들 (VFXManager 등)
      */
-    constructor(trait) {
+    constructor(trait, engines = {}) {
         super();
         this.trait = trait.toUpperCase();
+        this.vfxManager = engines.vfxManager;
     }
 
     async evaluate(unit, blackboard) {
@@ -23,6 +25,10 @@ class MBTIActionNode extends Node {
         const success = roll <= score;
 
         debugMBTIManager.logTraitCheck(this.trait, score, roll, success);
+
+        if (success && this.vfxManager) {
+            this.vfxManager.showMBTITrait(unit.sprite, this.trait);
+        }
 
         return success ? NodeState.SUCCESS : NodeState.FAILURE;
     }

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -26,6 +26,27 @@ export class UnitDetailDOM {
         // ✨ 1. 용병의 고유 속성 특화 정보를 가져옵니다.
         const attributeSpec = unitData.attributeSpec;
 
+        // --- MBTI 문자열과 툴팁 텍스트를 준비합니다. ---
+        const mbti = unitData.mbti;
+        let mbtiString = '';
+        if (mbti) {
+            mbtiString += mbti.E > mbti.I ? 'E' : 'I';
+            mbtiString += mbti.S > mbti.N ? 'S' : 'N';
+            mbtiString += mbti.T > mbti.F ? 'T' : 'F';
+            mbtiString += mbti.J > mbti.P ? 'J' : 'P';
+        }
+
+        const mbtiTooltips = {
+            E: '외향형(E): 위기 상황에서 최후의 발악을 선택할 확률이 높습니다.',
+            I: '내향형(I): 위기 상황에서 후퇴하여 생존을 도모할 확률이 높습니다.',
+            S: '감각형(S): 기절에서 회복했을 때, 자신을 기절시킨 적에게 즉시 복수하려는 경향이 있습니다.',
+            N: '직관형(N): 기절에서 회복했을 때, 전황을 다시 파악하고 가장 유리한 대상을 공격합니다.',
+            T: '사고형(T): 적의 위협적인 버프에 디버프로 맞서려는 경향이 있습니다.',
+            F: '감정형(F): 위험에 처한 아군을 우선적으로 보호하려는 경향이 있습니다.',
+            J: '판단형(J): 기절 회복 또는 자원 부족 시, 다음 턴을 위해 안전한 위치로 재정비하는 것을 선호합니다.',
+            P: '인식형(P): 기절 회복 또는 자원 부족 시, 즉흥적으로 0코스트 스킬을 사용하며 변수를 만들려 합니다.'
+        };
+
         const overlay = document.createElement('div');
         // ✨ [수정] ID 대신 클래스를 사용합니다.
         overlay.className = 'modal-overlay';
@@ -46,6 +67,7 @@ export class UnitDetailDOM {
             <div class="detail-header">
                 <span class="unit-name">${instanceName}</span>
                 <span class="unit-class">${unitData.name}</span>
+                <div class="unit-mbti" data-tooltip="${mbtiTooltips[mbtiString[0]]}\n${mbtiTooltips[mbtiString[1]]}\n${mbtiTooltips[mbtiString[2]]}\n${mbtiTooltips[mbtiString[3]]}">${mbtiString}</div>
                 <span class="unit-level">Lv. ${unitData.level}</span>
             </div>
             <div id="unit-detail-close">X</div>

--- a/src/game/utils/VFXManager.js
+++ b/src/game/utils/VFXManager.js
@@ -254,6 +254,36 @@ export class VFXManager {
         debugLogEngine.log('VFXManager', logMessage);
     }
 
+    /**
+     * MBTI 성향 문자를 머리 위에 표시합니다.
+     * @param {Phaser.GameObjects.Sprite} parentSprite
+     * @param {string} trait
+     */
+    showMBTITrait(parentSprite, trait) {
+        const style = {
+            fontFamily: '"Arial Black", Arial, sans-serif',
+            fontSize: '32px',
+            color: '#ea580c',
+            stroke: '#000000',
+            strokeThickness: 5,
+        };
+
+        const traitText = this.scene.add
+            .text(parentSprite.x, parentSprite.y - 60, trait, style)
+            .setOrigin(0.5, 0.5);
+        this.vfxLayer.add(traitText);
+
+        this.scene.tweens.add({
+            targets: traitText,
+            y: traitText.y - 40,
+            alpha: 0,
+            scale: 1.5,
+            duration: 1200,
+            ease: 'Cubic.easeOut',
+            onComplete: () => traitText.destroy(),
+        });
+    }
+
     // 스킬 이름을 머리 위에 표시하는 효과를 보여줍니다.
     showSkillName(parentSprite, skillName, color = '#ffffff') {
         const style = {


### PR DESCRIPTION
## Summary
- show mercenary MBTI type on unit detail UI with tooltip
- display MBTI letter as VFX when AI behaviour triggers
- allow MBTI action node to trigger this VFX
- wire VFX manager into MBTI nodes in all AI behaviors

## Testing
- `npm install`
- `for f in tests/*.js; do node $f || break; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688a102c4c4883279ea5c723eda37c73