### PR TITLE
Fix healer AI behavior and adjust unit AI assignment

### DIFF
--- a/src/ai/behaviors/createFlyingmanAI.js
+++ b/src/ai/behaviors/createFlyingmanAI.js
@@ -2,7 +2,6 @@ import BehaviorTree from '../BehaviorTree.js';
 import SelectorNode from '../nodes/SelectorNode.js';
 import SequenceNode from '../nodes/SequenceNode.js';
 import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
-import SuccessNode from '../nodes/SuccessNode.js';
 
 // 신규 및 기존 노드 import
 import CanUseSkillBySlotNode from '../nodes/CanUseSkillBySlotNode.js';
@@ -50,9 +49,7 @@ function createFlyingmanAI(engines = {}) {
             new FindPriorityTargetNode(engines),
             new FindPathToTargetNode(engines),
             new MoveToTargetNode(engines)
-        ]),
-
-        // new SuccessNode(),
+        ])
     ]);
 
     return new BehaviorTree(rootNode);

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -2,7 +2,6 @@ import BehaviorTree from '../BehaviorTree.js';
 import SelectorNode from '../nodes/SelectorNode.js';
 import SequenceNode from '../nodes/SequenceNode.js';
 import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
-import SuccessNode from '../nodes/SuccessNode.js';
 
 import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
@@ -41,8 +40,7 @@ function createHealerAI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
-        ]),
-        new SuccessNode()
+        ])
     ]);
     
     // ... MBTI 기반 특수 행동 로직 (필요 시 여기에 추가) ...

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -120,16 +120,15 @@ export class BattleSimulatorEngine {
         this._setupUnits(allUnits);
 
         allUnits.forEach(unit => {
-            // ✨ [수정] 거너와 나노맨서가 모두 원거리 AI를 사용하도록 조건을 통합합니다.
-            if (unit.name === '거너' || unit.name === '나노맨서') {
+            if (unit.name === '거너') {
+                aiManager.registerUnit(unit, createRangedAI(this.aiEngines));
+            } else if (unit.name === '나노맨서') {
                 aiManager.registerUnit(unit, createRangedAI(this.aiEngines));
             } else if (unit.name === '전사' || unit.name === '좀비') {
                 aiManager.registerUnit(unit, createMeleeAI(this.aiEngines));
             } else if (unit.name === '메딕') {
-                // ✨ 메딕 AI 등록 로직 추가
                 aiManager.registerUnit(unit, createHealerAI(this.aiEngines));
             } else if (unit.name === '플라잉맨') {
-                // ✨ 플라잉맨 AI 등록
                 aiManager.registerUnit(unit, createFlyingmanAI(this.aiEngines));
             }
         });


### PR DESCRIPTION
## Summary
- assign Nanomancer and Medic explicitly to proper AIs
- streamline Healer AI logic and remove SuccessNode
- drop SuccessNode from Flyingman AI

## Testing
- `node tests/movement_stat_test.js`
- `for f in tests/*_test.js; do node $f; done`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688bb386837483279074435dc68af517