### PR TITLE
feat: add MBTI-based auto equipment

### DIFF
--- a/src/game/dom/EquipmentManagementDOMEngine.js
+++ b/src/game/dom/EquipmentManagementDOMEngine.js
@@ -5,6 +5,8 @@ import { equipmentManager } from '../utils/EquipmentManager.js';
 import { itemInventoryManager } from '../utils/ItemInventoryManager.js';
 import { ItemTooltipManager } from './ItemTooltipManager.js';
 import { EQUIPMENT_SLOTS } from '../data/items.js';
+// 새로 만든 장비 자동 장착기를 불러옵니다.
+import { mercenaryEquipmentSelector } from '../utils/MercenaryEquipmentSelector.js';
 
 export class EquipmentManagementDOMEngine {
     constructor(scene) {
@@ -51,6 +53,30 @@ export class EquipmentManagementDOMEngine {
         backButton.innerText = '← 영지로';
         backButton.onclick = () => this.scene.scene.start('TerritoryScene');
         this.container.appendChild(backButton);
+
+        // 전원 자동장착 버튼 추가
+        const autoEquipButton = document.createElement('div');
+        autoEquipButton.id = 'auto-equip-all-items-button';
+        autoEquipButton.innerText = '[ 전원 자동장착 ]';
+        Object.assign(autoEquipButton.style, {
+            position: 'absolute',
+            top: '20px',
+            right: '20px',
+            padding: '8px 15px',
+            backgroundColor: 'rgba(240, 230, 140, 0.8)',
+            color: '#333',
+            border: '1px solid #f0e68c',
+            borderRadius: '5px',
+            cursor: 'pointer',
+            fontWeight: 'bold',
+            zIndex: '100'
+        });
+        autoEquipButton.onclick = () => {
+            mercenaryEquipmentSelector.autoEquipForParty();
+            this.refreshAll();
+            alert('모든 용병의 장비가 MBTI 성향에 따라 자동 장착되었습니다.');
+        };
+        this.container.appendChild(autoEquipButton);
     }
 
     createPanel(id, title) {
@@ -82,7 +108,8 @@ export class EquipmentManagementDOMEngine {
             const first = allMercs.find(m => m.uniqueId === partyMembers[0]);
             if (first) this.selectMercenary(first);
         } else if (this.selectedMercenaryData) {
-             this.selectMercenary(this.selectedMercenaryData);
+            const updatedMercData = mercenaryEngine.getMercenaryById(this.selectedMercenaryData.uniqueId);
+            if (updatedMercData) this.selectMercenary(updatedMercData);
         }
     }
     
@@ -98,7 +125,7 @@ export class EquipmentManagementDOMEngine {
 
     refreshMercenaryDetails() {
         if (!this.selectedMercenaryData) { this.mercenaryDetailsContent.innerHTML = '<p>용병을 선택하세요.</p>'; return; }
-        const mercData = this.selectedMercenaryData;
+        const mercData = mercenaryEngine.getMercenaryById(this.selectedMercenaryData.uniqueId);
         this.mercenaryDetailsContent.innerHTML = '';
 
         const portrait = document.createElement('div');
@@ -234,8 +261,10 @@ export class EquipmentManagementDOMEngine {
     }
 
     refreshAll() {
-        this.refreshMercenaryDetails();
         this.refreshInventory();
+        if (this.selectedMercenaryData) {
+            this.selectMercenary(this.selectedMercenaryData);
+        }
         this.draggedData = null;
     }
 

--- a/src/game/utils/ArenaManager.js
+++ b/src/game/utils/ArenaManager.js
@@ -5,6 +5,9 @@ import { ownedSkillsManager } from './OwnedSkillsManager.js';
 import { mercenaryCardSelector } from './MercenaryCardSelector.js';
 import { formationEngine } from './FormationEngine.js';
 import { mbtiPositioningEngine } from './MBTIPositioningEngine.js';
+// 장비 자동 장착 엔진 및 인벤토리 매니저를 가져옵니다.
+import { mercenaryEquipmentSelector } from './MercenaryEquipmentSelector.js';
+import { itemInventoryManager } from './ItemInventoryManager.js';
 
 /**
  * 아레나 컨텐츠와 관련된 로직(적 생성, 보상 등)을 관리하는 엔진
@@ -21,6 +24,8 @@ class ArenaManager {
     generateEnemyTeam() {
         this.enemyTeam = [];
         let availableCards = [...skillInventoryManager.getInventory()];
+        // 아레나 적들을 위한 임시 장비 인벤토리 풀
+        let availableItems = [...itemInventoryManager.getInventory()];
         const mercenaryTypes = Object.values(mercenaryData);
 
         // --- \u2728 아레나 '적' 진영의 모든 빈 셀 목록을 준비 ---
@@ -51,11 +56,14 @@ class ArenaManager {
             });
             availableCards = remainingCards;
 
-            // 3. MBTI에 따라 위치 결정
+            // 3. MBTI에 따라 장비 선택
+            availableItems = mercenaryEquipmentSelector._selectAndEquipBestItemsForMerc(enemyMercenary, availableItems);
+
+            // 4. MBTI에 따라 위치 결정
             const chosenCell = mbtiPositioningEngine.determinePosition(enemyMercenary, availableCells, placedEnemies, 'enemy');
 
             if (chosenCell) {
-                // 4. 결정된 위치 정보 저장
+                // 5. 결정된 위치 정보 저장
                 enemyMercenary.gridX = chosenCell.col;
                 enemyMercenary.gridY = chosenCell.row;
                 // formationEngine에 DOM이 아닌 논리적 위치를 저장합니다.
@@ -71,7 +79,7 @@ class ArenaManager {
             this.enemyTeam.push(enemyMercenary);
         }
 
-        console.log('[ArenaManager] 아레나 적 팀 생성 및 자동 배치가 완료되었습니다.');
+        console.log('[ArenaManager] 아레나 적 팀 생성 및 자동 장비/스킬/배치가 완료되었습니다.');
         return this.enemyTeam;
     }
 

--- a/src/game/utils/MercenaryEquipmentSelector.js
+++ b/src/game/utils/MercenaryEquipmentSelector.js
@@ -1,0 +1,116 @@
+import { itemInventoryManager } from './ItemInventoryManager.js';
+import { equipmentManager } from './EquipmentManager.js';
+import { partyEngine } from './PartyEngine.js';
+import { mercenaryEngine } from './MercenaryEngine.js';
+import { EQUIPMENT_SLOTS } from '../data/items.js';
+
+/**
+ * 용병의 MBTI 성향과 현재 상황을 고려하여 최적의 장비를 자동으로 장착하는 엔진
+ */
+class MercenaryEquipmentSelector {
+    constructor() {
+        this.name = 'MercenaryEquipmentSelector';
+    }
+
+    /**
+     * 현재 파티의 모든 용병에게 최적의 장비를 찾아 장착시킵니다.
+     */
+    autoEquipForParty() {
+        const partyMemberIds = partyEngine.getPartyMembers().filter(id => id !== undefined);
+        let availableItems = itemInventoryManager.getInventory();
+
+        // 1. 모든 용병의 장비를 해제하여 인벤토리 풀에 통합합니다.
+        partyMemberIds.forEach(id => {
+            const unit = mercenaryEngine.getMercenaryById(id);
+            if (!unit) return;
+
+            const equipped = equipmentManager.getEquippedItems(unit.uniqueId);
+            equipped.forEach((instanceId, index) => {
+                if (instanceId) {
+                    const slotTypes = ['WEAPON', 'ARMOR', 'ACCESSORY1', 'ACCESSORY2'];
+                    equipmentManager.unequipItem(unit.uniqueId, slotTypes[index]);
+                }
+            });
+        });
+        availableItems = itemInventoryManager.getInventory(); // 최신 인벤토리 다시 로드
+
+        // 2. 각 용병별로 최적의 장비를 찾아 장착합니다.
+        partyMemberIds.forEach(id => {
+            const mercenary = mercenaryEngine.getMercenaryById(id);
+            if (!mercenary) return;
+
+            availableItems = this._selectAndEquipBestItemsForMerc(mercenary, availableItems);
+        });
+    }
+
+    /**
+     * 한 명의 용병을 위해 사용 가능한 아이템 중에서 최적의 장비를 선택하고 장착합니다.
+     * @param {object} mercenary - 장비를 장착할 용병
+     * @param {Array<object>} availableItems - 사용 가능한 아이템 목록
+     * @returns {Array<object>} - 장착하고 남은 아이템 목록
+     * @private
+     */
+    _selectAndEquipBestItemsForMerc(mercenary, availableItems) {
+        let remainingItems = [...availableItems];
+        const slotTypes = ['WEAPON', 'ARMOR', 'ACCESSORY1', 'ACCESSORY2'];
+
+        slotTypes.forEach(slotType => {
+            const baseSlotType = slotType.replace(/\d+$/, ''); // 'ACCESSORY1' -> 'ACCESSORY'
+            const requiredItemType = EQUIPMENT_SLOTS[baseSlotType];
+
+            const candidates = remainingItems.filter(item => item.type === requiredItemType);
+            if (candidates.length === 0) return;
+
+            // 모든 후보 아이템에 대해 점수를 매깁니다.
+            const scoredCandidates = candidates.map(item => ({
+                item,
+                score: this._calculateItemScore(mercenary, item)
+            }));
+
+            // 가장 높은 점수를 받은 아이템을 찾습니다.
+            scoredCandidates.sort((a, b) => b.score - a.score);
+            const bestChoice = scoredCandidates[0];
+
+            // 장착하고 인벤토리 풀에서 제거합니다.
+            equipmentManager.equipItem(mercenary.uniqueId, slotType, bestChoice.item.instanceId);
+            remainingItems = remainingItems.filter(item => item.instanceId !== bestChoice.item.instanceId);
+        });
+
+        return remainingItems;
+    }
+
+    /**
+     * 용병의 MBTI 성향에 따라 아이템의 점수를 계산합니다.
+     * @param {object} mercenary
+     * @param {object} item
+     * @returns {number}
+     * @private
+     */
+    _calculateItemScore(mercenary, item) {
+        let score = 100; // 기본 점수
+        const mbti = mercenary.mbti;
+        const stats = item.stats;
+
+        // E vs I: 공격/지속력 vs 방어/효율
+        if (stats.physicalAttack || stats.valor || stats.strength) score += (mbti.E / 100) * 20;
+        if (stats.physicalDefense || stats.endurance || stats.tokenCostReduction) score += (mbti.I / 100) * 20;
+
+        // S vs N: 확실성 vs 변수 창출
+        if (stats.accuracy || stats.criticalChance) score += (mbti.S / 100) * 15;
+        if (item.synergy || stats.statusEffectApplication) score += (mbti.N / 100) * 25; // 시너지를 더 높게 평가
+
+        // T vs F: 자기 강화 vs 팀 기여(생존)
+        if (stats.criticalDamageMultiplier || stats.lifeSteal) score += (mbti.T / 100) * 20;
+        if (stats.hp || stats.healingGivenPercentage) score += (mbti.F / 100) * 15;
+
+        // J vs P: 계획(세트 완성) vs 즉흥(특수 효과)
+        // (세트 완성 로직은 더 복잡하므로 여기서는 MBTI 효과에만 집중)
+        if (item.mbtiEffects && item.mbtiEffects.length > 0) {
+             score += (mbti.P / 100) * 30; // P는 특이한 MBTI 효과를 선호
+        }
+
+        return score;
+    }
+}
+
+export const mercenaryEquipmentSelector = new MercenaryEquipmentSelector();


### PR DESCRIPTION
## Summary
- add MercenaryEquipmentSelector to auto-equip mercenaries based on MBTI traits
- wire party equipment UI with auto-equip button
- auto-equip enemy mercenaries when generating Arena teams

## Testing
- `for f in tests/*.js; do echo "Running $f"; node $f; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688ccd451384832781946db0b0a1bc33