### PR TITLE
Remove fallback success nodes from AI behaviors

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -64,8 +64,7 @@ function createMeleeAI(engines = {}) {
                 new CanUseSkillBySlotNode(0),
                 new FindTargetBySkillTypeNode(engines),
                 new UseSkillNode(engines)
-            ]),
-            new SuccessNode()
+            ])
         ]),
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);
@@ -95,8 +94,7 @@ function createMeleeAI(engines = {}) {
                 new HasNotMovedNode(),
                 new FleeNode(engines),
                 new MoveToTargetNode(engines)
-            ]),
-            new SuccessNode()
+            ])
         ]),
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);
@@ -123,8 +121,7 @@ function createMeleeAI(engines = {}) {
                 new CanUseSkillBySlotNode(3),
                 new FindTargetBySkillTypeNode(engines),
                 executeSkillBranch
-            ]),
-            new SuccessNode()
+            ])
         ]),
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);
@@ -144,8 +141,7 @@ function createMeleeAI(engines = {}) {
                 new HasNotMovedNode(),
                 new FindPathToAllyNode(engines),
                 new MoveToTargetNode(engines)
-            ]),
-            new SuccessNode()
+            ])
         ]),
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);
@@ -167,8 +163,7 @@ function createMeleeAI(engines = {}) {
                 new HasNotMovedNode(),
                 new FleeNode(engines),
                 new MoveToTargetNode(engines)
-            ]),
-            new SuccessNode()
+            ])
         ])
     ]);
 
@@ -209,8 +204,7 @@ function createMeleeAI(engines = {}) {
                 new MBTIActionNode('N', engines),
                 { async evaluate() { debugMBTIManager.logAction('원래 목표 유지 (N)'); return NodeState.SUCCESS; } },
                 { async evaluate() { return NodeState.FAILURE; } }
-            ]),
-            new SuccessNode()
+            ])
         ])
     ]);
 
@@ -243,8 +237,7 @@ function createMeleeAI(engines = {}) {
                 }},
                 new CanUseSkillBySlotNode(3),
                 executeSkillBranch
-            ]),
-            new SuccessNode()
+            ])
         ])
     ]);
 

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -63,8 +63,7 @@ function createRangedAI(engines = {}) {
                 new CanUseSkillBySlotNode(3),
                 new FindTargetBySkillTypeNode(engines),
                 executeSkillBranch
-            ]),
-            new SuccessNode()
+            ])
         ]),
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);
@@ -91,8 +90,7 @@ function createRangedAI(engines = {}) {
                 new HasNotMovedNode(),
                 new FindSafeRepositionNode(engines),
                 new MoveToTargetNode(engines)
-            ]),
-            new SuccessNode()
+            ])
         ]),
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);
@@ -119,8 +117,7 @@ function createRangedAI(engines = {}) {
                 new CanUseSkillBySlotNode(3),
                 new FindTargetBySkillTypeNode(engines),
                 executeSkillBranch
-            ]),
-            new SuccessNode()
+            ])
         ]),
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);
@@ -140,8 +137,7 @@ function createRangedAI(engines = {}) {
                 new HasNotMovedNode(),
                 new FindPathToAllyNode(engines),
                 new MoveToTargetNode(engines)
-            ]),
-            new SuccessNode()
+            ])
         ]),
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);
@@ -167,8 +163,7 @@ function createRangedAI(engines = {}) {
                 { async evaluate() { debugMBTIManager.logAction('유리한 위치로 이동 (J)'); return NodeState.SUCCESS; } },
                 new FindSafeRepositionNode(engines),
                 new MoveToTargetNode(engines)
-            ]),
-            new SuccessNode()
+            ])
         ])
     ]);
 
@@ -184,8 +179,7 @@ function createRangedAI(engines = {}) {
         new FindKitingPositionNode(engines),
         new MoveToTargetNode(engines),
         new SelectorNode([
-            attackSequence,
-            new SuccessNode()
+            attackSequence
         ])
     ]);
 

--- a/src/ai/behaviors/createFlyingmanAI.js
+++ b/src/ai/behaviors/createFlyingmanAI.js
@@ -52,7 +52,7 @@ function createFlyingmanAI(engines = {}) {
             new MoveToTargetNode(engines)
         ]),
 
-        new SuccessNode(),
+        // new SuccessNode(),
     ]);
 
     return new BehaviorTree(rootNode);

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -58,8 +58,7 @@ function createHealerAI(engines = {}) {
                 new CanUseSkillBySlotNode(0),
                 { async evaluate(unit, blackboard) { blackboard.set('skillTarget', unit); return NodeState.SUCCESS; } },
                 new UseSkillNode(engines)
-            ]),
-            new SuccessNode()
+            ])
         ]),
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);
@@ -85,8 +84,7 @@ function createHealerAI(engines = {}) {
                 new HasNotMovedNode(),
                 new FindSafeRepositionNode(engines),
                 new MoveToTargetNode(engines)
-            ]),
-            new SuccessNode()
+            ])
         ]),
         { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
     ]);


### PR DESCRIPTION
## Summary
- clean up MeleeAI branches by removing trailing `SuccessNode`
- trim extraneous success nodes in RangedAI
- tidy healer AI behavior selectors
- comment out unused success node in Flyingman AI

## Testing
- `for f in tests/*.js; do echo "Running $f"; node $f; done`
- `python3 -m http.server 8000 &> /tmp/server.log & echo $!`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688a4a3ece9883278c06891dbe45cf5b