### PR TITLE
Add ranged attack stat

### DIFF
--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -43,7 +43,10 @@ class CombatCalculationEngine {
             return { damage: 0, hitType: '무효', comboCount: 0 };
         }
 
-        const baseAttack = attacker.finalStats?.physicalAttack || 0;
+        const isRanged = skill.tags?.includes(SKILL_TAGS.RANGED) && skill.tags?.includes(SKILL_TAGS.PHYSICAL);
+        const baseAttack = isRanged
+            ? (attacker.finalStats?.rangedAttack || 0)
+            : (attacker.finalStats?.physicalAttack || 0);
 
         // 콤보 배율 계산을 위한 정보
         let comboMultiplier = 1.0;

--- a/src/game/utils/StatEngine.js
+++ b/src/game/utils/StatEngine.js
@@ -117,6 +117,7 @@ class StatEngine {
 
         // 3. \uC8FC\uC6A9 \uC804\uD22C \uB2A5\uB825\uCE58\uB97C \uACC4\uC0B0\uD569\uB2C8\uB2E4.
         calculated.physicalAttack = (calculated.strength || 0) * 1.5;
+        calculated.rangedAttack = (calculated.agility || 0) * 1.5;
         calculated.physicalDefense = (calculated.endurance || 0) * 1.2;
         calculated.magicAttack = (calculated.intelligence || 0) * 1.5;
         calculated.magicDefense = (calculated.wisdom || 0) * 1.2;


### PR DESCRIPTION
## Summary
- compute `rangedAttack` from agility in StatEngine
- use ranged attack for physical ranged skills
- run existing tests

## Testing
- `for f in tests/*.js; do node $f || exit 1; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688b68ec2468832780dee210cf4878c2