### PR TITLE
Prevent duplicate skill equips

### DIFF
--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -318,6 +318,15 @@ export class SkillManagementDOMEngine {
         const draggedInstanceData = skillInventoryManager.getInstanceData(draggedInstanceId);
         const draggedSkillData = skillInventoryManager.getSkillData(draggedInstanceData.skillId, draggedInstanceData.grade);
 
+        // --- ▼ 중복 착용 방지 로직 추가 ▼ ---
+        if (this.draggedData.source === 'inventory') {
+            if (ownedSkillsManager.hasSkillId(unitId, draggedInstanceData.skillId)) {
+                alert('이미 동일한 종류의 스킬을 장착하고 있습니다.');
+                return;
+            }
+        }
+        // --- ▲ 중복 착용 방지 로직 추가 ▲ ---
+
         // ✨ [추가] 스킬 장착 규칙 검사
         const isSpecialSkill = draggedSkillData.tags.includes(SKILL_TAGS.SPECIAL);
         const isSpecialSlot = targetSlotIndex >= 4;

--- a/src/game/utils/MercenaryCardSelector.js
+++ b/src/game/utils/MercenaryCardSelector.js
@@ -110,7 +110,8 @@ class MercenaryCardSelector {
             }
             
             selected.push(choice);
-            currentCandidates = currentCandidates.filter(c => c.instanceId !== choice.instanceId);
+            const chosenSkillId = this._getSkillData(choice).id;
+            currentCandidates = currentCandidates.filter(c => this._getSkillData(c).id !== chosenSkillId);
         }
         return selected;
     }

--- a/src/game/utils/OwnedSkillsManager.js
+++ b/src/game/utils/OwnedSkillsManager.js
@@ -1,4 +1,5 @@
 import { debugLogEngine } from './DebugLogEngine.js';
+import { skillInventoryManager } from './SkillInventoryManager.js';
 
 /**
  * 각 용병이 장착한 스킬을 관리하는 매니저
@@ -49,6 +50,21 @@ class OwnedSkillsManager {
     getEquippedSkills(unitId) {
         this.initializeSlots(unitId);
         return this.equippedSkills.get(unitId);
+    }
+
+    /**
+     * 특정 유닛이 지정한 skillId를 가진 스킬을 이미 장착했는지 확인합니다.
+     * @param {number} unitId - 확인할 유닛 ID
+     * @param {string} skillId - 스킬 ID (예: 'charge')
+     * @returns {boolean} 장착 여부
+     */
+    hasSkillId(unitId, skillId) {
+        const equipped = this.getEquippedSkills(unitId);
+        return equipped.some(instanceId => {
+            if (!instanceId) return false;
+            const instanceData = skillInventoryManager.getInstanceData(instanceId);
+            return instanceData && instanceData.skillId === skillId;
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- add `hasSkillId` to `OwnedSkillsManager`
- block equipping duplicate skills via drag-and-drop
- avoid duplicated skill IDs when AI auto-equips

## Testing
- `for f in tests/*.js; do echo "Running $f"; node $f; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688b5781101083278bb051735416b877