### PR TITLE
Add equipment management scene skeleton

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -747,6 +747,21 @@ body {
     display: none;
 }
 
+/* --- 장비 관리 씬 스타일 --- */
+#equipment-management-container {
+    /* skill-management-container와 동일한 스타일을 공유 */
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    background-size: cover;
+    background-position: center;
+    pointer-events: auto;
+    display: none;
+}
+
 #skill-main-layout {
     display: flex;
     justify-content: center;
@@ -1725,4 +1740,29 @@ body {
 .stat-item:not([data-tooltip]):hover::after,
 .stat-item:not([data-tooltip]):hover::before {
     display: none;
+}
+
+/* --- 장비 관리 씬 전용 스타일 --- */
+.merc-equipment-slots-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 15px;
+    margin-top: 20px;
+}
+
+.merc-equip-slot {
+    width: 250px;
+    height: 50px;
+    background-color: rgba(0, 0, 0, 0.4);
+    border: 2px solid #666;
+    border-radius: 5px;
+    display: flex;
+    align-items: center;
+    padding: 0 15px;
+    font-size: 16px;
+    color: #ccc;
+}
+.merc-equip-slot:hover {
+    border-color: #fff;
 }

--- a/src/game/dom/EquipmentManagementDOMEngine.js
+++ b/src/game/dom/EquipmentManagementDOMEngine.js
@@ -1,0 +1,123 @@
+import { mercenaryEngine } from '../utils/MercenaryEngine.js';
+import { partyEngine } from '../utils/PartyEngine.js';
+import { UnitDetailDOM } from './UnitDetailDOM.js';
+import { equipmentManager } from '../utils/EquipmentManager.js';
+
+export class EquipmentManagementDOMEngine {
+    constructor(scene) {
+        this.scene = scene;
+        this.container = document.createElement('div');
+        this.container.id = 'equipment-management-container';
+        // 스킬 관리 씬과 동일한 스타일 클래스 적용
+        this.container.className = 'skill-management-container';
+        document.getElementById('app').appendChild(this.container);
+
+        this.selectedMercenaryData = null;
+        this.createView();
+    }
+
+    createView() {
+        this.container.style.display = 'block';
+        this.container.style.backgroundImage = 'url(assets/images/territory/inventory-scene.png)';
+
+        const mainLayout = document.createElement('div');
+        mainLayout.id = 'skill-main-layout';
+        this.container.appendChild(mainLayout);
+
+        const listPanel = this.createPanel('merc-list-panel', '출정 용병');
+        mainLayout.appendChild(listPanel);
+        this.mercenaryListContent = listPanel.querySelector('.panel-content');
+
+        const detailsPanel = this.createPanel('merc-details-panel', '용병 장비 슬롯');
+        mainLayout.appendChild(detailsPanel);
+        this.mercenaryDetailsContent = detailsPanel.querySelector('.panel-content');
+
+        const inventoryPanel = this.createPanel('equipment-inventory-panel', '장비 인벤토리');
+        mainLayout.appendChild(inventoryPanel);
+        this.equipmentInventoryContent = inventoryPanel.querySelector('.panel-content');
+        this.equipmentInventoryContent.innerHTML = '<p style="text-align: center; color: #888; margin-top: 20px;">장비가 없습니다.</p>';
+
+        this.populateMercenaryList();
+
+        const backButton = document.createElement('div');
+        backButton.id = 'skill-back-button';
+        backButton.innerText = '← 영지로';
+        backButton.onclick = () => this.scene.scene.start('TerritoryScene');
+        this.container.appendChild(backButton);
+    }
+
+    createPanel(id, title) {
+        const panel = document.createElement('div');
+        panel.id = id;
+        panel.className = 'skill-panel';
+        panel.innerHTML = `<div class="panel-title">${title}</div><div class="panel-content"></div>`;
+        return panel;
+    }
+
+    populateMercenaryList() {
+        this.mercenaryListContent.innerHTML = '';
+        const partyMembers = partyEngine.getPartyMembers().filter(id => id !== undefined);
+        const allMercs = mercenaryEngine.getAllAlliedMercenaries();
+
+        partyMembers.forEach(id => {
+            const merc = allMercs.find(m => m.uniqueId === id);
+            if (merc) {
+                const item = document.createElement('div');
+                item.className = 'merc-list-item';
+                item.innerText = merc.instanceName;
+                item.dataset.mercId = merc.uniqueId;
+                item.onclick = () => this.selectMercenary(merc);
+                this.mercenaryListContent.appendChild(item);
+            }
+        });
+
+        if (partyMembers.length > 0) {
+            const first = allMercs.find(m => m.uniqueId === partyMembers[0]);
+            if (first) this.selectMercenary(first);
+        }
+    }
+
+    selectMercenary(mercData) {
+        this.selectedMercenaryData = mercData;
+        // ... (선택된 용병 하이라이트 로직은 스킬 관리와 동일) ...
+        this.refreshMercenaryDetails();
+    }
+
+    refreshMercenaryDetails() {
+        if (!this.selectedMercenaryData) {
+            this.mercenaryDetailsContent.innerHTML = '<p>용병을 선택하세요.</p>';
+            return;
+        }
+        const mercData = this.selectedMercenaryData;
+        this.mercenaryDetailsContent.innerHTML = '';
+
+        const portrait = document.createElement('div');
+        portrait.className = 'merc-portrait-small';
+        portrait.style.backgroundImage = `url(${mercData.uiImage})`;
+        portrait.onclick = () => document.body.appendChild(UnitDetailDOM.create(mercData));
+        this.mercenaryDetailsContent.appendChild(portrait);
+
+        const slotsContainer = document.createElement('div');
+        slotsContainer.className = 'merc-equipment-slots-container';
+
+        const equipSlotLabels = ['무기', '갑옷', '악세사리1', '악세사리2'];
+        const equippedItems = equipmentManager.getEquippedItems(mercData.uniqueId);
+
+        equipSlotLabels.forEach((label, idx) => {
+            const slot = document.createElement('div');
+            slot.className = 'merc-equip-slot';
+
+            const slotLabel = document.createElement('span');
+            slotLabel.innerText = label;
+            slot.appendChild(slotLabel);
+
+            slotsContainer.appendChild(slot);
+        });
+
+        this.mercenaryDetailsContent.appendChild(slotsContainer);
+    }
+
+    destroy() {
+        this.container.remove();
+    }
+}

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -35,6 +35,8 @@ export class TerritoryDOMEngine {
         this.addSkillManagementButton(1, 1);
         // --- ✨ [신규] 선조 소환 관리 버튼 추가 ---
         this.addSummonManagementButton(2, 1); // 스킬 관리 옆에 배치
+        // ✨ [신규] 장비 관리 아이콘을 추가합니다.
+        this.addEquipmentManagementButton(1, 2); // 비어있는 (1, 2) 슬롯에 추가
         this.addArenaButton(0, 2); // 아레나 아이콘 추가
     }
 
