### PR TITLE
Add MBTI positioning and integrate into arena

### DIFF
--- a/src/game/dom/ArenaDOMEngine.js
+++ b/src/game/dom/ArenaDOMEngine.js
@@ -1,7 +1,7 @@
 import { partyEngine } from '../utils/PartyEngine.js';
 import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 import { formationEngine } from '../utils/FormationEngine.js';
-import { arenaManager } from '../utils/ArenaManager.js'; // ArenaManager import
+import { arenaManager } from '../utils/ArenaManager.js';
 
 export class ArenaDOMEngine {
     constructor(scene, domEngine) {
@@ -129,24 +129,25 @@ export class ArenaDOMEngine {
         }
     }
 
-    // ArenaDOMEngine 클래스 내에 새로운 메소드 추가
+    // 저장된 위치를 사용하여 적 유닛을 배치합니다.
     placeEnemyUnits() {
         const enemyTeam = arenaManager.getEnemyTeam();
-        const cells = Array.from(this.grid.children).filter(c => !c.classList.contains('ally-area'));
 
         enemyTeam.forEach(unit => {
-            // 적 진형 내에서 무작위 빈 셀을 찾습니다.
-            const availableCells = cells.filter(c => !c.hasChildNodes());
-            if (availableCells.length === 0) return;
+            const savedIndex = formationEngine.getPosition(unit.uniqueId);
+            if (savedIndex === undefined) return; // 위치 정보가 없으면 건너뜀
 
-            const cell = availableCells[Math.floor(Math.random() * availableCells.length)];
-            if (!cell) return;
+            const cell = this.grid.querySelector(`.formation-cell[data-index='${savedIndex}']`);
+            if (!cell || cell.hasChildNodes()) return; // 셀이 없거나 이미 유닛이 있으면 건너뜀
+
+            // 아군 영역에 배치되지 않도록 방어 코드 추가
+            if (cell.classList.contains('ally-area')) return;
 
             const unitDiv = document.createElement('div');
-            unitDiv.className = 'formation-unit'; // 동일한 스타일 사용
+            unitDiv.className = 'formation-unit';
             unitDiv.dataset.unitId = unit.uniqueId;
             unitDiv.style.backgroundImage = `url(assets/images/unit/${unit.id}.png)`;
-            unitDiv.style.filter = 'grayscale(80%) brightness(0.8)'; // 적으로 보이도록 필터 적용
+            unitDiv.style.filter = 'grayscale(80%) brightness(0.8)';
 
             const nameLabel = document.createElement('div');
             nameLabel.className = 'formation-unit-name';

--- a/src/game/utils/ArenaManager.js
+++ b/src/game/utils/ArenaManager.js
@@ -3,6 +3,8 @@ import { mercenaryData } from '../data/mercenaries.js';
 import { skillInventoryManager } from './SkillInventoryManager.js';
 import { ownedSkillsManager } from './OwnedSkillsManager.js';
 import { mercenaryCardSelector } from './MercenaryCardSelector.js';
+import { formationEngine } from './FormationEngine.js';
+import { mbtiPositioningEngine } from './MBTIPositioningEngine.js';
 
 /**
  * 아레나 컨텐츠와 관련된 로직(적 생성, 보상 등)을 관리하는 엔진
@@ -14,33 +16,61 @@ class ArenaManager {
     }
 
     /**
-     * 12명의 랜덤한 적 용병 팀을 생성하고 MBTI에 따라 스킬을 장착시킵니다.
+     * 12명의 랜덤한 적 용병 팀을 생성하고, 스킬과 위치를 MBTI에 따라 결정합니다.
      */
     generateEnemyTeam() {
         this.enemyTeam = [];
         let availableCards = [...skillInventoryManager.getInventory()];
         const mercenaryTypes = Object.values(mercenaryData);
 
+        // --- 아레나 적 진영의 모든 빈 셀 목록을 미리 준비 ---
+        const ALLY_COLS = 8;
+        const ALLY_ROWS = 9;
+        let availableCells = [];
+        for (let r = 0; r < ALLY_ROWS; r++) {
+            for (let c = 0; c < ALLY_COLS; c++) {
+                // formationEngine의 grid가 로드되었다고 가정.
+                // BattleStageManager에서 그리드를 생성하므로, 이 시점에서는 셀 정보를 직접 생성.
+                availableCells.push({ col: c, row: r, isOccupied: false });
+            }
+        }
+
+        const placedAllies = [];
+
         for (let i = 0; i < 12; i++) {
+            if (availableCells.length === 0) break; // 배치할 공간이 없으면 중단
+
             // 1. 랜덤 클래스의 적 용병 생성
             const randomType = mercenaryTypes[Math.floor(Math.random() * mercenaryTypes.length)];
             const enemyMercenary = mercenaryEngine.hireMercenary(randomType, 'enemy');
 
-            // 2. MBTI에 따라 스킬 선택 (강화된 로직 사용)
+            // 2. MBTI에 따라 스킬 선택
             const { selectedCards, remainingCards } = mercenaryCardSelector.selectCardsForMercenary(enemyMercenary, availableCards);
-
-            // 3. 선택된 스킬을 용병에게 장착
             selectedCards.forEach((cardInstance, index) => {
                 ownedSkillsManager.equipSkill(enemyMercenary.uniqueId, index, cardInstance.instanceId);
             });
-            
-            console.log(`[ArenaManager] ${enemyMercenary.instanceName}(${enemyMercenary.mbti.E > 50 ? 'E' : 'I'}...)에게 스킬 ${selectedCards.length}개 장착 완료.`);
+            availableCards = remainingCards;
+
+            // 3. MBTI에 따라 위치 결정
+            const chosenCell = mbtiPositioningEngine.determinePosition(enemyMercenary, availableCells, placedAllies);
+
+            if (chosenCell) {
+                // 4. 결정된 위치 정보 저장
+                enemyMercenary.gridX = chosenCell.col;
+                enemyMercenary.gridY = chosenCell.row;
+                // formationEngine에 DOM이 아닌 논리적 위치를 저장합니다.
+                // ArenaDOMEngine은 이 정보를 사용하게 됩니다.
+                formationEngine.setPosition(enemyMercenary.uniqueId, (chosenCell.row * ALLY_COLS) + chosenCell.col);
+
+                placedAllies.push(enemyMercenary);
+                // 사용된 셀은 후보에서 제거
+                availableCells = availableCells.filter(c => c.col !== chosenCell.col || c.row !== chosenCell.row);
+            }
 
             this.enemyTeam.push(enemyMercenary);
-            availableCards = remainingCards; // 남은 카드 풀 업데이트
         }
-        
-        console.log('[ArenaManager] 아레나 적 팀 생성이 완료되었습니다.', this.enemyTeam);
+
+        console.log('[ArenaManager] 아레나 적 팀 생성 및 자동 배치가 완료되었습니다.');
         return this.enemyTeam;
     }
 

--- a/src/game/utils/MBTIPositioningEngine.js
+++ b/src/game/utils/MBTIPositioningEngine.js
@@ -1,0 +1,76 @@
+/**
+ * 용병의 MBTI 성향에 따라 전투 진형의 위치를 결정하는 엔진
+ */
+class MBTIPositioningEngine {
+    constructor() {
+        this.name = 'MBTIPositioningEngine';
+        // 아군 진영의 크기 (0~7열, 0~8행)
+        this.ALLY_COLS = 8;
+        this.ALLY_ROWS = 9;
+        this.ROW_CENTER = Math.floor(this.ALLY_ROWS / 2); // 중앙 행
+    }
+
+    /**
+     * 주어진 용병에게 가장 적합한 셀을 찾아서 반환합니다.
+     * @param {object} mercenary - 위치를 결정할 용병
+     * @param {Array<object>} availableCells - 배치 가능한 모든 빈 셀의 목록
+     * @param {Array<object>} placedAllies - 이미 배치된 다른 아군 용병 목록
+     * @returns {object|null} - 선택된 최적의 셀 또는 null
+     */
+    determinePosition(mercenary, availableCells, placedAllies) {
+        if (!availableCells || availableCells.length === 0) {
+            return null;
+        }
+
+        const mbti = mercenary.mbti;
+
+        // 1. 각 후보 셀에 대해 MBTI 기반 종합 점수 계산
+        const scoredCells = availableCells.map(cell => {
+            let totalScore = 1.0; // 기본 점수
+
+            // E vs I: 전방 선호 vs 후방 선호
+            const frontPreference = cell.col / (this.ALLY_COLS - 1); // 0 (후방) ~ 1 (전방)
+            totalScore *= (frontPreference * mbti.E) + ((1 - frontPreference) * mbti.I);
+
+            // S vs N: 중앙 선호 vs 측면 선호
+            const centerPreference = 1 - (Math.abs(cell.row - this.ROW_CENTER) / this.ROW_CENTER); // 0 (측면) ~ 1 (중앙)
+            totalScore *= (centerPreference * mbti.S) + ((1 - centerPreference) * mbti.N);
+
+            // T vs F: 독립 선호 vs 밀집 선호
+            if (placedAllies.length > 0) {
+                const minDistance = Math.min(...placedAllies.map(ally =>
+                    Math.abs(cell.col - ally.gridX) + Math.abs(cell.row - ally.gridY)
+                ));
+                const isolationPreference = Math.min(minDistance / 5, 1); // 거리가 5 이상이면 최대 점수
+                const cohesionPreference = 1 - isolationPreference;
+                totalScore *= (isolationPreference * mbti.T) + (cohesionPreference * mbti.F);
+            }
+
+            return { cell, score: totalScore };
+        });
+
+        // 2. J vs P: 결정적 선택 vs 유연한(무작위) 선택
+        let finalChoice;
+        if (Math.random() * 100 < mbti.P && scoredCells.length > 1) {
+            // 가중치 기반 랜덤 선택
+            const totalWeight = scoredCells.reduce((sum, item) => sum + item.score, 0);
+            let random = Math.random() * totalWeight;
+            for (const item of scoredCells) {
+                if (random < item.score) {
+                    finalChoice = item.cell;
+                    break;
+                }
+                random -= item.score;
+            }
+            if (!finalChoice) finalChoice = scoredCells[scoredCells.length - 1].cell; // Fallback
+        } else {
+            // 최고점수 선택 (J 성향)
+            scoredCells.sort((a, b) => b.score - a.score);
+            finalChoice = scoredCells[0].cell;
+        }
+
+        return finalChoice;
+    }
+}
+
+export const mbtiPositioningEngine = new MBTIPositioningEngine();


### PR DESCRIPTION
## Summary
- create `MBTIPositioningEngine` to decide unit placement based on MBTI
- auto-place enemies in `ArenaManager` via the new engine
- read stored positions when placing enemies in `ArenaDOMEngine`

## Testing
- `node tests/movement_stat_test.js`
- `for f in tests/*_skill_integration_test.js; do node $f; done`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688a2275f2408327b1adebca4fbc91da