### PR TITLE
Remove ranged attack skill and balance axe strike

### DIFF
--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -181,56 +181,6 @@ export const activeSkills = {
         }
     },
 
-    // ✨ [신규] 원거리 공격 스킬 추가
-    rangedAttack: {
-        yinYangValue: -1,
-        NORMAL: {
-            id: 'rangedAttack',
-            name: '원거리 공격',
-            type: 'ACTIVE',
-            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.PHYSICAL],
-            cost: 1,
-            description: '원거리의 적을 {{damage}}% 데미지로 공격합니다.',
-            illustrationPath: 'assets/images/skills/gunner-attack-icon.png',
-            damageMultiplier: { min: 0.9, max: 1.1 },
-            cooldown: 0,
-        },
-        RARE: {
-            id: 'rangedAttack',
-            name: '원거리 공격 [R]',
-            type: 'ACTIVE',
-            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.PHYSICAL],
-            cost: 0,
-            description: '원거리의 적을 {{damage}}% 데미지로 공격합니다.',
-            illustrationPath: 'assets/images/skills/gunner-attack-icon.png',
-            damageMultiplier: { min: 0.9, max: 1.1 },
-            cooldown: 0,
-        },
-        EPIC: {
-            id: 'rangedAttack',
-            name: '원거리 공격 [E]',
-            type: 'ACTIVE',
-            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.PHYSICAL],
-            cost: 0,
-            description: '원거리의 적을 {{damage}}% 데미지로 공격하고, 50% 확률로 토큰 1개를 생성합니다.',
-            illustrationPath: 'assets/images/skills/gunner-attack-icon.png',
-            damageMultiplier: { min: 0.9, max: 1.1 },
-            cooldown: 0,
-            generatesToken: { chance: 0.5, amount: 1 }
-        },
-        LEGENDARY: {
-            id: 'rangedAttack',
-            name: '원거리 공격 [L]',
-            type: 'ACTIVE',
-            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.PHYSICAL],
-            cost: 0,
-            description: '원거리의 적을 {{damage}}% 데미지로 공격하고, 100% 확률로 토큰 1개를 생성합니다.',
-            illustrationPath: 'assets/images/skills/gunner-attack-icon.png',
-            damageMultiplier: { min: 0.9, max: 1.1 },
-            cooldown: 0,
-            generatesToken: { chance: 1.0, amount: 1 }
-        }
-    },
     // --- ▼ [신규] 나노빔 스킬 추가 ▼ ---
     nanobeam: {
         yinYangValue: -1,
@@ -294,7 +244,7 @@ export const activeSkills = {
             cost: 1,
             description: '적을 {{damage}}% 위력으로 공격하고, 최대 용맹 배리어의 5%를 회복합니다.',
             illustrationPath: 'assets/images/skills/axe-strike.png',
-            damageMultiplier: { min: 0.9, max: 1.1 },
+            damageMultiplier: { min: 0.45, max: 0.55 },
             cooldown: 0,
             restoresBarrierPercent: 0.05
         },
@@ -306,7 +256,7 @@ export const activeSkills = {
             cost: 0,
             description: '적을 {{damage}}% 위력으로 공격하고, 최대 용맹 배리어의 5%를 회복합니다.',
             illustrationPath: 'assets/images/skills/axe-strike.png',
-            damageMultiplier: { min: 0.9, max: 1.1 },
+            damageMultiplier: { min: 0.45, max: 0.55 },
             cooldown: 0,
             restoresBarrierPercent: 0.05
         },
@@ -318,7 +268,7 @@ export const activeSkills = {
             cost: 0,
             description: '적을 {{damage}}% 위력으로 공격하고, 최대 용맹 배리어의 7%를 회복합니다.',
             illustrationPath: 'assets/images/skills/axe-strike.png',
-            damageMultiplier: { min: 0.9, max: 1.1 },
+            damageMultiplier: { min: 0.45, max: 0.55 },
             cooldown: 0,
             restoresBarrierPercent: 0.07
         },
@@ -330,7 +280,7 @@ export const activeSkills = {
             cost: 0,
             description: '적을 {{damage}}% 위력으로 공격하고, 최대 용맹 배리어의 10%를 회복합니다.',
             illustrationPath: 'assets/images/skills/axe-strike.png',
-            damageMultiplier: { min: 0.9, max: 1.1 },
+            damageMultiplier: { min: 0.45, max: 0.55 },
             cooldown: 0,
             restoresBarrierPercent: 0.10
         }

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -26,8 +26,6 @@ class SkillInventoryManager {
                 this.addSkillById('attack', grade); // 공격 스킬도 각 등급별 2장 지급
 
                 // ✨ 추가 기본 스킬 카드 지급
-                // 원거리 공격 스킬 카드도 등급별로 지급합니다.
-                this.addSkillById('rangedAttack', grade);
                 this.addSkillById('nanobeam', grade);
                 this.addSkillById('axeStrike', grade);
                 this.addSkillById('stoneSkin', grade);

--- a/tests/gunner_skill_integration_test.js
+++ b/tests/gunner_skill_integration_test.js
@@ -10,7 +10,7 @@ const suppressShotBase = {
     LEGENDARY: { id: 'suppressShot', damageMultiplier: { min: 1.1, max: 1.3 }, turnOrderEffect: 'pushToBack', effect: { tokenLoss: 1 } }
 };
 
-// --- ▼ [신규] 넉백샷 및 원거리 공격 테스트 데이터 추가 ▼ ---
+// --- ▼ [신규] 넉백샷 테스트 데이터 추가 ▼ ---
 const knockbackShotBase = {
     NORMAL: { id: 'knockbackShot', cost: 2, cooldown: 2, damageMultiplier: { min: 0.7, max: 0.9 }, push: 1 },
     RARE: { id: 'knockbackShot', cost: 2, cooldown: 1, damageMultiplier: { min: 0.7, max: 0.9 }, push: 1 },
@@ -18,13 +18,7 @@ const knockbackShotBase = {
     LEGENDARY: { id: 'knockbackShot', cost: 1, cooldown: 1, damageMultiplier: { min: 0.7, max: 0.9 }, push: 2 }
 };
 
-const rangedAttackBase = {
-    NORMAL: { id: 'rangedAttack', cost: 1, cooldown: 0, damageMultiplier: { min: 0.9, max: 1.1 } },
-    RARE: { id: 'rangedAttack', cost: 0, cooldown: 0, damageMultiplier: { min: 0.9, max: 1.1 } },
-    EPIC: { id: 'rangedAttack', cost: 0, cooldown: 0, damageMultiplier: { min: 0.9, max: 1.1 }, generatesToken: { chance: 0.5, amount: 1 } },
-    LEGENDARY: { id: 'rangedAttack', cost: 0, cooldown: 0, damageMultiplier: { min: 0.9, max: 1.1 }, generatesToken: { chance: 1.0, amount: 1 } }
-};
-// --- ▲ [신규] 넉백샷 및 원거리 공격 테스트 데이터 추가 ▲ ---
+// --- ▲ [신규] 넉백샷 테스트 데이터 추가 ▲ ---
 
 // --- ▼ [신규] 사냥꾼의 감각 테스트 데이터 추가 ▼ ---
 const huntSenseBase = {
@@ -97,26 +91,6 @@ for (const grade of grades) {
 }
 // --- ▲ [신규] 넉백샷 테스트 로직 추가 ▲ ---
 
-// --- ▼ [신규] 원거리 공격 테스트 로직 추가 ▼ ---
-for (const grade of grades) {
-    const skill = skillModifierEngine.getModifiedSkill(rangedAttackBase[grade], grade);
-    assert(skill.damageMultiplier && typeof skill.damageMultiplier === 'object');
-
-    if (grade === 'NORMAL') {
-        assert.strictEqual(skill.cost, 1, `Ranged attack cost failed for ${grade}`);
-    } else {
-        assert.strictEqual(skill.cost, 0, `Ranged attack cost failed for ${grade}`);
-    }
-
-    if (grade === 'EPIC') {
-        assert(skill.generatesToken && skill.generatesToken.chance === 0.5, `Token generation failed for ${grade}`);
-    } else if (grade === 'LEGENDARY') {
-        assert(skill.generatesToken && skill.generatesToken.chance === 1.0, `Token generation failed for ${grade}`);
-    } else {
-        assert(!skill.generatesToken, `Unexpected token generation for ${grade}`);
-    }
-}
-// --- ▲ [신규] 원거리 공격 테스트 로직 추가 ▲ ---
 
 // --- ▼ [신규] 사냥꾼의 감각 테스트 로직 추가 ▼ ---
 for (const grade of grades) {


### PR DESCRIPTION
## Summary
- remove the `rangedAttack` skill definition and distribution
- reduce `axeStrike` damage multiplier to half
- clean up inventory initialization and gunner tests

## Testing
- `node tests/gunner_skill_integration_test.js`
- `for f in tests/*_test.js; do echo "running $f"; node $f; done`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688b66dc3318832792289cc5c59f7da2