### PR TITLE
feat: allow log file downloads

### DIFF
--- a/src/game/scenes/TerritoryScene.js
+++ b/src/game/scenes/TerritoryScene.js
@@ -4,6 +4,8 @@ import { DOMEngine } from '../utils/DOMEngine.js';
 import { TerritoryDOMEngine } from '../dom/TerritoryDOMEngine.js';
 // 새로 만든 해상도 로그 매니저를 import 합니다.
 import { debugResolutionLogManager } from '../debug/DebugResolutionLogManager.js';
+// ✨ 로그 다운로더를 import 합니다.
+import { logDownloader } from '../utils/LogDownloader.js';
 
 export class TerritoryScene extends Scene {
     constructor() {
@@ -29,6 +31,12 @@ export class TerritoryScene extends Scene {
         // --- 중요: 해상도 정보 로그 출력 ---
         // 게임이 시작될 때 현재 해상도 정보를 콘솔에 기록합니다.
         debugResolutionLogManager.logResolution(this.sys.game);
+
+        // ✨ 'L' 키를 누르면 로그를 다운로드하는 이벤트 리스너를 추가합니다.
+        this.input.keyboard.on('keydown-L', () => {
+            console.log("'L' 키가 눌렸습니다. 로그 다운로드를 시작합니다...");
+            logDownloader.download();
+        });
 
         // 씬이 종료될 때 DOM 요소들을 정리하도록 이벤트를 설정합니다.
         this.events.on('shutdown', () => {

--- a/src/game/utils/DebugLogEngine.js
+++ b/src/game/utils/DebugLogEngine.js
@@ -1,37 +1,28 @@
 /**
- * 브라우저 개발자 도구 콘솔에 구조화된 로그를 출력하는 엔진 (싱글턴)
+ * 브라우저 개발자 도구 콘솔에 구조화된 로그를 출력하고, 파일로 저장할 수 있도록 기록하는 엔진
  */
 class DebugLogEngine {
     constructor() {
         if (DebugLogEngine.instance) {
             return DebugLogEngine.instance;
         }
-        
+
         // 이 값을 false로 바꾸면 모든 디버그 로그가 출력되지 않습니다.
         this.enabled = true;
-        
+
+        this.logHistory = [];
         this.managers = {};
         this._welcomeMessage();
 
         DebugLogEngine.instance = this;
     }
 
-    /**
-     * 엔진이 처음 초기화될 때 콘솔에 환영 메시지를 출력합니다.
-     */
     _welcomeMessage() {
         if (!this.enabled) return;
-        console.log(
-            '%c[DebugLogEngine]%c가 활성화되었습니다. 이제 매니저를 등록할 수 있습니다.',
-            'color: #7F00FF; font-weight: bold;', // 보라색, 굵게
-            'color: default;'
-        );
+        const message = 'DebugLogEngine이 활성화되었습니다. 이제 매니저를 등록할 수 있습니다.';
+        this.log('Engine', message);
     }
 
-    /**
-     * 새로운 디버그 매니저를 엔진에 등록합니다.
-     * @param {object} manager - 등록할 매니저. 'name' 속성이 필수입니다.
-     */
     register(manager) {
         if (manager && manager.name) {
             this.managers[manager.name] = manager;
@@ -40,46 +31,41 @@ class DebugLogEngine {
         }
     }
 
-    /**
-     * 일반 로그를 출력합니다.
-     * @param {string} source - 로그 출처 (매니저 이름)
-     * @param  {...any} args - 출력할 내용들
-     */
+    _recordLog(level, source, args) {
+        if (!this.enabled) return;
+
+        const logEntry = {
+            timestamp: new Date().toISOString(),
+            level: level,
+            source: source,
+            message: args.map(arg => {
+                try {
+                    JSON.stringify(arg);
+                    return arg;
+                } catch (e) {
+                    return arg.toString();
+                }
+            })
+        };
+        this.logHistory.push(logEntry);
+
+        const color = this._getSourceColor(source);
+        const consoleMethod = console[level] || console.log;
+        consoleMethod(`%c[${source}]`, `color: ${color}; font-weight: bold;`, ...args);
+    }
+
     log(source, ...args) {
-        if (!this.enabled) return;
-        // 출처(source)에 따라 색상이 바뀌도록 스타일을 적용합니다.
-        console.log(
-            `%c[${source}]`,
-            `color: ${this._getSourceColor(source)}; font-weight: bold;`,
-            ...args
-        );
+        this._recordLog('log', source, args);
     }
 
-    /**
-     * 경고 로그를 출력합니다.
-     * @param {string} source - 로그 출처
-     * @param  {...any} args - 출력할 내용들
-     */
     warn(source, ...args) {
-        if (!this.enabled) return;
-        console.warn(`[${source}]`, ...args);
+        this._recordLog('warn', source, args);
     }
 
-    /**
-     * 에러 로그를 출력합니다.
-     * @param {string} source - 로그 출처
-     * @param  {...any} args - 출력할 내용들
-     */
     error(source, ...args) {
-        if (!this.enabled) return;
-        console.error(`[${source}]`, ...args);
+        this._recordLog('error', source, args);
     }
 
-    /**
-     * 로그 출처(source) 문자열을 기반으로 고유한 색상을 생성합니다.
-     * @param {string} source - 출처 문자열
-     * @returns {string} - CSS 색상 코드
-     */
     _getSourceColor(source) {
         let hash = 0;
         for (let i = 0; i < source.length; i++) {
@@ -94,5 +80,4 @@ class DebugLogEngine {
     }
 }
 
-// 다른 파일에서 쉽게 사용할 수 있도록 유일한 인스턴스를 생성하여 내보냅니다.
 export const debugLogEngine = new DebugLogEngine();

--- a/src/game/utils/LogDownloader.js
+++ b/src/game/utils/LogDownloader.js
@@ -1,0 +1,49 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * DebugLogEngine에 기록된 로그를 파일로 다운로드하는 유틸리티 클래스
+ */
+class LogDownloader {
+    /**
+     * 기록된 모든 로그를 JSON 파일로 다운로드합니다.
+     */
+    static download() {
+        const logs = debugLogEngine.logHistory;
+        if (logs.length === 0) {
+            alert('다운로드할 로그가 없습니다.');
+            return;
+        }
+
+        try {
+            const replacer = (key, value) => {
+                if (key === 'sprite' || key === 'scene' || key === 'parent') {
+                    return '[Circular Reference]';
+                }
+                return value;
+            };
+
+            const jsonData = JSON.stringify(logs, replacer, 2);
+            const blob = new Blob([jsonData], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+
+            const a = document.createElement('a');
+            a.href = url;
+            const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+            a.download = `muscle-and-blood-log-${timestamp}.json`;
+
+            document.body.appendChild(a);
+            a.click();
+
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+
+            debugLogEngine.log('LogDownloader', '로그 파일 다운로드를 성공적으로 시작했습니다.');
+        } catch (error) {
+            console.error('로그 다운로드 중 오류 발생:', error);
+            debugLogEngine.error('LogDownloader', '로그 파일 생성에 실패했습니다.', error);
+            alert('로그 파일을 생성하는 데 실패했습니다. 개발자 콘솔을 확인해주세요.');
+        }
+    }
+}
+
+export const logDownloader = LogDownloader;


### PR DESCRIPTION
## Summary
- extend DebugLogEngine to capture log history for export
- add LogDownloader utility to save logs as JSON
- enable 'L' key in TerritoryScene to trigger log download

## Testing
- `for f in tests/*.js; do node $f || break; done`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688cf8f8298883279cb0dec578510185