### PR TITLE
Fix MBTI debug output when unit lacks MBTI data

### DIFF
--- a/src/game/debug/DebugMBTIManager.js
+++ b/src/game/debug/DebugMBTIManager.js
@@ -15,7 +15,11 @@ class DebugMBTIManager {
      * @param {object} unit - 해당 유닛
      */
     logDecisionStart(decisionName, unit) {
-        const mbtiString = `E:${unit.mbti.E}/I:${unit.mbti.I} S:${unit.mbti.S}/N:${unit.mbti.N} T:${unit.mbti.T}/F:${unit.mbti.F} J:${unit.mbti.J}/P:${unit.mbti.P}`;
+        let mbtiString = 'N/A';
+        if (unit && unit.mbti) {
+            const m = unit.mbti;
+            mbtiString = `E:${m.E}/I:${m.I} S:${m.S}/N:${m.N} T:${m.T}/F:${m.F} J:${m.J}/P:${m.P}`;
+        }
         console.groupCollapsed(
             `%c[${this.name}]`, `color: #ea580c; font-weight: bold;`,
             `${unit.instanceName} - ${decisionName} (MBTI: ${mbtiString})`


### PR DESCRIPTION
## Summary
- prevent `DebugMBTIManager` from crashing when a unit has no MBTI

## Testing
- `for f in tests/*test.js; do echo "Running $f"; node $f || exit 1; done`
- `node tests/movement_stat_test.js`
- `node tests/warrior_skill_integration_test.js`

------
https://chatgpt.com/codex/tasks/task_e_688a14ef89e08327a76f3972350e3b8c