### PR TITLE
Improve enemy orientation and placement

### DIFF
--- a/src/game/utils/ArenaManager.js
+++ b/src/game/utils/ArenaManager.js
@@ -23,22 +23,22 @@ class ArenaManager {
         let availableCards = [...skillInventoryManager.getInventory()];
         const mercenaryTypes = Object.values(mercenaryData);
 
-        // --- 아레나 적 진영의 모든 빈 셀 목록을 미리 준비 ---
-        const ALLY_COLS = 8;
-        const ALLY_ROWS = 9;
+        // --- \u2728 아레나 '적' 진영의 모든 빈 셀 목록을 준비 ---
+        const ENEMY_START_COL = 8; // 적 진영 시작 열
+        const TOTAL_COLS = 16;
+        const TOTAL_ROWS = 9;
         let availableCells = [];
-        for (let r = 0; r < ALLY_ROWS; r++) {
-            for (let c = 0; c < ALLY_COLS; c++) {
-                // formationEngine의 grid가 로드되었다고 가정.
-                // BattleStageManager에서 그리드를 생성하므로, 이 시점에서는 셀 정보를 직접 생성.
+        for (let r = 0; r < TOTAL_ROWS; r++) {
+            // 8열부터 15열까지를 적 진영으로 설정합니다.
+            for (let c = ENEMY_START_COL; c < TOTAL_COLS; c++) {
                 availableCells.push({ col: c, row: r, isOccupied: false });
             }
         }
 
-        const placedAllies = [];
+        const placedEnemies = [];
 
         for (let i = 0; i < 12; i++) {
-            if (availableCells.length === 0) break; // 배치할 공간이 없으면 중단
+            if (availableCells.length === 0) break; 
 
             // 1. 랜덤 클래스의 적 용병 생성
             const randomType = mercenaryTypes[Math.floor(Math.random() * mercenaryTypes.length)];
@@ -52,7 +52,7 @@ class ArenaManager {
             availableCards = remainingCards;
 
             // 3. MBTI에 따라 위치 결정
-            const chosenCell = mbtiPositioningEngine.determinePosition(enemyMercenary, availableCells, placedAllies);
+            const chosenCell = mbtiPositioningEngine.determinePosition(enemyMercenary, availableCells, placedEnemies, 'enemy');
 
             if (chosenCell) {
                 // 4. 결정된 위치 정보 저장
@@ -60,9 +60,10 @@ class ArenaManager {
                 enemyMercenary.gridY = chosenCell.row;
                 // formationEngine에 DOM이 아닌 논리적 위치를 저장합니다.
                 // ArenaDOMEngine은 이 정보를 사용하게 됩니다.
-                formationEngine.setPosition(enemyMercenary.uniqueId, (chosenCell.row * ALLY_COLS) + chosenCell.col);
+                const cellIndex = (chosenCell.row * TOTAL_COLS) + chosenCell.col;
+                formationEngine.setPosition(enemyMercenary.uniqueId, cellIndex);
 
-                placedAllies.push(enemyMercenary);
+                placedEnemies.push(enemyMercenary);
                 // 사용된 셀은 후보에서 제거
                 availableCells = availableCells.filter(c => c.col !== chosenCell.col || c.row !== chosenCell.row);
             }

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -154,6 +154,11 @@ export class BattleSimulatorEngine {
             unit.sprite.setData('unitId', unit.uniqueId);
             unit.sprite.setData('team', unit.team);
 
+            // \u2728 적군 스프라이트는 오른쪽을 향하도록 좌우 반전합니다.
+            if (unit.team === 'enemy') {
+                unit.sprite.flipX = true;
+            }
+
             unit.currentHp = unit.finalStats.hp;
             // ✨ 배리어 상태 초기화
             unit.maxBarrier = unit.finalStats.maxBarrier;

--- a/src/game/utils/MBTIPositioningEngine.js
+++ b/src/game/utils/MBTIPositioningEngine.js
@@ -6,6 +6,7 @@ class MBTIPositioningEngine {
         this.name = 'MBTIPositioningEngine';
         // 아군 진영의 크기 (0~7열, 0~8행)
         this.ALLY_COLS = 8;
+        this.TOTAL_COLS = 16;
         this.ALLY_ROWS = 9;
         this.ROW_CENTER = Math.floor(this.ALLY_ROWS / 2); // 중앙 행
     }
@@ -17,7 +18,7 @@ class MBTIPositioningEngine {
      * @param {Array<object>} placedAllies - 이미 배치된 다른 아군 용병 목록
      * @returns {object|null} - 선택된 최적의 셀 또는 null
      */
-    determinePosition(mercenary, availableCells, placedAllies) {
+    determinePosition(mercenary, availableCells, placedAllies, team = 'ally') {
         if (!availableCells || availableCells.length === 0) {
             return null;
         }
@@ -29,7 +30,15 @@ class MBTIPositioningEngine {
             let totalScore = 1.0; // 기본 점수
 
             // E vs I: 전방 선호 vs 후방 선호
-            const frontPreference = cell.col / (this.ALLY_COLS - 1); // 0 (후방) ~ 1 (전방)
+            // \u2728 팀에 따라 전/후방 기준을 다르게 적용
+            let frontPreference;
+            if (team === 'ally') {
+                // 아군: 0열(후방) ~ 7열(전방)
+                frontPreference = cell.col / (this.ALLY_COLS - 1);
+            } else {
+                // 적군: 15열(후방) ~ 8열(전방)
+                frontPreference = ((this.TOTAL_COLS - 1) - cell.col) / (this.ALLY_COLS - 1);
+            }
             totalScore *= (frontPreference * mbti.E) + ((1 - frontPreference) * mbti.I);
 
             // S vs N: 중앙 선호 vs 측면 선호


### PR DESCRIPTION
## Summary
- flip enemy sprites when initializing battle units
- spawn arena enemies in the correct right-side columns
- update MBTI positioning to handle enemy team orientation

## Testing
- `for f in tests/*.js; do node $f; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688b5a352f40832791cdfd0d1d5fc4d7