### PR TITLE
Add SkillEffectProcessor and update UseSkillNode

### DIFF
--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -1,41 +1,26 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
 import { skillEngine, SKILL_TYPES } from '../../game/utils/SkillEngine.js';
-import { statusEffectManager } from '../../game/utils/StatusEffectManager.js';
-import { spriteEngine } from '../../game/utils/SpriteEngine.js';
-import { combatCalculationEngine } from '../../game/utils/CombatCalculationEngine.js';
-import { formationEngine } from '../../game/utils/FormationEngine.js';
 import { skillInventoryManager } from '../../game/utils/SkillInventoryManager.js';
-import { ownedSkillsManager } from '../../game/utils/OwnedSkillsManager.js';
 import { skillModifierEngine } from '../../game/utils/SkillModifierEngine.js';
-import { tokenEngine } from '../../game/utils/TokenEngine.js';
 import { debugSkillExecutionManager } from '../../game/debug/DebugSkillExecutionManager.js';
-import { sharedResourceEngine } from '../../game/utils/SharedResourceEngine.js';
-import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
-// ✨ 1. 새로 만든 BattleTagManager를 import 합니다.
-import { battleTagManager } from '../../game/utils/BattleTagManager.js';
-import { turnOrderManager } from '../../game/utils/TurnOrderManager.js';
 import { classProficiencies } from '../../game/data/classProficiencies.js';
 import { diceEngine } from '../../game/utils/DiceEngine.js';
