### PR TITLE
Add equipment card slots in unit detail

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -427,7 +427,11 @@ body {
 
 /* equipment-grid는 오른쪽 영역을 차지하게 됩니다. */
 .equipment-grid {
-    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+    justify-items: center;
+    margin-top: 10px;
 }
 
 .stat-item {
@@ -444,11 +448,25 @@ body {
 }
 
 .equip-slot {
-    height: 50px;
+    width: 80px;
+    height: 100px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.equip-slot-image {
+    width: 70px;
+    height: 70px;
     background-color: rgba(0,0,0,0.3);
-    border: 1px solid #444;
-    margin-bottom: 8px;
-    border-radius: 4px;
+    border: 2px dashed #555;
+    border-radius: 5px;
+}
+
+.equip-slot-label {
+    margin-top: 6px;
+    font-size: 14px;
+    color: #aaa;
 }
 
 .detail-footer {
@@ -478,7 +496,14 @@ body {
     flex-direction: column;
     gap: 15px;
     width: 100%;
+    margin-bottom: 20px;
 }
+
+/* --- 장비 카드 섹션 스타일 --- */
+.equipment-section {
+    width: 100%;
+}
+
 
 .unit-skills .skill-grid {
     display: flex;

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -221,6 +221,41 @@ export class UnitDetailDOM {
 
         rightSection.appendChild(skillsContainer);
 
+        // --- ▼ 장비 카드 섹션 추가 ▼ ---
+        const equipmentSection = document.createElement('div');
+        equipmentSection.className = 'equipment-section';
+        equipmentSection.innerHTML = `<div class="section-title">장비 카드</div>`;
+
+        const equipmentGrid = document.createElement('div');
+        equipmentGrid.className = 'equipment-grid';
+
+        const equipSlots = [
+            { label: '무기' },
+            { label: '갑옷' },
+            { label: '악세사리1' },
+            { label: '악세사리2' }
+        ];
+
+        equipSlots.forEach(slotInfo => {
+            const slot = document.createElement('div');
+            slot.className = 'equip-slot';
+
+            const slotImage = document.createElement('div');
+            slotImage.className = 'equip-slot-image';
+
+            const slotLabel = document.createElement('div');
+            slotLabel.className = 'equip-slot-label';
+            slotLabel.innerText = slotInfo.label;
+
+            slot.appendChild(slotImage);
+            slot.appendChild(slotLabel);
+            equipmentGrid.appendChild(slot);
+        });
+
+        equipmentSection.appendChild(equipmentGrid);
+        rightSection.appendChild(equipmentSection);
+        // --- ▲ 장비 카드 섹션 추가 ▲ ---
+
         detailContent.appendChild(leftSection);
         detailContent.appendChild(rightSection);
         detailPane.appendChild(detailContent);


### PR DESCRIPTION
## Summary
- expand unit detail panel with an equipment card section
- style new equipment slots and update skill container spacing

## Testing
- `for f in tests/*.js; do node $f; done`
- `python3 -m http.server 8001 &` and `curl http://localhost:8001/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688bd5e14af8832785f3abc77d9f0b93