### PR TITLE
Add yin yang debug logs

### DIFF
--- a/src/game/debug/DebugYinYangManager.js
+++ b/src/game/debug/DebugYinYangManager.js
@@ -1,0 +1,45 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * AI의 음양(Yin-Yang) 시스템 관련 의사결정 과정을 추적하고 로그로 남기는 디버그 매니저
+ */
+class DebugYinYangManager {
+    constructor() {
+        this.name = 'DebugYinYang';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 유닛의 음양 지수 변경을 로그로 남깁니다.
+     * @param {number} unitId - 유닛 ID
+     * @param {number} oldValue - 이전 값
+     * @param {number} newValue - 새 값
+     * @param {number} change - 변화량
+     */
+    logBalanceUpdate(unitId, oldValue, newValue, change) {
+        const color = change > 0 ? '#22c55e' : '#ef4444';
+        console.groupCollapsed(
+            `%c[${this.name}]`, `color: #a855f7; font-weight: bold;`,
+            `☯️ 유닛 ${unitId} 음양 지수 변경`
+        );
+        debugLogEngine.log(this.name, `지수 변경: ${oldValue.toFixed(2)} -> %c${newValue.toFixed(2)} (${change > 0 ? '+' : ''}${change.toFixed(2)})`, `color: ${color}; font-weight: bold;`);
+        console.groupEnd();
+    }
+
+    /**
+     * 음양 지수가 스킬 점수에 어떻게 영향을 미치는지 로그로 남깁니다.
+     * @param {string} skillName - 스킬 이름
+     * @param {number} baseScore - 기본 점수
+     * @param {number} yinYangBonus - 음양 보너스 점수
+     * @param {number} finalScore - 최종 점수
+     */
+    logScoreModification(skillName, baseScore, yinYangBonus, finalScore) {
+        if (yinYangBonus === 0) return;
+        debugLogEngine.log(
+            'SkillScoreEngine',
+            `[음양 활용] 스킬 [${skillName}] 점수 보정: 기본(${baseScore.toFixed(2)}) + 음양 보너스(${yinYangBonus.toFixed(2)}) = 최종 ${finalScore.toFixed(2)}`
+        );
+    }
+}
+
+export const debugYinYangManager = new DebugYinYangManager();

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -9,6 +9,7 @@ import { aiMemoryEngine } from './AIMemoryEngine.js';
 import { debugAIMemoryManager } from '../debug/DebugAIMemoryManager.js';
 // ✨ 1. YinYangEngine을 import 합니다.
 import { yinYangEngine } from './YinYangEngine.js';
+import { debugYinYangManager } from '../debug/DebugYinYangManager.js';
 
 /**
  * AI의 스킬 선택을 위해 각 스킬의 전략적 가치를 계산하는 엔진
@@ -113,6 +114,13 @@ class SkillScoreEngine {
                 }
             }
         }
+
+        debugYinYangManager.logScoreModification(
+            skillData.name,
+            baseScore + tagScore + situationScore,
+            yinYangBonus,
+            finalScore
+        );
 
         debugLogEngine.log(
             this.name,

--- a/src/game/utils/YinYangEngine.js
+++ b/src/game/utils/YinYangEngine.js
@@ -1,4 +1,5 @@
 import { debugLogEngine } from './DebugLogEngine.js';
+import { debugYinYangManager } from '../debug/DebugYinYangManager.js';
 
 /**
  * 전투 중 모든 유닛의 음양(Yin-Yang) 지수를 관리하는 엔진입니다.
@@ -30,16 +31,13 @@ class YinYangEngine {
      * @param {number} skillYinYangValue - 사용된 스킬의 음양 값 (예: -15, 20)
      */
     updateBalance(unitId, skillYinYangValue) {
-        if (!this.unitBalances.has(unitId)) return;
+        if (!this.unitBalances.has(unitId) || !skillYinYangValue) return;
 
         const oldValue = this.unitBalances.get(unitId);
         const newValue = oldValue + skillYinYangValue;
         this.unitBalances.set(unitId, newValue);
 
-        debugLogEngine.log(
-            this.name,
-            `유닛 ${unitId}의 음양 지수 변경: ${oldValue} -> ${newValue} (${skillYinYangValue > 0 ? '+' : ''}${skillYinYangValue})`
-        );
+        debugYinYangManager.logBalanceUpdate(unitId, oldValue, newValue, skillYinYangValue);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add `DebugYinYangManager` for yin-yang system logs
- record balance updates in `YinYangEngine`
- log yin-yang influence on skill scores in `SkillScoreEngine`

## Testing
- `node tests/movement_stat_test.js`
- `for f in tests/*_test.js; do node $f; done`
- `python3 -m http.server 8000 &`; `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688b5b90b040832792412ce4162e6a16