### PR TITLE
feat: log stat changes when equipping items

### DIFF
--- a/src/game/debug/DebugEquipmentManager.js
+++ b/src/game/debug/DebugEquipmentManager.js
@@ -1,0 +1,36 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+import { statEngine } from '../utils/StatEngine.js';
+
+/**
+ * 장비 장착/해제 시 스탯 변화를 추적하고 기록하는 디버그 매니저
+ */
+class DebugEquipmentManager {
+    constructor() {
+        this.name = 'DebugEquipment';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 장비 변경 후 유닛의 최종 스탯을 로그로 출력합니다.
+     * @param {object} unit - 스탯이 변경된 유닛
+     * @param {string} action - 변경 원인 (예: '장착', '해제', '교체')
+     */
+    logStatChange(unit, action) {
+        if (!unit) return;
+
+        // 최신 스탯을 다시 계산합니다.
+        const finalStats = statEngine.calculateStats(unit, unit.baseStats, []);
+
+        console.groupCollapsed(
+            `%c[${this.name}]`,
+            `color: #f59e0b; font-weight: bold;`,
+            `'${unit.instanceName}' (ID: ${unit.uniqueId}) 스탯 업데이트 (${action})`
+        );
+
+        console.table(finalStats);
+
+        console.groupEnd();
+    }
+}
+
+export const debugEquipmentManager = new DebugEquipmentManager();

--- a/src/game/dom/EquipmentManagementDOMEngine.js
+++ b/src/game/dom/EquipmentManagementDOMEngine.js
@@ -61,7 +61,6 @@ export class EquipmentManagementDOMEngine {
         return panel;
     }
     
-    // ... populateMercenaryList, selectMercenary ...
     populateMercenaryList() {
         this.mercenaryListContent.innerHTML = '';
         const partyMembers = partyEngine.getPartyMembers().filter(id => id !== undefined);
@@ -121,7 +120,6 @@ export class EquipmentManagementDOMEngine {
         
         slotTypes.forEach((slotType, idx) => {
             const itemInstanceId = equippedItems[idx];
-            // 캐시 또는 인벤토리에서 아이템 정보 가져오기
             const item = itemInstanceId ? (equipmentManager.itemInstanceCache.get(itemInstanceId) || itemInventoryManager.getItem(itemInstanceId)) : null;
             const slot = this.createEquipSlot(slotType, slotLabels[idx], item);
             slotsContainer.appendChild(slot);
@@ -145,6 +143,18 @@ export class EquipmentManagementDOMEngine {
             slot.ondragstart = e => this.onDragStart(e, { source: 'slot', instanceId: item.instanceId, slotType: slotType });
             slot.onmouseenter = e => ItemTooltipManager.show(item, e);
             slot.onmouseleave = () => ItemTooltipManager.hide();
+
+            // 등급별 별 표시 추가
+            const gradeMap = { NORMAL: 1, RARE: 2, EPIC: 3, LEGENDARY: 4 };
+            const starsContainer = document.createElement('div');
+            starsContainer.className = 'grade-stars';
+            const starCount = gradeMap[item.grade] || 1;
+            for (let i = 0; i < starCount; i++) {
+                const starImg = document.createElement('img');
+                starImg.src = 'assets/images/territory/skill-card-star.png';
+                starsContainer.appendChild(starImg);
+            }
+            slot.appendChild(starsContainer);
         }
 
         const slotLabel = document.createElement('span');
@@ -173,6 +183,18 @@ export class EquipmentManagementDOMEngine {
             itemCard.ondragstart = e => this.onDragStart(e, { source: 'inventory', instanceId: item.instanceId });
             itemCard.onmouseenter = e => ItemTooltipManager.show(item, e);
             itemCard.onmouseleave = () => ItemTooltipManager.hide();
+
+            // 인벤토리 카드에도 등급별 별 표시 추가
+            const gradeMap = { NORMAL: 1, RARE: 2, EPIC: 3, LEGENDARY: 4 };
+            const starsContainer = document.createElement('div');
+            starsContainer.className = 'grade-stars';
+            const starCount = gradeMap[item.grade] || 1;
+            for (let i = 0; i < starCount; i++) {
+                const starImg = document.createElement('img');
+                starImg.src = 'assets/images/territory/skill-card-star.png';
+                starsContainer.appendChild(starImg);
+            }
+            itemCard.appendChild(starsContainer);
             
             this.equipmentInventoryContent.appendChild(itemCard);
         });
@@ -192,11 +214,10 @@ export class EquipmentManagementDOMEngine {
         const unitId = this.selectedMercenaryData.uniqueId;
         const draggedInstanceId = this.draggedData.instanceId;
 
-        // 아이템 스왑 로직
         if (this.draggedData.source === 'slot') {
             const sourceSlotType = this.draggedData.slotType;
             equipmentManager.swapItems(unitId, sourceSlotType, targetSlotType);
-        } else { // 인벤토리 -> 슬롯
+        } else { 
             equipmentManager.equipItem(unitId, targetSlotType, draggedInstanceId);
         }
         
@@ -220,6 +241,6 @@ export class EquipmentManagementDOMEngine {
 
     destroy() {
         this.container.remove();
-        ItemTooltipManager.hide(); // 씬 전환 시 툴팁 제거
+        ItemTooltipManager.hide();
     }
 }

--- a/src/game/utils/EquipmentManager.js
+++ b/src/game/utils/EquipmentManager.js
@@ -1,13 +1,13 @@
 import { debugLogEngine } from './DebugLogEngine.js';
 import { itemInventoryManager } from './ItemInventoryManager.js';
 import { EQUIPMENT_SLOTS } from '../data/items.js';
+import { debugEquipmentManager } from '../debug/DebugEquipmentManager.js';
+import { mercenaryEngine } from './MercenaryEngine.js';
 
 class EquipmentManager {
     constructor() {
         this.name = 'EquipmentManager';
-        // key: unitId => { WEAPON: null, ARMOR: null, ACCESSORY1: null, ACCESSORY2: null }
         this.equippedItems = new Map();
-        // 장착된 모든 아이템의 인스턴스 데이터를 임시 보관하여 소멸을 방지합니다.
         this.itemInstanceCache = new Map();
         debugLogEngine.register(this);
         debugLogEngine.log(this.name, '장비 관리 매니저가 초기화되었습니다.');
@@ -28,12 +28,9 @@ class EquipmentManager {
         this.initializeSlots(unitId);
         const slots = this.equippedItems.get(unitId);
 
-        // 인벤토리에서 장착할 아이템을 가져옵니다.
         const itemToEquip = itemInventoryManager.getItem(instanceId);
         if (!itemToEquip) return;
 
-        // --- ▼ [버그 수정] 아이템 타입 비교 로직 수정 ▼ ---
-        // 'ACCESSORY1' -> 'ACCESSORY'로 변환하여 비교 준비
         const baseSlotType = slotType.replace(/\d+$/, '');
         const requiredItemType = EQUIPMENT_SLOTS[baseSlotType];
 
@@ -41,15 +38,11 @@ class EquipmentManager {
             alert(`[${itemToEquip.type}] 아이템은 [${requiredItemType}] 슬롯에 장착할 수 없습니다.`);
             return;
         }
-        // --- ▲ [버그 수정] ▲ ---
 
-        // 인벤토리에서 아이템을 제거합니다.
         itemInventoryManager.removeItem(instanceId);
-        // 캐시에 아이템 데이터를 저장합니다.
         this.itemInstanceCache.set(instanceId, itemToEquip);
 
         const prevItemInstanceId = slots[slotType];
-        // 이전에 장착된 아이템이 있었다면 캐시에서 찾아 인벤토리로 되돌립니다.
         if (prevItemInstanceId) {
             const prevItem = this.itemInstanceCache.get(prevItemInstanceId);
             if (prevItem) {
@@ -60,6 +53,10 @@ class EquipmentManager {
 
         slots[slotType] = instanceId;
         debugLogEngine.log(this.name, `유닛 ${unitId}의 ${slotType} 슬롯에 아이템 ${instanceId} 장착.`);
+
+        // 스탯 변경 로그 출력
+        const unit = mercenaryEngine.getMercenaryById(unitId);
+        debugEquipmentManager.logStatChange(unit, `아이템 '${itemToEquip.name}' 장착`);
     }
 
     swapItems(unitId, sourceSlotType, targetSlotType) {
@@ -91,6 +88,10 @@ class EquipmentManager {
         slots[sourceSlotType] = targetId;
         slots[targetSlotType] = sourceId;
         debugLogEngine.log(this.name, `유닛 ${unitId}의 ${sourceSlotType}와 ${targetSlotType} 슬롯 아이템을 교체.`);
+
+        // 스탯 변경 로그 출력
+        const unit = mercenaryEngine.getMercenaryById(unitId);
+        debugEquipmentManager.logStatChange(unit, '아이템 교체');
     }
 
     unequipItem(unitId, slotType) {
@@ -99,7 +100,6 @@ class EquipmentManager {
         const itemInstanceId = slots[slotType];
 
         if (itemInstanceId) {
-            // 캐시에서 아이템을 찾아 인벤토리로 옮깁니다.
             const item = this.itemInstanceCache.get(itemInstanceId);
             if (item) {
                 itemInventoryManager.addItem(item);
@@ -107,6 +107,10 @@ class EquipmentManager {
             }
             slots[slotType] = null;
             debugLogEngine.log(this.name, `유닛 ${unitId}의 ${slotType} 슬롯에서 아이템 ${itemInstanceId} 해제.`);
+
+            // 스탯 변경 로그 출력
+            const unit = mercenaryEngine.getMercenaryById(unitId);
+            debugEquipmentManager.logStatChange(unit, `아이템 '${item.name}' 해제`);
         }
     }
 


### PR DESCRIPTION
## Summary
- add DebugEquipmentManager to log stat changes when equipment is updated
- show equipment grade stars in management UI
- log stat changes through EquipmentManager when items are equipped, swapped, or removed

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688c724e08a88327952cf917953caa56