### PR TITLE
Add arena battle scene and unit detail viewer

### DIFF
--- a/public/unit-detail-viewer.html
+++ b/public/unit-detail-viewer.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>용병 상세 정보</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400..900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background-color: #1a1817;
+        }
+    </style>
+</head>
+<body>
+    <div id="detail-container"></div>
+
+    <script type="module" src="unit-detail-viewer.js"></script>
+</body>
+</html>

--- a/public/unit-detail-viewer.js
+++ b/public/unit-detail-viewer.js
@@ -1,0 +1,34 @@
+// 필요한 모든 데이터와 유틸리티를 직접 import합니다.
+// 이 스크립트는 게임의 메인 번들과 독립적으로 실행됩니다.
+import { UnitDetailDOM } from '../src/game/dom/UnitDetailDOM.js';
+import { statEngine } from '../src/game/utils/StatEngine.js';
+import { ownedSkillsManager } from '../src/game/utils/OwnedSkillsManager.js';
+import { skillInventoryManager } from '../src/game/utils/SkillInventoryManager.js';
+import { skillModifierEngine } from '../src/game/utils/SkillModifierEngine.js';
+import { classGrades } from '../src/game/data/classGrades.js';
+import { classProficiencies } from '../src/game/data/classProficiencies.js';
+import { classSpecializations } from '../src/game/data/classSpecializations.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const unitDataString = localStorage.getItem('selectedUnitForDetail');
+    if (unitDataString) {
+        const unitData = JSON.parse(unitDataString);
+        const detailElement = UnitDetailDOM.create(unitData);
+        const container = document.getElementById('detail-container');
+        container.appendChild(detailElement);
+        requestAnimationFrame(() => {
+            detailElement.classList.add('visible');
+        });
+        detailElement.onclick = (e) => {
+            if (e.target === detailElement) {
+                window.close();
+            }
+        };
+        const closeButton = detailElement.querySelector('#unit-detail-close');
+        if(closeButton) {
+            closeButton.onclick = () => window.close();
+        }
+    } else {
+        document.body.innerHTML = '<h1>유닛 정보를 불러올 수 없습니다.</h1>';
+    }
+});

--- a/src/game/scenes/ArenaBattleScene.js
+++ b/src/game/scenes/ArenaBattleScene.js
@@ -1,0 +1,45 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { BattleStageManager } from '../utils/BattleStageManager.js';
+import { CameraControlEngine } from '../utils/CameraControlEngine.js';
+import { partyEngine } from '../utils/PartyEngine.js';
+import { BattleSimulatorEngine } from '../utils/BattleSimulatorEngine.js';
+import { arenaManager } from '../utils/ArenaManager.js';
+
+export class ArenaBattleScene extends Scene {
+    constructor() {
+        super('ArenaBattleScene');
+        this.stageManager = null;
+        this.cameraControl = null;
+        this.battleSimulator = null;
+    }
+
+    create() {
+        // 다른 DOM 컨테이너 숨기기
+        ['dungeon-container', 'territory-container', 'formation-container'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.style.display = 'none';
+        });
+
+        const stageConfig = {
+            background: 'battle-stage-arena',
+        };
+
+        this.stageManager = new BattleStageManager(this);
+        this.stageManager.createStage(stageConfig.background);
+        this.cameraControl = new CameraControlEngine(this);
+        this.cameras.main.setZoom(2);
+
+        this.battleSimulator = new BattleSimulatorEngine(this);
+
+        const partyUnits = partyEngine.getDeployedMercenaries();
+        const enemyUnits = arenaManager.getEnemyTeam();
+
+        this.battleSimulator.start(partyUnits, enemyUnits);
+
+        this.events.on('shutdown', () => {
+            if (this.stageManager) this.stageManager.destroy();
+            if (this.cameraControl) this.cameraControl.destroy();
+            if (this.battleSimulator) this.battleSimulator.shutdown();
+        });
+    }
+}

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -16,6 +16,7 @@ import { SkillManagementScene } from './SkillManagementScene.js';
 // ✨ SummonManagementScene을 import 합니다.
 import { SummonManagementScene } from './SummonManagementScene.js';
 import { ArenaScene } from './ArenaScene.js';
+import { ArenaBattleScene } from './ArenaBattleScene.js';
 
 export class Boot extends Scene
 {
@@ -48,6 +49,7 @@ export class Boot extends Scene
         // ✨ 새로 만든 씬을 추가합니다.
         this.scene.add('SummonManagementScene', SummonManagementScene);
         this.scene.add('ArenaScene', ArenaScene);
+        this.scene.add('ArenaBattleScene', ArenaBattleScene);
 
         this.scene.start('Preloader');
     }


### PR DESCRIPTION
## Summary
- show enemy info on click and add start battle button in Arena DOM
- add independent unit-detail viewer page
- implement ArenaBattleScene and register it in Boot
- ensure formation grid uses helper to create unit elements

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`
- `for f in tests/*.js; do node $f; done | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_688a23e4ac088327a2d515981751f363