-import { classSpecializations } from '../../game/data/classSpecializations.js';
-// ✨ 1. YinYangEngine을 import 합니다.
-import { yinYangEngine } from '../../game/utils/YinYangEngine.js';
+import SkillEffectProcessor from '../../game/utils/SkillEffectProcessor.js'; // 새로 만든 클래스를 import
 
 class UseSkillNode extends Node {
-    constructor({ vfxManager, animationEngine, delayEngine, terminationManager, summoningEngine, skillEngine: se, battleSimulator } = {}) {
+    constructor(engines = {}) {
         super();
-        this.vfxManager = vfxManager;
-        this.animationEngine = animationEngine;
-        this.delayEngine = delayEngine;
-        this.terminationManager = terminationManager;
-        this.summoningEngine = summoningEngine;
-        this.skillEngine = se || skillEngine;
-        this.combatEngine = combatCalculationEngine;
-        this.battleSimulator = battleSimulator;
+        this.delayEngine = engines.delayEngine;
+        this.skillEngine = engines.skillEngine || skillEngine;
+        this.vfxManager = engines.vfxManager;
+        // SkillEffectProcessor를 초기화합니다.
+        this.skillEffectProcessor = new SkillEffectProcessor(engines);
     }
 
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
+
         const skillTarget = blackboard.get('skillTarget');
         const instanceId = blackboard.get('currentSkillInstanceId');
 
@@ -46,242 +31,38 @@ class UseSkillNode extends Node {
 
         const instanceData = skillInventoryManager.getInstanceData(instanceId);
         const baseSkillData = skillInventoryManager.getSkillData(instanceData.skillId, instanceData.grade);
-
         const modifiedSkill = skillModifierEngine.getModifiedSkill(baseSkillData, instanceData.grade);
-        if (!modifiedSkill) {
-            debugAIManager.logNodeResult(NodeState.FAILURE, '스킬 데이터 처리 오류');
+
+        if (!modifiedSkill || !this.skillEngine.canUseSkill(unit, modifiedSkill)) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, `스킬 [${modifiedSkill?.name}] 사용 조건 미충족`);
             return NodeState.FAILURE;
         }
 
         debugSkillExecutionManager.logSkillExecution(unit, baseSkillData, modifiedSkill, instanceData.grade);
 
-        // ✨ 숙련도에 따른 주사위 굴림으로 최종 계수 결정
-        let finalDamageMultiplier = modifiedSkill.damageMultiplier;
-        if (typeof finalDamageMultiplier === 'object') {
-            const prof = classProficiencies[unit.id] || [];
-            const matching = modifiedSkill.tags.filter(t => prof.includes(t)).length;
-            const rolls = Math.max(1, matching);
-            finalDamageMultiplier = diceEngine.rollWithAdvantage(
-                finalDamageMultiplier.min,
-                finalDamageMultiplier.max,
-                rolls
-            );
-            debugLogEngine.log('UseSkillNode', `${unit.instanceName}의 [${modifiedSkill.name}] 숙련도 체크. 일치 태그: ${matching}개. 주사위 ${rolls}번 굴림 -> 최종 계수: ${finalDamageMultiplier.toFixed(2)}`);
-        }
+        // 최종 사용할 스킬 데이터를 준비합니다 (숙련도 보너스 적용)
+        const finalSkill = this._applyProficiency(unit, modifiedSkill);
 
-        let finalHealMultiplier = modifiedSkill.healMultiplier;
-        if (typeof finalHealMultiplier === 'object') {
-            const prof = classProficiencies[unit.id] || [];
-            const matching = modifiedSkill.tags.filter(t => prof.includes(t)).length;
-            const rolls = Math.max(1, matching);
-            finalHealMultiplier = diceEngine.rollWithAdvantage(
-                finalHealMultiplier.min,
-                finalHealMultiplier.max,
-                rolls
-            );
-        }
-
-        const skillToUse = { ...modifiedSkill, damageMultiplier: finalDamageMultiplier, healMultiplier: finalHealMultiplier };
-
-        if (!this.skillEngine.canUseSkill(unit, modifiedSkill)) {
-            debugAIManager.logNodeResult(NodeState.FAILURE, `스킬 [${modifiedSkill.name}] 사용 조건 미충족`);
-            return NodeState.FAILURE;
-        }
-
-        // ✨ 클래스 특화 태그 보너스 적용
-        const specializations = classSpecializations[unit.id] || [];
-        skillToUse.tags.forEach(tag => {
-            const spec = specializations.find(s => s.tag === tag);
-            if (spec) {
-                const bonusEffectSkill = { name: `특화 보너스: ${spec.tag}`, effect: spec.effect };
-                statusEffectManager.addEffect(unit, bonusEffectSkill, unit);
-                debugLogEngine.log('UseSkillNode', `${unit.instanceName}가 특화 태그 [${spec.tag}] 보너스 획득!`);
-            }
-        });
-
-        // ✨ [신규] 속성 특화 보너스 적용 로직
-        if (unit.attributeSpec) {
-            const spec = unit.attributeSpec;
-            if (skillToUse.tags.includes(spec.tag)) {
-                const bonusEffectSkill = {
-                    name: `속성 특화: ${spec.tag}`,
-                    effect: spec.effect
-                };
-                statusEffectManager.addEffect(unit, bonusEffectSkill, unit);
-                debugLogEngine.log('UseSkillNode', `${unit.instanceName}가 속성 특화 태그 [${spec.tag}] 보너스 획득!`);
-            }
-        }
-
-        // ✨ 2. 스킬 사용이 확정된 이 시점에 BattleTagManager에 정보를 기록합니다.
-        battleTagManager.recordSkillUse(unit, skillTarget, modifiedSkill);
-
-        // ✨ [수정] 자원 소모 시 unit.team 정보 전달
-        if (modifiedSkill.resourceCost) {
-            sharedResourceEngine.spendResource(unit.team, modifiedSkill.resourceCost);
-            const costText = Array.isArray(modifiedSkill.resourceCost) 
-                ? modifiedSkill.resourceCost.map(c => `[${c.type}] ${c.amount}`).join(', ')
-                : `[${modifiedSkill.resourceCost.type}] ${modifiedSkill.resourceCost.amount}`;
-            debugLogEngine.log('UseSkillNode', `${costText} 소모`);
-        }
-
-        this.skillEngine.recordSkillUse(unit, modifiedSkill); // 보정된 데이터로 기록
-        // ✨ 스킬 사용이 확정된 후 음양 지수를 업데이트합니다.
-        yinYangEngine.updateBalance(unit.uniqueId, modifiedSkill.yinYangValue);
-
+        // 스킬 사용 기록
+        this.skillEngine.recordSkillUse(unit, finalSkill);
         const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
         usedSkills.add(instanceId);
         blackboard.set('usedSkillsThisTurn', usedSkills);
 
-        const skillColor = SKILL_TYPES[modifiedSkill.type].color;
-        this.vfxManager.showSkillName(unit.sprite, modifiedSkill.name, skillColor);
+        // 스킬 이름 VFX 표시
+        this.vfxManager.showSkillName(unit.sprite, finalSkill.name, SKILL_TYPES[finalSkill.type].color);
 
-        // 스킬 애니메이션 및 효과 적용 로직
-        if (modifiedSkill.type === 'ACTIVE' || modifiedSkill.type === 'DEBUFF') {
-            // ✨ 1. 공격 스프라이트로 변경
-            spriteEngine.changeSpriteForDuration(unit, 'attack', 600);
-            await this.animationEngine.attack(unit.sprite, skillTarget.sprite);
+        // ✨ SkillEffectProcessor에 모든 처리를 위임합니다.
+        await this.skillEffectProcessor.process({
+            unit,
+            target: skillTarget,
+            skill: finalSkill,
+            instanceId,
+            grade: instanceData.grade,
+            blackboard
+        });
 
-            // ✨ 2. 피격 스프라이트로 변경
-            spriteEngine.changeSpriteForDuration(skillTarget, 'hitted', 300);
-
-            if (modifiedSkill.type === 'ACTIVE') {
-                const { damage: totalDamage, hitType, comboCount } = this.combatEngine.calculateDamage(
-                    unit,
-                    skillTarget,
-                    skillToUse,
-                    instanceId,
-                    instanceData.grade
-                );
-
-                // ✨ 배리어 및 체력 데미지 분배 로직
-                const damageToBarrier = Math.min(skillTarget.currentBarrier, totalDamage);
-                const damageToHp = totalDamage - damageToBarrier;
-
-                if (damageToBarrier > 0) {
-                    skillTarget.currentBarrier -= damageToBarrier;
-                    this.vfxManager.createDamageNumber(
-                        skillTarget.sprite.x,
-                        skillTarget.sprite.y - 10,
-                        damageToBarrier,
-                        '#ffd700',
-                        hitType
-                    );
-                }
-                if (damageToHp > 0) {
-                    skillTarget.currentHp -= damageToHp;
-                    this.vfxManager.createDamageNumber(
-                        skillTarget.sprite.x,
-                        skillTarget.sprite.y + 10,
-                        damageToHp,
-                        '#ff4d4d',
-                        hitType
-                    );
-                }
-
-                this.vfxManager.showComboCount(comboCount);
-                this.vfxManager.createBloodSplatter(skillTarget.sprite.x, skillTarget.sprite.y);
-
-                // 토큰 생성 효과 처리
-                if (modifiedSkill.generatesToken) {
-                    if (Math.random() < modifiedSkill.generatesToken.chance) {
-                        tokenEngine.addTokens(
-                            unit.uniqueId,
-                            modifiedSkill.generatesToken.amount,
-                            `${modifiedSkill.name} 효과`
-                        );
-                    }
-                }
-
-                if (modifiedSkill.turnOrderEffect === 'pushToBack' && this.battleSimulator) {
-                    this.battleSimulator.turnQueue = turnOrderManager.pushToBack(this.battleSimulator.turnQueue, skillTarget);
-                }
-
-                // ✨ 넉백(push) 효과 처리
-                if (modifiedSkill.push && modifiedSkill.push > 0) {
-                    await formationEngine.pushUnit(skillTarget, unit, modifiedSkill.push, this.animationEngine);
-                }
-
-                // --- ▼ [신규] 배리어 회복 로직 추가 ▼ ---
-                if (modifiedSkill.restoresBarrierPercent && unit.maxBarrier > 0) {
-                    const healAmount = Math.round(unit.maxBarrier * modifiedSkill.restoresBarrierPercent);
-                    unit.currentBarrier = Math.min(unit.maxBarrier, unit.currentBarrier + healAmount);
-                    this.vfxManager.createDamageNumber(
-                        unit.sprite.x,
-                        unit.sprite.y - 10,
-                        `+${healAmount}`,
-                        '#ffd700',
-                        '배리어'
-                    );
-                }
-                // --- ▲ [신규] 배리어 회복 로직 추가 ▲ ---
-
-                if (skillTarget.currentHp <= 0) {
-                    this.terminationManager.handleUnitDeath(skillTarget);
-                }
-            }
-        } else if (modifiedSkill.type === 'SUMMON') {
-            spriteEngine.changeSpriteForDuration(unit, 'cast', 600);
-            this.summoningEngine.summon(unit, modifiedSkill);
-        } else {
-            // ✨ 3. 캐스트 스프라이트 변경 (기존 로직 유지)
-            spriteEngine.changeSpriteForDuration(unit, 'cast', 600);
-        }
-
-        // ✨ AID 타입 스킬 처리 - 회복 및 디버프 제거 (치료 금지 체크)
-        if (modifiedSkill.type === 'AID') {
-            if (skillTarget.isHealingProhibited) {
-                debugLogEngine.log('UseSkillNode', `${skillTarget.instanceName}은(는) 치료 금지 상태라 회복 불가!`);
-            } else {
-                const healAmount = Math.round(unit.finalStats.wisdom * (skillToUse.healMultiplier || 0));
-                skillTarget.currentHp = Math.min(skillTarget.finalStats.hp, skillTarget.currentHp + healAmount);
-                this.vfxManager.createDamageNumber(skillTarget.sprite.x, skillTarget.sprite.y, `+${healAmount}`, '#22c55e');
-                if (modifiedSkill.removesDebuff && Math.random() < modifiedSkill.removesDebuff.chance) {
-                    statusEffectManager.removeOneDebuff(skillTarget);
-                }
-            }
-        }
-
-        // ✨ [수정] 자원 생성 시 unit.team 정보 전달
-        if (modifiedSkill.generatesResource) {
-            sharedResourceEngine.addResource(unit.team, modifiedSkill.generatesResource.type, modifiedSkill.generatesResource.amount);
-            debugLogEngine.log('UseSkillNode', `[${modifiedSkill.generatesResource.type}] ${modifiedSkill.generatesResource.amount} 생산`);
-        }
-
-        if (modifiedSkill.effect) {
-            const targets = [skillTarget];
-            if (modifiedSkill.numberOfTargets && modifiedSkill.numberOfTargets > 1) {
-                const enemyUnits = blackboard.get('enemyUnits')?.filter(e => e.currentHp > 0 && e.uniqueId !== skillTarget.uniqueId) || [];
-                if (enemyUnits.length > 0) {
-                    let farthestEnemies = [];
-                    let maxDist = -1;
-                    enemyUnits.forEach(enemy => {
-                        const dist = Math.abs(unit.gridX - enemy.gridX) + Math.abs(unit.gridY - enemy.gridY);
-                        if (dist > maxDist) {
-                            maxDist = dist;
-                            farthestEnemies = [enemy];
-                        } else if (dist === maxDist) {
-                            farthestEnemies.push(enemy);
-                        }
-                    });
-                    if (farthestEnemies.length > 0) {
-                        const secondTarget = farthestEnemies.sort((a, b) => a.currentHp - b.currentHp)[0];
-                        if (secondTarget) targets.push(secondTarget);
-                    }
-                }
-            }
-
-            targets.forEach(target => {
-                const roll = Math.random();
-                if (modifiedSkill.effect.chance === undefined || roll < modifiedSkill.effect.chance) {
-                    statusEffectManager.addEffect(target, modifiedSkill, unit);
-                } else {
-                    debugLogEngine.log('UseSkillNode', `[${modifiedSkill.name}]의 효과 발동 실패 (확률: ${modifiedSkill.effect.chance}, 주사위: ${roll.toFixed(2)})`);
-                }
-            });
-        }
-
-        console.log(`[AI] ${unit.instanceName}이(가) ${skillTarget.instanceName}에게 스킬 [${modifiedSkill.name}] 사용!`);
-
+        // 처리 후 블랙보드 정리
         blackboard.set('currentSkillData', null);
         blackboard.set('currentSkillInstanceId', null);
         blackboard.set('skillTarget', null);
@@ -291,5 +72,32 @@ class UseSkillNode extends Node {
         debugAIManager.logNodeResult(NodeState.SUCCESS);
         return NodeState.SUCCESS;
     }
+
+    /**
+     * 숙련도에 따라 스킬의 최종 계수를 결정하여 반환합니다.
+     * @private
+     */
+    _applyProficiency(unit, skill) {
+        const finalSkill = { ...skill };
+        const proficiencies = classProficiencies[unit.id] || [];
+        const matchingTags = skill.tags.filter(t => proficiencies.includes(t)).length;
+        const rolls = Math.max(1, matchingTags);
+
+        if (typeof skill.damageMultiplier === 'object') {
+            finalSkill.damageMultiplier = diceEngine.rollWithAdvantage(
+                skill.damageMultiplier.min, skill.damageMultiplier.max, rolls
+            );
+            debugLogEngine.log('UseSkillNode', `${unit.instanceName}의 [${skill.name}] 숙련도 체크. ${rolls}번 굴림 -> 최종 계수: ${finalSkill.damageMultiplier.toFixed(2)}`);
+        }
+
+        if (typeof skill.healMultiplier === 'object') {
+            finalSkill.healMultiplier = diceEngine.rollWithAdvantage(
+                skill.healMultiplier.min, skill.healMultiplier.max, rolls
+            );
+        }
+
+        return finalSkill;
+    }
 }
+
 export default UseSkillNode;

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -1,0 +1,205 @@
+import { SKILL_TYPES } from './SkillEngine.js';
+import { statusEffectManager } from './StatusEffectManager.js';
+import { spriteEngine } from './SpriteEngine.js';
+import { combatCalculationEngine } from './CombatCalculationEngine.js';
+import { formationEngine } from './FormationEngine.js';
+import { tokenEngine } from './TokenEngine.js';
+import { battleTagManager } from './BattleTagManager.js';
+import { turnOrderManager } from './TurnOrderManager.js';
+import { classSpecializations } from '../data/classSpecializations.js';
+import { yinYangEngine } from './YinYangEngine.js';
+import { sharedResourceEngine } from './SharedResourceEngine.js';
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 스킬의 실제 효과(데미지, 치유, 상태이상 등)를 게임 세계에 적용하는 것을 전담하는 엔진
+ */
+class SkillEffectProcessor {
+    constructor(engines) {
+        this.vfxManager = engines.vfxManager;
+        this.animationEngine = engines.animationEngine;
+        this.terminationManager = engines.terminationManager;
+        this.summoningEngine = engines.summoningEngine;
+        this.battleSimulator = engines.battleSimulator;
+    }
+
+    /**
+     * 스킬 효과 적용의 메인 메서드
+     * @param {object} context - 스킬 처리에 필요한 모든 정보
+     */
+    async process(context) {
+        const { unit, target, skill, instanceId, grade, blackboard } = context;
+
+        // 1. 공통 처리: 태그 기록, 자원 소모, 음양 지수 업데이트
+        this._handleCommonPreEffects(unit, target, skill);
+
+        // 2. 스킬 타입별 분기 처리
+        switch (skill.type) {
+            case 'ACTIVE':
+            case 'DEBUFF':
+                await this._processOffensiveSkill(unit, target, skill, instanceId, grade);
+                break;
+            case 'AID':
+                await this._processAidSkill(unit, target, skill);
+                break;
+            case 'SUMMON':
+                await this._processSummonSkill(unit, skill);
+                break;
+            case 'BUFF':
+            case 'STRATEGY':
+                // BUFF와 STRATEGY는 주로 상태 효과 적용이 핵심
+                spriteEngine.changeSpriteForDuration(unit, 'cast', 600);
+                break;
+        }
+
+        // 3. 공통 처리: 상태 효과 적용, 자원 생성
+        this._handleCommonPostEffects(unit, target, skill, blackboard);
+    }
+
+    _handleCommonPreEffects(unit, target, skill) {
+        battleTagManager.recordSkillUse(unit, target, skill);
+        yinYangEngine.updateBalance(unit.uniqueId, skill.yinYangValue);
+
+        if (skill.resourceCost) {
+            sharedResourceEngine.spendResource(unit.team, skill.resourceCost);
+            const costText = Array.isArray(skill.resourceCost)
+                ? skill.resourceCost.map(c => `[${c.type}] ${c.amount}`).join(', ')
+                : `[${skill.resourceCost.type}] ${skill.resourceCost.amount}`;
+            debugLogEngine.log('SkillEffectProcessor', `${costText} 소모`);
+        }
+    }
+
+    _handleCommonPostEffects(unit, target, skill, blackboard) {
+        if (skill.generatesResource) {
+            sharedResourceEngine.addResource(unit.team, skill.generatesResource.type, skill.generatesResource.amount);
+            debugLogEngine.log('SkillEffectProcessor', `[${skill.generatesResource.type}] ${skill.generatesResource.amount} 생산`);
+        }
+
+        // 클래스 및 속성 특화 보너스 적용
+        this._applySpecializationBonuses(unit, skill);
+        
+        // 상태 효과 적용
+        if (skill.effect) {
+            this._applyStatusEffects(unit, target, skill, blackboard);
+        }
+    }
+
+    async _processOffensiveSkill(unit, target, skill, instanceId, grade) {
+        spriteEngine.changeSpriteForDuration(unit, 'attack', 600);
+        await this.animationEngine.attack(unit.sprite, target.sprite);
+        spriteEngine.changeSpriteForDuration(target, 'hitted', 300);
+
+        if (skill.type !== 'ACTIVE') return;
+
+        const { damage: totalDamage, hitType, comboCount } = combatCalculationEngine.calculateDamage(unit, target, skill, instanceId, grade);
+        
+        const damageToBarrier = Math.min(target.currentBarrier, totalDamage);
+        const damageToHp = totalDamage - damageToBarrier;
+
+        if (damageToBarrier > 0) {
+            target.currentBarrier -= damageToBarrier;
+            this.vfxManager.createDamageNumber(target.sprite.x, target.sprite.y - 10, damageToBarrier, '#ffd700', hitType);
+        }
+        if (damageToHp > 0) {
+            target.currentHp -= damageToHp;
+            this.vfxManager.createDamageNumber(target.sprite.x, target.sprite.y + 10, damageToHp, '#ff4d4d', hitType);
+        }
+
+        this.vfxManager.showComboCount(comboCount);
+        this.vfxManager.createBloodSplatter(target.sprite.x, target.sprite.y);
+
+        if (skill.generatesToken && Math.random() < skill.generatesToken.chance) {
+            tokenEngine.addTokens(unit.uniqueId, skill.generatesToken.amount, `${skill.name} 효과`);
+        }
+        if (skill.turnOrderEffect === 'pushToBack' && this.battleSimulator) {
+            this.battleSimulator.turnQueue = turnOrderManager.pushToBack(this.battleSimulator.turnQueue, target);
+        }
+        if (skill.push > 0) {
+            await formationEngine.pushUnit(target, unit, skill.push, this.animationEngine);
+        }
+        if (skill.restoresBarrierPercent && unit.maxBarrier > 0) {
+            const healAmount = Math.round(unit.maxBarrier * skill.restoresBarrierPercent);
+            unit.currentBarrier = Math.min(unit.maxBarrier, unit.currentBarrier + healAmount);
+            this.vfxManager.createDamageNumber(unit.sprite.x, unit.sprite.y - 10, `+${healAmount}`, '#ffd700', '배리어');
+        }
+
+        if (target.currentHp <= 0) {
+            this.terminationManager.handleUnitDeath(target);
+        }
+    }
+
+    async _processAidSkill(unit, target, skill) {
+        spriteEngine.changeSpriteForDuration(unit, 'cast', 600);
+        if (target.isHealingProhibited) {
+            debugLogEngine.log('SkillEffectProcessor', `${target.instanceName}은(는) 치료 금지 상태라 회복 불가!`);
+            return;
+        }
+
+        const healAmount = Math.round(unit.finalStats.wisdom * (skill.healMultiplier || 0));
+        if (healAmount > 0) {
+            target.currentHp = Math.min(target.finalStats.hp, target.currentHp + healAmount);
+            this.vfxManager.createDamageNumber(target.sprite.x, target.sprite.y, `+${healAmount}`, '#22c55e');
+        }
+
+        if (skill.removesDebuff && Math.random() < skill.removesDebuff.chance) {
+            statusEffectManager.removeOneDebuff(target);
+        }
+    }
+
+    async _processSummonSkill(unit, skill) {
+        spriteEngine.changeSpriteForDuration(unit, 'cast', 600);
+        this.summoningEngine.summon(unit, skill);
+    }
+
+    _applySpecializationBonuses(unit, skill) {
+        const specializations = classSpecializations[unit.id] || [];
+        skill.tags.forEach(tag => {
+            const spec = specializations.find(s => s.tag === tag);
+            if (spec) {
+                statusEffectManager.addEffect(unit, { name: `특화 보너스: ${spec.tag}`, effect: spec.effect }, unit);
+                debugLogEngine.log('SkillEffectProcessor', `${unit.instanceName}가 특화 태그 [${spec.tag}] 보너스 획득!`);
+            }
+        });
+
+        if (unit.attributeSpec && skill.tags.includes(unit.attributeSpec.tag)) {
+            statusEffectManager.addEffect(unit, { name: `속성 특화: ${unit.attributeSpec.tag}`, effect: unit.attributeSpec.effect }, unit);
+            debugLogEngine.log('SkillEffectProcessor', `${unit.instanceName}가 속성 특화 태그 [${unit.attributeSpec.tag}] 보너스 획득!`);
+        }
+    }
+    
+    _applyStatusEffects(unit, target, skill, blackboard) {
+        const baseTargets = [target];
+        // 다중 타겟 처리
+        if (skill.numberOfTargets && skill.numberOfTargets > 1) {
+            const enemyUnits = blackboard.get('enemyUnits')?.filter(e => e.currentHp > 0 && e.uniqueId !== target.uniqueId) || [];
+            if (enemyUnits.length > 0) {
+                 let farthestEnemies = [];
+                let maxDist = -1;
+                enemyUnits.forEach(enemy => {
+                    const dist = Math.abs(unit.gridX - enemy.gridX) + Math.abs(unit.gridY - enemy.gridY);
+                    if (dist > maxDist) {
+                        maxDist = dist;
+                        farthestEnemies = [enemy];
+                    } else if (dist === maxDist) {
+                        farthestEnemies.push(enemy);
+                    }
+                });
+                if (farthestEnemies.length > 0) {
+                    const secondTarget = farthestEnemies.sort((a, b) => a.currentHp - b.currentHp)[0];
+                    if (secondTarget) baseTargets.push(secondTarget);
+                }
+            }
+        }
+    
+        baseTargets.forEach(currentTarget => {
+            const roll = Math.random();
+            if (skill.effect.chance === undefined || roll < skill.effect.chance) {
+                statusEffectManager.addEffect(currentTarget, skill, unit);
+            } else {
+                debugLogEngine.log('SkillEffectProcessor', `[${skill.name}]의 효과 발동 실패 (확률: ${skill.effect.chance}, 주사위: ${roll.toFixed(2)})`);
+            }
+        });
+    }
+}
+
+export default SkillEffectProcessor;


### PR DESCRIPTION
## Summary
- introduce `SkillEffectProcessor` to handle skill damage, healing and effects
- refactor `UseSkillNode` to delegate processing to new processor

## Testing
- `node tests/movement_stat_test.js`
- `node tests/critical_shot_skill_integration_test.js`
- `node tests/flyingmen_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `node tests/medic_skill_integration_test.js`
- `node tests/nanomancer_skill_integration_test.js`
- `node tests/proficiency_specialization_test.js`
- `node tests/summon_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688b7233053883278609b32d4c40e0f8