### PR TITLE
Implement AI memory and scoring updates

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -249,8 +249,8 @@ function createMeleeAI(engines = {}) {
     ]);
 
     const attackSequence = new SequenceNode([
-        new FindBestSkillByScoreNode(engines),
         new FindTargetBySkillTypeNode(engines),
+        new FindBestSkillByScoreNode(engines),
         executeSkillBranch
     ]);
 

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -173,8 +173,8 @@ function createRangedAI(engines = {}) {
     ]);
 
     const attackSequence = new SequenceNode([
-        new FindBestSkillByScoreNode(engines),
         new FindTargetBySkillTypeNode(engines),
+        new FindBestSkillByScoreNode(engines),
         executeSkillBranch
     ]);
 

--- a/src/game/debug/DebugAIMemoryManager.js
+++ b/src/game/debug/DebugAIMemoryManager.js
@@ -1,0 +1,62 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * AI의 기억(Memory) 및 학습 과정을 추적하고 로그로 남기는 디버그 매니저
+ */
+class DebugAIMemoryManager {
+    constructor() {
+        this.name = 'DebugAIMemory';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * AI가 전투 결과를 바탕으로 기억(가중치)을 갱신할 때 로그를 남깁니다.
+     * @param {number} attackerId - 공격자 ID
+     * @param {number} targetId - 대상 ID
+     * @param {string} attackType - 공격 타입
+     * @param {number} oldValue - 이전 가중치
+     * @param {number} newValue - 새 가중치
+     */
+    logMemoryUpdate(attackerId, targetId, attackType, oldValue, newValue) {
+        const change = newValue - oldValue;
+        const color = change > 0 ? '#22c55e' : '#ef4444';
+        console.groupCollapsed(
+            `%c[${this.name}]`, `color: #8b5cf6; font-weight: bold;`,
+            `🧠 유닛 ${attackerId}의 기억 업데이트 (대상: ${targetId})`
+        );
+        debugLogEngine.log(this.name, `공격 타입: ${attackType}`);
+        debugLogEngine.log(this.name, `가중치 변경: ${oldValue.toFixed(2)} -> %c${newValue.toFixed(2)} (${change > 0 ? '+' : ''}${change.toFixed(2)})`, `color: ${color}; font-weight: bold;`);
+        console.groupEnd();
+    }
+
+    /**
+     * AI가 스킬을 선택하기 위해 기억을 조회할 때 로그를 남깁니다.
+     * @param {number} attackerId
+     * @param {object} memory
+     */
+    logMemoryRead(attackerId, memory) {
+        if (!memory || Object.keys(memory).length === 0) return;
+        console.groupCollapsed(
+            `%c[${this.name}]`, `color: #8b5cf6; font-weight: bold;`,
+            `🤔 유닛 ${attackerId}의 기억 조회`
+        );
+        console.table(memory);
+        console.groupEnd();
+    }
+
+    /**
+     * 학습된 가중치가 스킬 점수에 어떻게 영향을 미치는지 로그로 남깁니다.
+     * @param {string} skillName
+     * @param {number} baseScore
+     * @param {number} weight
+     * @param {number} finalScore
+     */
+    logScoreModification(skillName, baseScore, weight, finalScore) {
+        debugLogEngine.log(
+            'SkillScoreEngine',
+            `[기억 활용] 스킬 [${skillName}] 점수 보정: 기본(${baseScore.toFixed(2)}) * 가중치(${weight.toFixed(2)}) = 최종 ${finalScore.toFixed(2)}`
+        );
+    }
+}
+
+export const debugAIMemoryManager = new DebugAIMemoryManager();

--- a/src/game/utils/AIMemoryEngine.js
+++ b/src/game/utils/AIMemoryEngine.js
@@ -1,0 +1,104 @@
+import { debugAIMemoryManager } from '../debug/DebugAIMemoryManager.js';
+
+/**
+ * IndexedDB를 사용하여 각 AI 유닛의 전투 경험을 저장하고 관리하는 '기억' 엔진
+ */
+class AIMemoryEngine {
+    constructor() {
+        this.db = null;
+        this.dbName = 'AIMemoryDB';
+        this.storeName = 'combatMemory';
+        this.initDB();
+    }
+
+    /**
+     * IndexedDB를 초기화하고 객체 저장소를 생성합니다.
+     */
+    initDB() {
+        const request = indexedDB.open(this.dbName, 1);
+
+        request.onupgradeneeded = (event) => {
+            this.db = event.target.result;
+            if (!this.db.objectStoreNames.contains(this.storeName)) {
+                this.db.createObjectStore(this.storeName, { keyPath: 'id' });
+            }
+        };
+
+        request.onsuccess = (event) => {
+            this.db = event.target.result;
+            console.log('[AIMemoryEngine] IndexedDB가 성공적으로 초기화되었습니다.');
+        };
+
+        request.onerror = (event) => {
+            console.error('[AIMemoryEngine] IndexedDB 초기화 오류:', event.target.errorCode);
+        };
+    }
+
+    /**
+     * 특정 공격자와 대상에 대한 기억(가중치)을 가져옵니다.
+     * @param {number} attackerId - 공격자 유닛의 고유 ID
+     * @returns {Promise<object>} - 대상 ID를 키로 갖는 가중치 객체
+     */
+    getMemory(attackerId) {
+        return new Promise((resolve, reject) => {
+            if (!this.db) {
+                return resolve(null);
+            }
+            const transaction = this.db.transaction([this.storeName], 'readonly');
+            const store = transaction.objectStore(this.storeName);
+            const request = store.get(attackerId);
+
+            request.onsuccess = (event) => {
+                debugAIMemoryManager.logMemoryRead(attackerId, event.target.result?.memory || null);
+                resolve(event.target.result?.memory || {});
+            };
+
+            request.onerror = (event) => {
+                console.error('[AIMemoryEngine] 메모리 읽기 오류:', event.target.error);
+                reject(event.target.error);
+            };
+        });
+    }
+
+    /**
+     * 전투 결과를 바탕으로 AI의 기억(가중치)을 갱신합니다.
+     * @param {number} attackerId - 공격자 ID
+     * @param {number} targetId - 대상 ID
+     * @param {string} attackType - 공격 타입 ('melee', 'ranged', 'magic')
+     * @param {string} hitType - 전투 결과 ('치명타', '약점', '완화', '막기')
+     */
+    async updateMemory(attackerId, targetId, attackType, hitType) {
+        if (!this.db || !attackType || !hitType) return;
+
+        const memory = await this.getMemory(attackerId);
+        const targetMemoryKey = `target_${targetId}`;
+        const weightKey = `${attackType}_weight`;
+
+        if (!memory[targetMemoryKey]) {
+            memory[targetMemoryKey] = {};
+        }
+
+        if (memory[targetMemoryKey][weightKey] === undefined) {
+            memory[targetMemoryKey][weightKey] = 1.0;
+        }
+
+        let adjustment = 0;
+        if (hitType === '치명타' || hitType === '약점') {
+            adjustment = 0.1;
+        } else if (hitType === '완화' || hitType === '막기') {
+            adjustment = -0.15;
+        }
+
+        if (adjustment !== 0) {
+            const oldValue = memory[targetMemoryKey][weightKey];
+            memory[targetMemoryKey][weightKey] = Math.max(0.1, Math.min(2.0, oldValue + adjustment));
+            debugAIMemoryManager.logMemoryUpdate(attackerId, targetId, attackType, oldValue, memory[targetMemoryKey][weightKey]);
+        }
+
+        const transaction = this.db.transaction([this.storeName], 'readwrite');
+        const store = transaction.objectStore(this.storeName);
+        store.put({ id: attackerId, memory: memory });
+    }
+}
+
+export const aiMemoryEngine = new AIMemoryEngine();

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -21,6 +21,8 @@ import { fixedDamageManager } from './FixedDamageManager.js';
 // ✨ [신규] 스택 매니저와 확정 데미지 타입 상수를 가져옵니다.
 import { stackManager } from './StackManager.js';
 import { FIXED_DAMAGE_TYPES } from './FixedDamageManager.js';
+// ✨ AIMemoryEngine 추가
+import { aiMemoryEngine } from './AIMemoryEngine.js';
 
 /**
  * 실제 전투 데미지 계산을 담당하는 엔진
@@ -168,6 +170,14 @@ class CombatCalculationEngine {
                     return e.modifiers.stat === 'damageReduction' || e.modifiers.stat === 'damageIncrease';
                 });
             debugStatusEffectManager.logDamageModification(defender, initialDamage, finalDamage, effects);
+        }
+
+        // ✨ 전투 결과를 AI 기억에 저장
+        if (hitType && attacker.team !== defender.team) {
+            const attackType = this.getAttackTypeFromSkill(finalSkill);
+            if (attackType) {
+                aiMemoryEngine.updateMemory(attacker.uniqueId, defender.uniqueId, attackType, hitType);
+            }
         }
 
         // 디버그 로그에 finalDefense 사용하도록 수정


### PR DESCRIPTION
## Summary
- add `AIMemoryEngine` with debug logging hooks
- track skill memory via new `DebugAIMemoryManager`
- store combat results in memory from `CombatCalculationEngine`
- apply memory weights in `SkillScoreEngine`
- update `FindBestSkillByScoreNode` for async scoring
- adjust melee and ranged behavior sequences to choose target before skill

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688a3d08fac4832798ef74cf7ac53895