### PR TITLE
Update item generation system

### DIFF
--- a/tests/item_factory_test.js
+++ b/tests/item_factory_test.js
@@ -9,30 +9,46 @@ const baseRange = itemBaseData.baseballBat.baseStats.physicalAttack;
 for (let i = 0; i < 5; i++) {
     const item = itemFactory.createItem('baseballBat');
 
-    // 등급 태그를 제거한 뒤 접두사, 접미사 확인
     const cleanedName = item.name.replace(/^\[[^\]]+\]\s*/, '');
     const hasPrefix = prefixNames.some(name => cleanedName.startsWith(name));
     const hasSuffix = suffixNames.some(name => cleanedName.endsWith(name));
-    assert(hasPrefix && hasSuffix, 'Prefix or suffix missing in item name');
 
     // 기본 스탯 범위 검증
     assert(item.stats.physicalAttack >= baseRange.min && item.stats.physicalAttack <= baseRange.max,
         'Base stat out of range');
 
-    // 접두사와 접미사 스탯 적용 확인
-    const prefixData = itemAffixes.prefixes.find(p => cleanedName.startsWith(p.name));
-    const suffixData = itemAffixes.suffixes.find(s => cleanedName.endsWith(s.name));
-    const prefixKey = prefixData.isPercentage ? `${prefixData.stat}Percentage` : prefixData.stat;
-    const suffixKey = suffixData.isPercentage ? `${suffixData.stat}Percentage` : suffixData.stat;
+    const optionCount =
+        (hasPrefix ? 1 : 0) +
+        (hasSuffix ? 1 : 0) +
+        (item.mbtiEffects.length > 0 ? 1 : 0) +
+        (item.sockets.length > 0 ? 1 : 0);
 
-    assert(item.stats[prefixKey] >= prefixData.value.min && item.stats[prefixKey] <= prefixData.value.max,
-        'Prefix stat out of range');
-    assert(item.stats[suffixKey] >= suffixData.value.min && item.stats[suffixKey] <= suffixData.value.max,
-        'Suffix stat out of range');
+    // NORMAL 등급은 정확히 하나의 랜덤 옵션만 가진다
+    assert.strictEqual(optionCount, 1, 'Incorrect number of options for NORMAL grade');
 
-    // MBTI 효과 및 등급 확인
+    if (hasPrefix) {
+        const prefixData = itemAffixes.prefixes.find(p => cleanedName.startsWith(p.name));
+        const statKey = prefixData.isPercentage ? `${prefixData.stat}Percentage` : prefixData.stat;
+        assert(item.stats[statKey] >= prefixData.value.min && item.stats[statKey] <= prefixData.value.max,
+            'Prefix stat out of range');
+    }
+
+    if (hasSuffix) {
+        const suffixData = itemAffixes.suffixes.find(s => cleanedName.endsWith(s.name));
+        const statKey = suffixData.isPercentage ? `${suffixData.stat}Percentage` : suffixData.stat;
+        assert(item.stats[statKey] >= suffixData.value.min && item.stats[statKey] <= suffixData.value.max,
+            'Suffix stat out of range');
+    }
+
+    if (item.mbtiEffects.length > 0) {
+        assert(item.mbtiEffects.length === 1, 'Unexpected number of MBTI effects');
+    }
+
+    if (item.sockets.length > 0) {
+        assert(item.sockets.length >= 1 && item.sockets.length <= 3, 'Socket count out of range');
+    }
+
     assert.strictEqual(item.grade, 'NORMAL');
-    assert.strictEqual(item.mbtiEffects.length, 1);
 }
 
 console.log('Item factory tests passed.');


### PR DESCRIPTION
## Summary
- refactor `ItemFactory` to assign a random set of options based on item grade
- update item factory tests for the new logic

## Testing
- `node tests/item_factory_test.js`
- `python3 -m http.server 8000 &> /tmp/http.log &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688be5d5a63c8327976132e429e5dbc1