### PR TITLE
Add MBTI card selector and Arena manager

### DIFF
--- a/src/game/dom/ArenaDOMEngine.js
+++ b/src/game/dom/ArenaDOMEngine.js
@@ -1,6 +1,7 @@
 import { partyEngine } from '../utils/PartyEngine.js';
 import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 import { formationEngine } from '../utils/FormationEngine.js';
+import { arenaManager } from '../utils/ArenaManager.js'; // ArenaManager import
 
 export class ArenaDOMEngine {
     constructor(scene, domEngine) {
@@ -47,6 +48,7 @@ export class ArenaDOMEngine {
         }
 
         this.placeUnits();
+        this.placeEnemyUnits(); // 적 유닛 배치 함수 호출
 
         const backButton = document.createElement('div');
         backButton.id = 'formation-back-button';
@@ -125,6 +127,34 @@ export class ArenaDOMEngine {
             const otherId = parseInt(targetUnit.dataset.unitId);
             if (otherId) formationEngine.setPosition(otherId, parseInt(fromCell.dataset.index));
         }
+    }
+
+    // ArenaDOMEngine 클래스 내에 새로운 메소드 추가
+    placeEnemyUnits() {
+        const enemyTeam = arenaManager.getEnemyTeam();
+        const cells = Array.from(this.grid.children).filter(c => !c.classList.contains('ally-area'));
+
+        enemyTeam.forEach(unit => {
+            // 적 진형 내에서 무작위 빈 셀을 찾습니다.
+            const availableCells = cells.filter(c => !c.hasChildNodes());
+            if (availableCells.length === 0) return;
+
+            const cell = availableCells[Math.floor(Math.random() * availableCells.length)];
+            if (!cell) return;
+
+            const unitDiv = document.createElement('div');
+            unitDiv.className = 'formation-unit'; // 동일한 스타일 사용
+            unitDiv.dataset.unitId = unit.uniqueId;
+            unitDiv.style.backgroundImage = `url(assets/images/unit/${unit.id}.png)`;
+            unitDiv.style.filter = 'grayscale(80%) brightness(0.8)'; // 적으로 보이도록 필터 적용
+
+            const nameLabel = document.createElement('div');
+            nameLabel.className = 'formation-unit-name';
+            nameLabel.innerText = unit.instanceName || unit.name;
+            unitDiv.appendChild(nameLabel);
+
+            cell.appendChild(unitDiv);
+        });
     }
 
     hide() {

--- a/src/game/scenes/ArenaScene.js
+++ b/src/game/scenes/ArenaScene.js
@@ -1,6 +1,7 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { DOMEngine } from '../utils/DOMEngine.js';
 import { ArenaDOMEngine } from '../dom/ArenaDOMEngine.js';
+import { arenaManager } from '../utils/ArenaManager.js'; // ArenaManager import
 
 export class ArenaScene extends Scene {
     constructor() {
@@ -13,6 +14,9 @@ export class ArenaScene extends Scene {
         if (territoryContainer) {
             territoryContainer.style.display = 'none';
         }
+
+        // 씬이 시작될 때 아레나 적 팀을 생성합니다.
+        arenaManager.generateEnemyTeam();
 
         const domEngine = new DOMEngine(this);
         this.arenaDomEngine = new ArenaDOMEngine(this, domEngine);

--- a/src/game/utils/ArenaManager.js
+++ b/src/game/utils/ArenaManager.js
@@ -1,0 +1,52 @@
+import { mercenaryEngine } from './MercenaryEngine.js';
+import { mercenaryData } from '../data/mercenaries.js';
+import { skillInventoryManager } from './SkillInventoryManager.js';
+import { ownedSkillsManager } from './OwnedSkillsManager.js';
+import { mercenaryCardSelector } from './MercenaryCardSelector.js';
+
+/**
+ * 아레나 컨텐츠와 관련된 로직(적 생성, 보상 등)을 관리하는 엔진
+ */
+class ArenaManager {
+    constructor() {
+        this.name = 'ArenaManager';
+        this.enemyTeam = [];
+    }
+
+    /**
+     * 12명의 랜덤한 적 용병 팀을 생성하고 MBTI에 따라 스킬을 장착시킵니다.
+     */
+    generateEnemyTeam() {
+        this.enemyTeam = [];
+        let availableCards = [...skillInventoryManager.getInventory()];
+        const mercenaryTypes = Object.values(mercenaryData);
+
+        for (let i = 0; i < 12; i++) {
+            // 1. 랜덤 클래스의 적 용병 생성
+            const randomType = mercenaryTypes[Math.floor(Math.random() * mercenaryTypes.length)];
+            const enemyMercenary = mercenaryEngine.hireMercenary(randomType, 'enemy');
+
+            // 2. MBTI에 따라 스킬 선택 (강화된 로직 사용)
+            const { selectedCards, remainingCards } = mercenaryCardSelector.selectCardsForMercenary(enemyMercenary, availableCards);
+
+            // 3. 선택된 스킬을 용병에게 장착
+            selectedCards.forEach((cardInstance, index) => {
+                ownedSkillsManager.equipSkill(enemyMercenary.uniqueId, index, cardInstance.instanceId);
+            });
+            
+            console.log(`[ArenaManager] ${enemyMercenary.instanceName}(${enemyMercenary.mbti.E > 50 ? 'E' : 'I'}...)에게 스킬 ${selectedCards.length}개 장착 완료.`);
+
+            this.enemyTeam.push(enemyMercenary);
+            availableCards = remainingCards; // 남은 카드 풀 업데이트
+        }
+        
+        console.log('[ArenaManager] 아레나 적 팀 생성이 완료되었습니다.', this.enemyTeam);
+        return this.enemyTeam;
+    }
+
+    getEnemyTeam() {
+        return this.enemyTeam;
+    }
+}
+
+export const arenaManager = new ArenaManager();

--- a/src/game/utils/MercenaryCardSelector.js
+++ b/src/game/utils/MercenaryCardSelector.js
@@ -1,0 +1,110 @@
+import { SKILL_TAGS } from './SkillTagManager.js';
+import { skillInventoryManager } from './SkillInventoryManager.js';
+import { classProficiencies } from '../data/classProficiencies.js';
+
+/**
+ * 용병의 MBTI 성향에 따라 장착할 스킬 카드를 결정하는 엔진 (심화 버전)
+ */
+class MercenaryCardSelector {
+    constructor() {
+        this.name = 'MercenaryCardSelector';
+    }
+
+    /**
+     * 용병 한 명에게 장착할 8개의 스킬을 선택합니다.
+     * @param {object} mercenary - 스킬을 장착할 용병
+     * @param {Array<object>} availableCards - 사용 가능한 스킬 카드 인스턴스 목록
+     * @returns {{selectedCards: Array<object>, remainingCards: Array<object>}} - 선택된 카드와 남은 카드 목록
+     */
+    selectCardsForMercenary(mercenary, availableCards) {
+        // 1. 주 스킬과 특수 스킬 후보군 분리
+        const mainSkillCandidates = availableCards.filter(inst => {
+            const data = this._getSkillData(inst);
+            return data && data.type !== 'STRATEGY' && !data.tags?.includes(SKILL_TAGS.SPECIAL);
+        });
+
+        const specialSkillCandidates = availableCards.filter(inst => {
+            const data = this._getSkillData(inst);
+            return data && data.type !== 'STRATEGY' && data.tags?.includes(SKILL_TAGS.SPECIAL);
+        });
+
+        // 2. 주 스킬과 특수 스킬을 성향에 맞게 선택
+        const selectedMainSkills = this._selectSkillsByMBTI(mercenary, mainSkillCandidates, 4);
+        const remainingForSpecial = specialSkillCandidates.filter(inst => !selectedMainSkills.find(s => s.instanceId === inst.instanceId));
+        const selectedSpecialSkills = this._selectSkillsByMBTI(mercenary, remainingForSpecial, 4);
+
+        // 3. 최종 결과 조합 및 반환
+        const selectedCards = [...selectedMainSkills, ...selectedSpecialSkills];
+        const remainingCards = availableCards.filter(inst => !selectedCards.find(s => s.instanceId === inst.instanceId));
+
+        return { selectedCards, remainingCards };
+    }
+
+    /**
+     * MBTI 성향에 따라 스킬 목록을 필터링하고 가중치를 부여하여 스킬을 선택합니다.
+     * @private
+     */
+    _selectSkillsByMBTI(mercenary, candidates, count) {
+        let selected = [];
+        let currentCandidates = [...candidates];
+
+        for (let i = 0; i < count; i++) {
+            if (currentCandidates.length === 0) break;
+
+            // 각 카드에 대해 MBTI 기반 선호도 점수 계산
+            const weightedCandidates = currentCandidates.map(inst => {
+                const card = this._getSkillData(inst);
+                let score = 100; // 기본 점수
+
+                // E vs I: 외향(공격/돌진) vs 내향(원거리/방어)
+                if (card.tags.some(t => [SKILL_TAGS.CHARGE, SKILL_TAGS.MELEE].includes(t))) score += mercenary.mbti.E;
+                if (card.tags.some(t => [SKILL_TAGS.RANGED, SKILL_TAGS.WILL_GUARD].includes(t)) || card.type === 'BUFF') score += mercenary.mbti.I;
+
+                // S vs N: 감각(단순/확정) vs 직관(복합/상태이상)
+                if (card.tags.includes(SKILL_TAGS.FIXED) || (!card.effect && (card.damageMultiplier || card.healMultiplier))) score += mercenary.mbti.S;
+                if (card.effect || card.push || card.turnOrderEffect || card.tags.includes(SKILL_TAGS.PROHIBITION)) score += mercenary.mbti.N;
+
+                // T vs F: 사고(자신 강화/적 약화) vs 감정(아군 지원/치유)
+                if (card.type === 'DEBUFF' || (card.type === 'BUFF' && card.targetType === 'self')) score += mercenary.mbti.T;
+                if (card.type === 'AID' || (card.effect && card.effect.isGlobal)) score += mercenary.mbti.F;
+
+                // J vs P: 판단(정석/숙련) vs 인식(변칙/비숙련)
+                const isConventional = this._isConventional(card, mercenary.id);
+                if (isConventional) score += mercenary.mbti.J;
+                if (!isConventional) score += mercenary.mbti.P;
+
+                return { instance: inst, score };
+            });
+
+            // 점수에 기반한 가중치 랜덤 선택
+            const totalScore = weightedCandidates.reduce((sum, c) => sum + c.score, 0);
+            let random = Math.random() * totalScore;
+            
+            let choice = weightedCandidates[weightedCandidates.length - 1].instance; // fallback
+            for (const candidate of weightedCandidates) {
+                if (random < candidate.score) {
+                    choice = candidate.instance;
+                    break;
+                }
+                random -= candidate.score;
+            }
+            
+            selected.push(choice);
+            currentCandidates = currentCandidates.filter(c => c.instanceId !== choice.instanceId);
+        }
+        return selected;
+    }
+
+    // --- 헬퍼 함수들 ---
+
+    _getSkillData(instance) {
+        return skillInventoryManager.getSkillData(instance.skillId, instance.grade);
+    }
+
+    _isConventional(card, classId) {
+        const proficiencies = classProficiencies[classId] || [];
+        return card.tags.some(tag => proficiencies.includes(tag));
+    }
+}
+
+export const mercenaryCardSelector = new MercenaryCardSelector();


### PR DESCRIPTION
## Summary
- implement `MercenaryCardSelector` with MBTI weighted logic
- integrate new `ArenaManager` to generate enemy teams
- update Arena scene and DOM engine to place enemy units

## Testing
- `node tests/*_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688a1f7ad2588327a972fc4da9ffae79