### PR TITLE
Add MBTI grade effects to items

### DIFF
--- a/src/game/data/items.js
+++ b/src/game/data/items.js
@@ -1,6 +1,7 @@
 /**
  * 게임에 등장하는 모든 아이템의 기본 데이터와
- * 무작위로 부여될 수 있는 접두사, 접미사를 정의하는 파일
+ * 무작위로 부여될 수 있는 접두사, 접미사,
+ * 그리고 등급별로 적용 가능한 MBTI 특성 효과를 정의하는 파일
  */
 
 // 아이템이 장착될 수 있는 부위 정의
@@ -67,4 +68,16 @@ export const itemAffixes = {
         { name: '흡혈의', stat: 'lifeSteal', value: { min: 2, max: 4 } },
         { name: '끈기의', stat: 'aspirationDecayReduction', value: { min: 10, max: 15 } }
     ]
+};
+
+// --- ▼ [신규] MBTI 성향별 등급 효과 데이터베이스 ▼ ---
+export const mbtiGradeEffects = {
+    E: [{ trait: 'E', description: '외향형 장착 시, 주변 아군 수 비례 공격력 +{value}%', stat: 'physicalAttackPercentagePerAlly', value: { min: 1, max: 2 } }],
+    I: [{ trait: 'I', description: '내향형 장착 시, 스킬 토큰 소모량 -{value}%', stat: 'tokenCostReduction', value: { min: 5, max: 10 } }],
+    S: [{ trait: 'S', description: '감각형 장착 시, 명중률 +{value}', stat: 'accuracy', value: { min: 5, max: 10 } }],
+    N: [{ trait: 'N', description: '직관형 장착 시, 스킬 효과 지속시간 +{value}턴', stat: 'effectDuration', value: { min: 1, max: 1 } }],
+    T: [{ trait: 'T', description: '사고형 장착 시, 받는 치명타 피해량 -{value}%', stat: 'criticalDamageReduction', value: { min: 10, max: 15 } }],
+    F: [{ trait: 'F', description: '감정형 장착 시, 아군에게 주는 치유량 +{value}%', stat: 'healingGivenPercentage', value: { min: 5, max: 10 } }],
+    J: [{ trait: 'J', description: '판단형 장착 시, 모든 스킬 재사용 대기시간 -{value}턴', stat: 'cooldownReduction', value: { min: 1, max: 1 } }],
+    P: [{ trait: 'P', description: '인식형 장착 시, {value}% 확률로 토큰 미소모', stat: 'tokenFreeChance', value: { min: 5, max: 10 } }]
 };

--- a/tests/item_factory_test.js
+++ b/tests/item_factory_test.js
@@ -9,9 +9,10 @@ const baseRange = itemBaseData.baseballBat.baseStats.physicalAttack;
 for (let i = 0; i < 5; i++) {
     const item = itemFactory.createItem('baseballBat');
 
-    // 이름에 접두사와 접미사가 포함되어 있는지 확인
-    const hasPrefix = prefixNames.some(name => item.name.startsWith(name));
-    const hasSuffix = suffixNames.some(name => item.name.endsWith(name));
+    // 등급 태그를 제거한 뒤 접두사, 접미사 확인
+    const cleanedName = item.name.replace(/^\[[^\]]+\]\s*/, '');
+    const hasPrefix = prefixNames.some(name => cleanedName.startsWith(name));
+    const hasSuffix = suffixNames.some(name => cleanedName.endsWith(name));
     assert(hasPrefix && hasSuffix, 'Prefix or suffix missing in item name');
 
     // 기본 스탯 범위 검증
@@ -19,8 +20,8 @@ for (let i = 0; i < 5; i++) {
         'Base stat out of range');
 
     // 접두사와 접미사 스탯 적용 확인
-    const prefixData = itemAffixes.prefixes.find(p => item.name.startsWith(p.name));
-    const suffixData = itemAffixes.suffixes.find(s => item.name.endsWith(s.name));
+    const prefixData = itemAffixes.prefixes.find(p => cleanedName.startsWith(p.name));
+    const suffixData = itemAffixes.suffixes.find(s => cleanedName.endsWith(s.name));
     const prefixKey = prefixData.isPercentage ? `${prefixData.stat}Percentage` : prefixData.stat;
     const suffixKey = suffixData.isPercentage ? `${suffixData.stat}Percentage` : suffixData.stat;
 
@@ -28,6 +29,10 @@ for (let i = 0; i < 5; i++) {
         'Prefix stat out of range');
     assert(item.stats[suffixKey] >= suffixData.value.min && item.stats[suffixKey] <= suffixData.value.max,
         'Suffix stat out of range');
+
+    // MBTI 효과 및 등급 확인
+    assert.strictEqual(item.grade, 'NORMAL');
+    assert.strictEqual(item.mbtiEffects.length, 1);
 }
 
 console.log('Item factory tests passed.');


### PR DESCRIPTION
## Summary
- extend item database with MBTI grade bonuses
- upgrade `ItemFactory` to generate effects based on item grade
- update item factory unit tests for grade-aware names and MBTI effects

## Testing
- `node tests/item_factory_test.js`
- `for f in tests/*_test.js; do echo "Running $f"; node $f || exit 1; done`
- `python3 -m http.server 8000 & sleep 1 && curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688be1f4ac6083278c968576b3e803e8