### PR TITLE
Add baseball bat item and factory tests

### DIFF
--- a/src/game/data/items.js
+++ b/src/game/data/items.js
@@ -1,0 +1,70 @@
+/**
+ * 게임에 등장하는 모든 아이템의 기본 데이터와
+ * 무작위로 부여될 수 있는 접두사, 접미사를 정의하는 파일
+ */
+
+// 아이템이 장착될 수 있는 부위 정의
+export const EQUIPMENT_SLOTS = {
+    WEAPON: '무기',
+    ARMOR: '갑옷',
+    ACCESSORY: '장신구'
+};
+
+// 1. 장비 기본 스탯 데이터베이스
+export const itemBaseData = {
+    // --- 무기 ---
+    axe: {
+        id: 'axe',
+        name: '도끼',
+        type: EQUIPMENT_SLOTS.WEAPON,
+        illustrationPath: 'assets/images/item/throwing-axe.png',
+        baseStats: {
+            physicalAttack: { min: 8, max: 12 }
+        },
+        weight: 10
+    },
+    baseballBat: {
+        id: 'baseballBat',
+        name: '야구 방망이',
+        type: EQUIPMENT_SLOTS.WEAPON,
+        illustrationPath: 'assets/images/item/baseball-bat.png',
+        baseStats: {
+            physicalAttack: { min: 6, max: 9 }
+        },
+        weight: 8
+    },
+
+    // --- 방어구 ---
+    plateArmor: {
+        id: 'plateArmor',
+        name: '판금 갑옷',
+        type: EQUIPMENT_SLOTS.ARMOR,
+        illustrationPath: 'assets/images/item/plate-armor.png',
+        baseStats: {
+            physicalDefense: { min: 15, max: 20 },
+            hp: { min: 20, max: 30 }
+        },
+        weight: 25
+    }
+};
+
+// 2. 장비 접두사/접미사 부가 스탯 데이터베이스
+export const itemAffixes = {
+    // --- 접두사 (주로 공격, 성능 관련) ---
+    prefixes: [
+        { name: '날카로운', stat: 'criticalChance', value: { min: 3, max: 5 } },
+        { name: '파괴적인', stat: 'criticalDamageMultiplier', value: { min: 10, max: 15 } },
+        { name: '맹공의', stat: 'physicalAttack', value: { min: 5, max: 8 }, isPercentage: true },
+        { name: '마력의', stat: 'magicAttack', value: { min: 5, max: 8 }, isPercentage: true },
+        { name: '정밀한', stat: 'accuracy', value: { min: 5, max: 10 } }
+    ],
+
+    // --- 접미사 (주로 방어, 유틸리티 관련) ---
+    suffixes: [
+        { name: '견고함의', stat: 'physicalDefense', value: { min: 5, max: 8 }, isPercentage: true },
+        { name: '회피의', stat: 'physicalEvadeChance', value: { min: 3, max: 5 } },
+        { name: '재생의', stat: 'hpRegen', value: { min: 5, max: 10 } },
+        { name: '흡혈의', stat: 'lifeSteal', value: { min: 2, max: 4 } },
+        { name: '끈기의', stat: 'aspirationDecayReduction', value: { min: 10, max: 15 } }
+    ]
+};

