### PR TITLE
Fix AI skill usage and behavior flows

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -2,7 +2,6 @@ import BehaviorTree from '../BehaviorTree.js';
 import SelectorNode from '../nodes/SelectorNode.js';
 import SequenceNode from '../nodes/SequenceNode.js';
 import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
-import SuccessNode from '../nodes/SuccessNode.js';
 import { NodeState } from '../nodes/Node.js';
 
 import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
@@ -50,9 +49,7 @@ function createMeleeAI(engines = {}) {
             new FindMeleeStrategicTargetNode(engines),
             new FindPathToTargetNode(engines),
             new MoveToTargetNode(engines)
-        ]),
-        // 3. 아무것도 할 수 없으면 턴 종료
-        new SuccessNode()
+        ])
     ]);
 
     // --- MBTI 기반 특수 행동들 ---

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -2,7 +2,6 @@ import BehaviorTree from '../BehaviorTree.js';
 import SelectorNode from '../nodes/SelectorNode.js';
 import SequenceNode from '../nodes/SequenceNode.js';
 import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
-import SuccessNode from '../nodes/SuccessNode.js';
 
 import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
@@ -40,8 +39,7 @@ function createRangedAI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
-        ]),
-        new SuccessNode()
+        ])
     ]);
 
     // --- MBTI 기반 특수 행동들 ---

--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -7,6 +7,7 @@ import { debugSkillExecutionManager } from '../../game/debug/DebugSkillExecution
 import { classProficiencies } from '../../game/data/classProficiencies.js';
 import { diceEngine } from '../../game/utils/DiceEngine.js';
 import SkillEffectProcessor from '../../game/utils/SkillEffectProcessor.js'; // 새로 만든 클래스를 import
+import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 
 class UseSkillNode extends Node {
     constructor(engines = {}) {


### PR DESCRIPTION
## Summary
- import debugLogEngine in UseSkillNode
- remove SuccessNode usage in melee/ranged AI behaviors
- confirm flyingmen can't end movement on occupied tiles

## Testing
- `for f in tests/*_test.js; do node $f || exit 1; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688bad6430ec832793cb08806fd22c23