### PR TITLE
feat: add log download shortcut

### DIFF
--- a/src/game/scenes/ArenaBattleScene.js
+++ b/src/game/scenes/ArenaBattleScene.js
@@ -4,6 +4,7 @@ import { CameraControlEngine } from '../utils/CameraControlEngine.js';
 import { partyEngine } from '../utils/PartyEngine.js';
 import { BattleSimulatorEngine } from '../utils/BattleSimulatorEngine.js';
 import { arenaManager } from '../utils/ArenaManager.js';
+import { logDownloader } from '../utils/LogDownloader.js'; // logDownloader import 추가
 
 export class ArenaBattleScene extends Scene {
     constructor() {
@@ -36,7 +37,15 @@ export class ArenaBattleScene extends Scene {
 
         this.battleSimulator.start(partyUnits, enemyUnits);
 
+        // ✨ 'L' 키를 누르면 로그를 다운로드하는 이벤트 리스너를 추가합니다.
+        this.input.keyboard.on('keydown-L', () => {
+            console.log("'L' 키가 눌렸습니다. 로그 다운로드를 시작합니다...");
+            logDownloader.download();
+        });
+
         this.events.on('shutdown', () => {
+            // 'keydown-L' 이벤트 리스너를 해제합니다.
+            this.input.keyboard.off('keydown-L');
             if (this.stageManager) this.stageManager.destroy();
             if (this.cameraControl) this.cameraControl.destroy();
             if (this.battleSimulator) this.battleSimulator.shutdown();

--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -6,6 +6,7 @@ import { partyEngine } from '../utils/PartyEngine.js';
 import { monsterEngine } from '../utils/MonsterEngine.js';
 import { getMonsterBase } from '../data/monster.js';
 import { BattleSimulatorEngine } from '../utils/BattleSimulatorEngine.js';
+import { logDownloader } from '../utils/LogDownloader.js'; // logDownloader import 추가
 
 export class CursedForestBattleScene extends Scene {
     constructor() {
@@ -55,8 +56,15 @@ export class CursedForestBattleScene extends Scene {
         // BattleSimulatorEngine을 통해 전투를 시작합니다.
         this.battleSimulator.start(partyUnits, monsters);
 
+        // ✨ 'L' 키를 누르면 로그를 다운로드하는 이벤트 리스너를 추가합니다.
+        this.input.keyboard.on('keydown-L', () => {
+            console.log("'L' 키가 눌렸습니다. 로그 다운로드를 시작합니다...");
+            logDownloader.download();
+        });
 
         this.events.on('shutdown', () => {
+            // 'keydown-L' 이벤트 리스너를 해제합니다.
+            this.input.keyboard.off('keydown-L');
             ['dungeon-container', 'territory-container'].forEach(id => {
                 const el = document.getElementById(id);
                 if (el) el.style.display = 'block';


### PR DESCRIPTION
## Summary
- allow pressing **L** in forest and arena battles to download debug logs

## Testing
- `npm test` (fails: Missing script: "test")
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688dbf35b10c8327855e74dc3e91d864