### PR TITLE
Update ranged AI behavior and pathfinding

### DIFF
--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -3,201 +3,88 @@ import SelectorNode from '../nodes/SelectorNode.js';
 import SequenceNode from '../nodes/SequenceNode.js';
 import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
 import SuccessNode from '../nodes/SuccessNode.js';
-import { NodeState } from '../nodes/Node.js';
 
-import CanUseSkillBySlotNode from '../nodes/CanUseSkillBySlotNode.js';
 import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
 import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
 import UseSkillNode from '../nodes/UseSkillNode.js';
 import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
 import IsTargetTooCloseNode from '../nodes/IsTargetTooCloseNode.js';
-import FindMeleeStrategicTargetNode from '../nodes/FindMeleeStrategicTargetNode.js';
+import FindPreferredTargetNode from '../nodes/FindPreferredTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
-import MBTIActionNode from '../nodes/MBTIActionNode.js';
 import IsHealthBelowThresholdNode from '../nodes/IsHealthBelowThresholdNode.js';
 import FleeNode from '../nodes/FleeNode.js';
-import FindNearestAllyInDangerNode from '../nodes/FindNearestAllyInDangerNode.js';
-import FindPathToAllyNode from '../nodes/FindPathToAllyNode.js';
-import JustRecoveredFromStunNode from '../nodes/JustRecoveredFromStunNode.js';
-import SetTargetToStunnerNode from '../nodes/SetTargetToStunnerNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
-import FindEnemyMedicNode from '../nodes/FindEnemyMedicNode.js';
-import { debugMBTIManager } from '../../game/debug/DebugMBTIManager.js';
-import IsTokenBelowThresholdNode from '../nodes/IsTokenBelowThresholdNode.js';
 import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 
 function createRangedAI(engines = {}) {
-    const executeSkillBranch = new SelectorNode([
-        new SequenceNode([
-            new IsSkillInRangeNode(engines),
-            new UseSkillNode(engines)
-        ]),
-        new SequenceNode([
-            new HasNotMovedNode(),
-            new FindKitingPositionNode(engines),
-            new MoveToTargetNode(engines),
-            new IsSkillInRangeNode(engines),
-            new UseSkillNode(engines)
-        ])
+    // 스킬 하나를 실행하는 공통 로직 (이동 불포함)
+    const useSkillBranch = new SequenceNode([
+        new IsSkillInRangeNode(engines),
+        new UseSkillNode(engines)
     ]);
 
+    // 이동 후 스킬을 사용하는 공통 로직
+    const moveAndUseSkillBranch = new SequenceNode([
+        new HasNotMovedNode(),
+        new FindPathToSkillRangeNode(engines),
+        new MoveToTargetNode(engines),
+        new IsSkillInRangeNode(engines),
+        new UseSkillNode(engines)
+    ]);
+    
+    // 생존 본능 (체력이 낮을 때)
     const survivalBehavior = new SequenceNode([
         new IsHealthBelowThresholdNode(0.35),
-        {
-            async evaluate(unit) {
-                debugMBTIManager.logDecisionStart('생존 본능 발동', unit);
-                return NodeState.SUCCESS;
-            }
-        },
-        new SelectorNode([
-            new SequenceNode([
-                new MBTIActionNode('I', engines),
-                { async evaluate() { debugMBTIManager.logAction('후퇴 선택'); return NodeState.SUCCESS; } },
-                new FleeNode(engines),
-                new MoveToTargetNode(engines)
-            ]),
-            new SequenceNode([
-                new MBTIActionNode('E', engines),
-                { async evaluate() { debugMBTIManager.logAction('최후의 발악 선택'); return NodeState.SUCCESS; } },
-                new CanUseSkillBySlotNode(3),
-                new FindTargetBySkillTypeNode(engines),
-                executeSkillBranch
-            ])
-        ]),
-        { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
+        new FleeNode(engines),
+        new MoveToTargetNode(engines)
     ]);
 
-    const postStunRecoveryBehavior = new SequenceNode([
-        new JustRecoveredFromStunNode(),
-        {
-            async evaluate(unit) {
-                debugMBTIManager.logDecisionStart('기절 회복 후 반응', unit);
-                return NodeState.SUCCESS;
-            }
-        },
-        new SelectorNode([
-            new SequenceNode([
-                new MBTIActionNode('P', engines),
-                { async evaluate() { debugMBTIManager.logAction('즉각 반격 선택 (P)'); return NodeState.SUCCESS; } },
-                new CanUseSkillBySlotNode(3),
-                new FindTargetBySkillTypeNode(engines),
-                executeSkillBranch
-            ]),
-            new SequenceNode([
-                new MBTIActionNode('J', engines),
-                { async evaluate() { debugMBTIManager.logAction('위치 정비 선택 (J)'); return NodeState.SUCCESS; } },
-                new HasNotMovedNode(),
-                new FindSafeRepositionNode(engines),
-                new MoveToTargetNode(engines)
-            ])
-        ]),
-        { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
-    ]);
-
-    const lowTokenResponse = new SequenceNode([
-        new IsTokenBelowThresholdNode(1),
-        {
-            async evaluate(unit) {
-                debugMBTIManager.logDecisionStart('자원 부족 상황 판단', unit);
-                return NodeState.SUCCESS;
-            }
-        },
-        new SelectorNode([
-            new SequenceNode([
-                new MBTIActionNode('J', engines),
-                new HasNotMovedNode(),
-                { async evaluate() { debugMBTIManager.logAction('다음 턴을 위해 재배치 (J)'); return NodeState.SUCCESS; } },
-                new FindSafeRepositionNode(engines),
-                new MoveToTargetNode(engines)
-            ]),
-            new SequenceNode([
-                new MBTIActionNode('P', engines),
-                { async evaluate() { debugMBTIManager.logAction('0코스트 스킬 시도 (P)'); return NodeState.SUCCESS; } },
-                new CanUseSkillBySlotNode(3),
-                new FindTargetBySkillTypeNode(engines),
-                executeSkillBranch
-            ])
-        ]),
-        { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
-    ]);
-
-    const allyCareBehavior = new SequenceNode([
-        new FindNearestAllyInDangerNode(),
-        {
-            async evaluate(unit) {
-                debugMBTIManager.logDecisionStart('아군 보호 판단', unit);
-                return NodeState.SUCCESS;
-            }
-        },
-        new SelectorNode([
-            new SequenceNode([
-                new MBTIActionNode('F', engines),
-                { async evaluate() { debugMBTIManager.logAction('아군 지원 위치로 이동'); return NodeState.SUCCESS; } },
-                new HasNotMovedNode(),
-                new FindPathToAllyNode(engines),
-                new MoveToTargetNode(engines)
-            ])
-        ]),
-        { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
-    ]);
-
-    // 상황: 적 메딕 발견 시 대응
-    const enemyMedicResponse = new SequenceNode([
-        new FindEnemyMedicNode(),
-        new SelectorNode([
-            new SequenceNode([
-                new MBTIActionNode('P', engines),
-                { async evaluate(unit, blackboard) {
-                    const target = blackboard.get('enemyMedic');
-                    blackboard.set('skillTarget', target);
-                    debugMBTIManager.logAction('메딕 즉시 공격 (P)');
-                    return NodeState.SUCCESS;
-                }},
-                new CanUseSkillBySlotNode(3),
-                executeSkillBranch
-            ]),
-            new SequenceNode([
-                new MBTIActionNode('J', engines),
-                new HasNotMovedNode(),
-                { async evaluate() { debugMBTIManager.logAction('유리한 위치로 이동 (J)'); return NodeState.SUCCESS; } },
-                new FindSafeRepositionNode(engines),
-                new MoveToTargetNode(engines)
-            ])
-        ])
-    ]);
-
-    const attackSequence = new SequenceNode([
-        new FindTargetBySkillTypeNode(engines),
-        new FindBestSkillByScoreNode(engines),
-        executeSkillBranch
-    ]);
-
+    // 카이팅 (적이 너무 가까울 때)
     const kitingBehavior = new SequenceNode([
         new HasNotMovedNode(),
         new IsTargetTooCloseNode({ ...engines, dangerZone: 2 }),
         new FindKitingPositionNode(engines),
-        new MoveToTargetNode(engines),
+        new MoveToTargetNode(engines)
+    ]);
+
+    // 주 공격 로직
+    const mainAttackLogic = new SequenceNode([
+        // ✨ [수정] 스킬 점수 기반으로 최적의 스킬을 먼저 찾습니다.
+        new FindBestSkillByScoreNode(engines),
+        // ✨ [수정] 해당 스킬에 맞는 최적의 대상을 찾습니다.
+        new FindTargetBySkillTypeNode(engines),
         new SelectorNode([
-            attackSequence
+            // 사거리 내에 있으면 즉시 사용
+            useSkillBranch,
+            // 사거리 밖에 있으면 이동 후 사용
+            moveAndUseSkillBranch
         ])
     ]);
 
+    // 기본 이동 로직 (공격할 스킬이 없을 때)
+    const basicMovement = new SequenceNode([
+        new HasNotMovedNode(),
+        // ✨ [수정] 원거리 유닛에 맞는 타겟 탐색 노드를 사용합니다.
+        new FindPreferredTargetNode(engines), 
+        new FindPathToTargetNode(engines),
+        new MoveToTargetNode(engines)
+    ]);
+
+    // 최종 행동 트리 구성
     const rootNode = new SelectorNode([
         survivalBehavior,
-        postStunRecoveryBehavior,
-        lowTokenResponse,
-        enemyMedicResponse,
-        allyCareBehavior,
         kitingBehavior,
-        attackSequence,
+        mainAttackLogic,
+        basicMovement,
+        // 아무것도 할 게 없을 때 턴을 넘기기 전 마지막으로 위치 재선정 시도
         new SequenceNode([
             new HasNotMovedNode(),
-            new FindMeleeStrategicTargetNode(engines),
-            new FindPathToTargetNode(engines),
+            new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
         ]),
-        new SuccessNode()
+        new SuccessNode() // 모든 행동이 실패했을 경우 턴을 정상적으로 종료
     ]);
 
     return new BehaviorTree(rootNode);

--- a/src/ai/nodes/FindPathToTargetNode.js
+++ b/src/ai/nodes/FindPathToTargetNode.js
@@ -10,8 +10,8 @@ class FindPathToTargetNode extends Node {
 
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
-        // ✨ [수정] 'currentTargetUnit' 대신 'movementTarget'을 참조하도록 변경
-        const target = blackboard.get('movementTarget');
+        // ✨ [수정] 'movementTarget' 대신 'currentTargetUnit'을 참조하도록 변경
+        const target = blackboard.get('currentTargetUnit');
         if (!target) {
             debugAIManager.logNodeResult(NodeState.FAILURE, "이동 목표 없음");
             return NodeState.FAILURE;


### PR DESCRIPTION
## Summary
- adjust `FindPathToTargetNode` to read `currentTargetUnit` from the blackboard
- rewrite `RangedAI` with a simpler kiting and attack logic

## Testing
- `node tests/movement_stat_test.js`
- `node tests/critical_shot_skill_integration_test.js`
- `node tests/flyingmen_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/mighty_shield_skill_test.js`
- `node tests/nanomancer_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/proficiency_specialization_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688b54d29484832791bf2c51c622e2d2