### PR TITLE
feat: show status icons alongside unit sprites

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -153,6 +153,7 @@ export class BattleSimulatorEngine {
             this.vfxManager.updateTokenDisplay(unit, nameTag);
             this.vfxManager.updateHealthBar(unit.uniqueId, unit.currentHp, unit.finalStats.hp);
             this.vfxManager.updateAspirationBar(unit.uniqueId);
+            this.vfxManager.iconManager.updateIconsForUnit(unit.uniqueId);
         });
 
         this.gameLoop(); // 수정된 루프 시작
@@ -263,6 +264,7 @@ export class BattleSimulatorEngine {
                     this.vfxManager.updateTokenDisplay(unit, nameTag);
                     this.vfxManager.updateHealthBar(unit.uniqueId, unit.currentHp, unit.finalStats.hp);
                     this.vfxManager.updateAspirationBar(unit.uniqueId);
+                    this.vfxManager.iconManager.updateIconsForUnit(unit.uniqueId);
                 }
             });
             this.sharedResourceUI.update();


### PR DESCRIPTION
## Summary
- track buff, debuff, and passive icons per unit with new IconManager
- render status icons and aspiration bar state in VFX layer
- refresh icons for all combatants after each turn

## Testing
- `for f in tests/*.js; do echo "Running $f"; node "$f" | tail -n 1; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688cfd17c638832787069543584d2667