--- a/src/game/utils/ItemFactory.js
+++ b/src/game/utils/ItemFactory.js
@@ -1,0 +1,67 @@
+import { itemBaseData, itemAffixes } from '../data/items.js';
+import { uniqueIDManager } from './UniqueIDManager.js';
+import { diceEngine } from './DiceEngine.js';
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 아이템 데이터를 기반으로 고유한 아이템 인스턴스를 생성하는 공장 클래스
+ */
+class ItemFactory {
+    constructor() {
+        this.name = 'ItemFactory';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 지정된 ID의 기본 아이템에 무작위 접두사/접미사를 붙여 새로운 아이템을 생성합니다.
+     * @param {string} baseItemId - 생성할 아이템의 ID
+     * @returns {object|null} - 생성된 아이템 인스턴스 또는 null
+     */
+    createItem(baseItemId) {
+        const baseData = itemBaseData[baseItemId];
+        if (!baseData) {
+            debugLogEngine.error(this.name, `'${baseItemId}'에 해당하는 아이템 기본 데이터를 찾을 수 없습니다.`);
+            return null;
+        }
+
+        // 1. 랜덤 접두사, 접미사 선택
+        const prefix = diceEngine.getRandomElement(itemAffixes.prefixes);
+        const suffix = diceEngine.getRandomElement(itemAffixes.suffixes);
+
+        // 2. 최종 아이템 객체 생성
+        const newItem = {
+            instanceId: uniqueIDManager.getNextId(),
+            baseId: baseItemId,
+            name: `${prefix.name} ${baseData.name} ${suffix.name}`,
+            type: baseData.type,
+            illustrationPath: baseData.illustrationPath,
+            stats: {},
+            weight: baseData.weight
+        };
+
+        // 3. 기본 스탯 적용 (범위 내에서 랜덤 값 부여)
+        for (const [stat, range] of Object.entries(baseData.baseStats)) {
+            newItem.stats[stat] = this._getRandomValue(range.min, range.max);
+        }
+
+        // 4. 접두사/접미사 스탯 적용
+        [prefix, suffix].forEach(affix => {
+            const value = this._getRandomValue(affix.value.min, affix.value.max);
+            const statKey = affix.isPercentage ? `${affix.stat}Percentage` : affix.stat;
+            newItem.stats[statKey] = (newItem.stats[statKey] || 0) + value;
+        });
+
+        debugLogEngine.log(this.name, `새 아이템 생성: [${newItem.name}] (ID: ${newItem.instanceId})`);
+        return newItem;
+    }
+
+    /**
+     * 최소값과 최대값 사이의 랜덤 정수를 반환하는 헬퍼 함수
+     * @private
+     */
+    _getRandomValue(min, max) {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+}
+
+export const itemFactory = new ItemFactory();

--- a/tests/item_factory_test.js
+++ b/tests/item_factory_test.js
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import { itemFactory } from '../src/game/utils/ItemFactory.js';
+import { itemBaseData, itemAffixes } from '../src/game/data/items.js';
+
+const prefixNames = itemAffixes.prefixes.map(p => p.name);
+const suffixNames = itemAffixes.suffixes.map(s => s.name);
+const baseRange = itemBaseData.baseballBat.baseStats.physicalAttack;
+
+for (let i = 0; i < 5; i++) {
+    const item = itemFactory.createItem('baseballBat');
+
+    // 이름에 접두사와 접미사가 포함되어 있는지 확인
+    const hasPrefix = prefixNames.some(name => item.name.startsWith(name));
+    const hasSuffix = suffixNames.some(name => item.name.endsWith(name));
+    assert(hasPrefix && hasSuffix, 'Prefix or suffix missing in item name');
+
+    // 기본 스탯 범위 검증
+    assert(item.stats.physicalAttack >= baseRange.min && item.stats.physicalAttack <= baseRange.max,
+        'Base stat out of range');
+
+    // 접두사와 접미사 스탯 적용 확인
+    const prefixData = itemAffixes.prefixes.find(p => item.name.startsWith(p.name));
+    const suffixData = itemAffixes.suffixes.find(s => item.name.endsWith(s.name));
+    const prefixKey = prefixData.isPercentage ? `${prefixData.stat}Percentage` : prefixData.stat;
+    const suffixKey = suffixData.isPercentage ? `${suffixData.stat}Percentage` : suffixData.stat;
+
+    assert(item.stats[prefixKey] >= prefixData.value.min && item.stats[prefixKey] <= prefixData.value.max,
+        'Prefix stat out of range');
+    assert(item.stats[suffixKey] >= suffixData.value.min && item.stats[suffixKey] <= suffixData.value.max,
+        'Suffix stat out of range');
+}
+
+console.log('Item factory tests passed.');


### PR DESCRIPTION
## Summary
- set up item database with baseball bat, axe and plate armor
- implement `ItemFactory` for randomized prefix/suffix equipment generation
- verify item creation through `item_factory_test`

## Testing
- `node tests/item_factory_test.js`
- `for f in tests/*_test.js; do node $f || break; done`
- `python3 -m http.server 8000 &> /tmp/http.log &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688be10dbe588327b03d460e5071da2b