### PR TITLE
Fix skill scoring target retrieval

### DIFF
--- a/src/ai/nodes/FindBestSkillByScoreNode.js
+++ b/src/ai/nodes/FindBestSkillByScoreNode.js
@@ -18,34 +18,27 @@ class FindBestSkillByScoreNode extends Node {
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
 
-        const target = blackboard.get('skillTarget');
         const equippedSkillInstances = ownedSkillsManager.getEquippedSkills(unit.uniqueId);
+        const target = blackboard.get('skillTarget') || blackboard.get('currentTargetUnit');
         const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
         const allies = blackboard.get('allyUnits') || [];
         const enemies = blackboard.get('enemyUnits') || [];
 
         let bestSkill = null;
-        let maxScore = -Infinity;
+        let maxScore = -1;
 
-        const availableSkills = [];
         for (const instanceId of equippedSkillInstances) {
             if (!instanceId || usedSkills.has(instanceId)) continue;
+
             const instData = skillInventoryManager.getInstanceData(instanceId);
             const skillData = skillInventoryManager.getSkillData(instData.skillId, instData.grade);
+
             if (this.skillEngine.canUseSkill(unit, skillData)) {
-                availableSkills.push({ skillData, instanceId });
-            }
-        }
-
-        const scores = await Promise.all(
-            availableSkills.map(s => this.skillScoreEngine.calculateScore(unit, s.skillData, target, allies, enemies))
-        );
-
-        for (let i = 0; i < availableSkills.length; i++) {
-            const currentScore = scores[i];
-            if (currentScore > maxScore) {
-                maxScore = currentScore;
-                bestSkill = availableSkills[i];
+                const currentScore = await this.skillScoreEngine.calculateScore(unit, skillData, target, allies, enemies);
+                if (currentScore > maxScore) {
+                    maxScore = currentScore;
+                    bestSkill = { skillData, instanceId };
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- use fallback target in FindBestSkillByScoreNode
- calculate skill scores sequentially with updated parameters

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688a407adab48327b71725e2e9caca4c