### PR TITLE
Add AIMemory system

### DIFF
--- a/src/ai/nodes/FindBestSkillByScoreNode.js
+++ b/src/ai/nodes/FindBestSkillByScoreNode.js
@@ -22,6 +22,7 @@ class FindBestSkillByScoreNode extends Node {
         const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
         const allies = blackboard.get('allyUnits') || [];
         const enemies = blackboard.get('enemyUnits') || [];
+        const target = blackboard.get('skillTarget') || blackboard.get('currentTargetUnit');
 
         let bestSkill = null;
         let maxScore = -1;
@@ -34,7 +35,7 @@ class FindBestSkillByScoreNode extends Node {
 
             if (this.skillEngine.canUseSkill(unit, skillData)) {
                 // ✨ 스코어 계산 시 unit, allies, enemies 정보를 함께 전달합니다.
-                const currentScore = this.skillScoreEngine.calculateScore(unit, skillData, allies, enemies);
+                const currentScore = await this.skillScoreEngine.calculateScore(unit, skillData, target, allies, enemies);
                 if (currentScore > maxScore) {
                     maxScore = currentScore;
                     bestSkill = { skillData, instanceId };

--- a/src/game/debug/DebugAIMemoryManager.js
+++ b/src/game/debug/DebugAIMemoryManager.js
@@ -1,0 +1,42 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * AI의 기억(Memory) 및 학습 과정을 추적하고 로그로 남기는 디버그 매니저
+ */
+class DebugAIMemoryManager {
+    constructor() {
+        this.name = 'DebugAIMemory';
+        debugLogEngine.register(this);
+    }
+
+    logMemoryUpdate(attackerId, targetId, attackType, oldValue, newValue) {
+        const change = newValue - oldValue;
+        const color = change > 0 ? '#22c55e' : '#ef4444';
+        console.groupCollapsed(
+            `%c[${this.name}]`, `color: #8b5cf6; font-weight: bold;`,
+            `🧠 유닛 ${attackerId}의 기억 업데이트 (대상: ${targetId})`
+        );
+        debugLogEngine.log(this.name, `공격 타입: ${attackType}`);
+        debugLogEngine.log(this.name, `가중치 변경: ${oldValue.toFixed(2)} -> %c${newValue.toFixed(2)} (${change > 0 ? '+' : ''}${change.toFixed(2)})`, `color: ${color}; font-weight: bold;`);
+        console.groupEnd();
+    }
+
+    logMemoryRead(attackerId, memory) {
+        if (!memory || Object.keys(memory).length === 0) return;
+        console.groupCollapsed(
+            `%c[${this.name}]`, `color: #8b5cf6; font-weight: bold;`,
+            `🤔 유닛 ${attackerId}의 기억 조회`
+        );
+        console.table(memory);
+        console.groupEnd();
+    }
+    
+    logScoreModification(skillName, baseScore, weight, finalScore) {
+        debugLogEngine.log(
+            'SkillScoreEngine',
+            `[기억 활용] 스킬 [${skillName}] 점수 보정: 기본(${baseScore.toFixed(2)}) * 가중치(${weight.toFixed(2)}) = 최종 ${finalScore.toFixed(2)}`
+        );
+    }
+}
+
+export const debugAIMemoryManager = new DebugAIMemoryManager();

--- a/src/game/utils/AIMemoryEngine.js
+++ b/src/game/utils/AIMemoryEngine.js
@@ -1,0 +1,99 @@
+import { debugAIMemoryManager } from '../debug/DebugAIMemoryManager.js';
+
+/**
+ * IndexedDB를 사용하여 각 AI 유닛의 전투 경험을 저장하고 관리하는 '기억' 엔진
+ */
+class AIMemoryEngine {
+    constructor() {
+        this.db = null;
+        this.dbName = 'AIMemoryDB';
+        this.storeName = 'combatMemory';
+        this.initDB();
+    }
+
+    /**
+     * IndexedDB를 초기화하고 객체 저장소를 생성합니다.
+     */
+    initDB() {
+        const request = indexedDB.open(this.dbName, 1);
+
+        request.onupgradeneeded = (event) => {
+            this.db = event.target.result;
+            if (!this.db.objectStoreNames.contains(this.storeName)) {
+                this.db.createObjectStore(this.storeName, { keyPath: 'id' });
+            }
+        };
+
+        request.onsuccess = (event) => {
+            this.db = event.target.result;
+            console.log('[AIMemoryEngine] IndexedDB가 성공적으로 초기화되었습니다.');
+        };
+
+        request.onerror = (event) => {
+            console.error('[AIMemoryEngine] IndexedDB 초기화 오류:', event.target.errorCode);
+        };
+    }
+
+    /**
+     * 특정 공격자와 대상에 대한 기억(가중치)을 가져옵니다.
+     * @param {number} attackerId - 공격자 유닛의 고유 ID
+     * @returns {Promise<object>} - 대상 ID를 키로 갖는 가중치 객체
+     */
+    getMemory(attackerId) {
+        return new Promise((resolve, reject) => {
+            if (!this.db) {
+                return resolve(null); // DB가 준비되지 않았으면 기본값 반환
+            }
+            const transaction = this.db.transaction([this.storeName], 'readonly');
+            const store = transaction.objectStore(this.storeName);
+            const request = store.get(attackerId);
+
+            request.onsuccess = (event) => {
+                debugAIMemoryManager.logMemoryRead(attackerId, event.target.result?.memory || null);
+                resolve(event.target.result?.memory || {});
+            };
+
+            request.onerror = (event) => {
+                console.error('[AIMemoryEngine] 메모리 읽기 오류:', event.target.error);
+                reject(event.target.error);
+            };
+        });
+    }
+
+    /**
+     * 전투 결과를 바탕으로 AI의 기억(가중치)을 갱신합니다.
+     * @param {number} attackerId - 공격자 ID
+     * @param {number} targetId - 대상 ID
+     * @param {string} attackType - 공격 타입 ('melee', 'ranged', 'magic')
+     * @param {string} hitType - 전투 결과 ('치명타', '약점', '완화', '막기')
+     */
+    async updateMemory(attackerId, targetId, attackType, hitType) {
+        if (!this.db || !attackType || !hitType) return;
+
+        const memory = await this.getMemory(attackerId) || {};
+        const targetMemoryKey = `target_${targetId}`;
+        const weightKey = `${attackType}_weight`;
+
+        if (!memory[targetMemoryKey]) memory[targetMemoryKey] = {};
+        if (memory[targetMemoryKey][weightKey] === undefined) memory[targetMemoryKey][weightKey] = 1.0;
+
+        let adjustment = 0;
+        if (hitType === '치명타' || hitType === '약점') {
+            adjustment = 0.1; // 긍정적 경험: 가중치 10% 증가
+        } else if (hitType === '완화' || hitType === '막기') {
+            adjustment = -0.15; // 부정적 경험: 가중치 15% 감소
+        }
+
+        if (adjustment !== 0) {
+            const oldValue = memory[targetMemoryKey][weightKey];
+            memory[targetMemoryKey][weightKey] = Math.max(0.1, Math.min(2.0, oldValue + adjustment));
+            debugAIMemoryManager.logMemoryUpdate(attackerId, targetId, attackType, oldValue, memory[targetMemoryKey][weightKey]);
+        }
+
+        const transaction = this.db.transaction([this.storeName], 'readwrite');
+        const store = transaction.objectStore(this.storeName);
+        store.put({ id: attackerId, memory: memory });
+    }
+}
+
+export const aiMemoryEngine = new AIMemoryEngine();

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -21,6 +21,7 @@ import { fixedDamageManager } from './FixedDamageManager.js';
 // ✨ [신규] 스택 매니저와 확정 데미지 타입 상수를 가져옵니다.
 import { stackManager } from './StackManager.js';
 import { FIXED_DAMAGE_TYPES } from './FixedDamageManager.js';
+import { aiMemoryEngine } from './AIMemoryEngine.js';
 
 /**
  * 실제 전투 데미지 계산을 담당하는 엔진
@@ -168,6 +169,14 @@ class CombatCalculationEngine {
                     return e.modifiers.stat === 'damageReduction' || e.modifiers.stat === 'damageIncrease';
                 });
             debugStatusEffectManager.logDamageModification(defender, initialDamage, finalDamage, effects);
+        }
+
+        // 전투 결과를 AI 기억에 저장합니다.
+        if (hitType && attacker.team !== defender.team) {
+            const attackType = this.getAttackTypeFromSkill(skill);
+            if (attackType) {
+                aiMemoryEngine.updateMemory(attacker.uniqueId, defender.uniqueId, attackType, hitType);
+            }
         }
 
         // 디버그 로그에 finalDefense 사용하도록 수정


### PR DESCRIPTION
## Summary
- introduce `AIMemoryEngine` for persistent combat memories
- log learning activity with `DebugAIMemoryManager`
- update combat calculations to record battle results in memory
- adjust skill scoring to apply memory weights
- adapt `FindBestSkillByScoreNode` to use async scoring

## Testing
- `for f in tests/*.js; do echo "running $f"; node $f || exit 1; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688a3e5206b48327a24b1ea796791581