@@ -152,6 +154,22 @@ export class TerritoryDOMEngine {
             this.container.style.display = 'none';
             // ✨ SummonManagementScene을 시작합니다.
             this.scene.scene.start('SummonManagementScene');
+        });
+        this.grid.appendChild(button);
+    }
+
+    // ✨ [신규] 장비 관리 버튼 추가 메소드
+    addEquipmentManagementButton(col, row) {
+        const button = document.createElement('div');
+        button.className = 'building-icon';
+        button.style.backgroundImage = `url(assets/images/territory/inventory-icon.png)`;
+        button.style.gridColumnStart = col + 1;
+        button.style.gridRowStart = row + 1;
+        button.addEventListener('mouseover', (event) => this.domEngine.showTooltip(event.clientX, event.clientY, '[장비 관리]'));
+        button.addEventListener('mouseout', () => this.domEngine.hideTooltip());
+        button.addEventListener('click', () => {
+            this.container.style.display = 'none';
+            this.scene.scene.start('EquipmentManagementScene');
         });
         this.grid.appendChild(button);
     }

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -15,6 +15,8 @@ import { CursedForestBattleScene } from './CursedForestBattleScene.js';
 import { SkillManagementScene } from './SkillManagementScene.js';
 // ✨ SummonManagementScene을 import 합니다.
 import { SummonManagementScene } from './SummonManagementScene.js';
+// ✨ EquipmentManagementScene을 import합니다.
+import { EquipmentManagementScene } from './EquipmentManagementScene.js';
 import { ArenaScene } from './ArenaScene.js';
 import { ArenaBattleScene } from './ArenaBattleScene.js';
 
@@ -48,6 +50,8 @@ export class Boot extends Scene
         this.scene.add('SkillManagementScene', SkillManagementScene);
         // ✨ 새로 만든 씬을 추가합니다.
         this.scene.add('SummonManagementScene', SummonManagementScene);
+        // ✨ 장비 관리 씬을 추가합니다.
+        this.scene.add('EquipmentManagementScene', EquipmentManagementScene);
         this.scene.add('ArenaScene', ArenaScene);
         this.scene.add('ArenaBattleScene', ArenaBattleScene);
 

--- a/src/game/scenes/EquipmentManagementScene.js
+++ b/src/game/scenes/EquipmentManagementScene.js
@@ -1,0 +1,24 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { DOMEngine } from '../utils/DOMEngine.js';
+import { EquipmentManagementDOMEngine } from '../dom/EquipmentManagementDOMEngine.js';
+
+export class EquipmentManagementScene extends Scene {
+    constructor() {
+        super('EquipmentManagementScene');
+        this.equipmentDomEngine = null;
+    }
+
+    create() {
+        const territoryContainer = document.getElementById('territory-container');
+        if (territoryContainer) {
+            territoryContainer.style.display = 'none';
+        }
+
+        const domEngine = new DOMEngine(this);
+        this.equipmentDomEngine = new EquipmentManagementDOMEngine(this);
+
+        this.events.on('shutdown', () => {
+            this.equipmentDomEngine.destroy();
+        });
+    }
+}

--- a/src/game/utils/EquipmentManager.js
+++ b/src/game/utils/EquipmentManager.js
@@ -1,0 +1,59 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 각 용병이 장착한 장비를 관리하는 매니저
+ * 장비 인스턴스 ID를 저장합니다.
+ */
+class EquipmentManager {
+    constructor() {
+        // key: unitId => [weaponId, armorId, acc1Id, acc2Id]
+        this.equippedItems = new Map();
+        debugLogEngine.log('EquipmentManager', '장비 관리 매니저가 초기화되었습니다.');
+    }
+
+    initializeSlots(unitId) {
+        if (!this.equippedItems.has(unitId)) {
+            // [무기, 갑옷, 악세사리1, 악세사리2] 슬롯
+            this.equippedItems.set(unitId, [null, null, null, null]);
+        }
+    }
+
+    /**
+     * 용병의 특정 슬롯에 장비를 장착합니다.
+     * @param {number} unitId
+     * @param {number} slotIndex
+     * @param {number} instanceId
+     * @returns {number|null} 기존 장비 인스턴스 ID
+     */
+    equipItem(unitId, slotIndex, instanceId) {
+        this.initializeSlots(unitId);
+        const slots = this.equippedItems.get(unitId);
+        if (slotIndex < 0 || slotIndex >= slots.length) return null;
+
+        const prev = slots[slotIndex];
+        slots[slotIndex] = instanceId;
+        console.log(`[EquipmentManager] 유닛 ${unitId}의 ${slotIndex}번 슬롯에 장비 ${instanceId} 장착. 이전 장비: ${prev}`);
+        return prev;
+    }
+
+    /**
+     * 장착 해제
+     */
+    unequipItem(unitId, slotIndex) {
+        if (!this.equippedItems.has(unitId)) return null;
+        const slots = this.equippedItems.get(unitId);
+        if (slotIndex < 0 || slotIndex >= slots.length) return null;
+
+        const removed = slots[slotIndex];
+        slots[slotIndex] = null;
+        console.log(`[EquipmentManager] 유닛 ${unitId}의 ${slotIndex}번 슬롯에서 장비 ${removed} 해제.`);
+        return removed;
+    }
+
+    getEquippedItems(unitId) {
+        this.initializeSlots(unitId);
+        return this.equippedItems.get(unitId);
+    }
+}
+
+export const equipmentManager = new EquipmentManager();


### PR DESCRIPTION
## Summary
- add `EquipmentManager` utility for per-unit gear slots
- create `EquipmentManagementScene` and DOM engine
- register the new scene in Boot and add a button on the territory screen
- apply UI styles for equipment management slots

## Testing
- `node tests/critical_shot_skill_integration_test.js && node tests/flyingmen_skill_integration_test.js && node tests/gunner_skill_integration_test.js && node tests/medic_skill_integration_test.js && node tests/mighty_shield_skill_test.js && node tests/movement_stat_test.js && node tests/nanomancer_skill_integration_test.js && node tests/proficiency_specialization_test.js && node tests/summon_skill_integration_test.js && node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688bd90b4a3483278163b25226e506a9