### PR TITLE
Improve status effect visuals and melee AI

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -2,120 +2,88 @@ import BehaviorTree from '../BehaviorTree.js';
 import SelectorNode from '../nodes/SelectorNode.js';
 import SequenceNode from '../nodes/SequenceNode.js';
 import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import AttackTargetNode from '../nodes/AttackTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
+import JustRecoveredFromStunNode from '../nodes/JustRecoveredFromStunNode.js';
+import SetTargetToStunnerNode from '../nodes/SetTargetToStunnerNode.js';
+import IsTargetValidNode from '../nodes/IsTargetValidNode.js';
+import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
+import IsTargetInRangeNode from '../nodes/IsTargetInRangeNode.js';
+import FindLowestHealthEnemyNode from '../nodes/FindLowestHealthEnemyNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import IsHealthBelowThresholdNode from '../nodes/IsHealthBelowThresholdNode.js';
+import SuccessNode from '../nodes/SuccessNode.js';
 import { NodeState } from '../nodes/Node.js';
 
-import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
-import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
-import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
-import UseSkillNode from '../nodes/UseSkillNode.js';
-import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
-import FindMeleeStrategicTargetNode from '../nodes/FindMeleeStrategicTargetNode.js';
-import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
-import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
-import MBTIActionNode from '../nodes/MBTIActionNode.js';
-import IsHealthBelowThresholdNode from '../nodes/IsHealthBelowThresholdNode.js';
-import FleeNode from '../nodes/FleeNode.js';
-import FindNearestAllyInDangerNode from '../nodes/FindNearestAllyInDangerNode.js';
-import FindPathToAllyNode from '../nodes/FindPathToAllyNode.js';
-import { debugMBTIManager } from '../../game/debug/DebugMBTIManager.js';
-
 function createMeleeAI(engines = {}) {
-    // --- 공통 사용 브랜치 ---
-    const executeSkillBranch = new SelectorNode([
-        new SequenceNode([
-            new IsSkillInRangeNode(engines),
-            new UseSkillNode(engines)
-        ]),
-        new SequenceNode([
-            new HasNotMovedNode(),
-            new FindPathToSkillRangeNode(engines),
-            new MoveToTargetNode(engines),
-            new IsSkillInRangeNode(engines),
-            new UseSkillNode(engines)
-        ])
-    ]);
-
-    // --- 기본 행동 (최후의 보루) ---
-    const basicActionBranch = new SelectorNode([
-        // 1. 사용 가능한 스킬이 있으면 공격
-        new SequenceNode([
-            new FindBestSkillByScoreNode(engines),
-            new FindTargetBySkillTypeNode(engines),
-            executeSkillBranch
-        ]),
-        // 2. 스킬 사용이 불가능하면 이동이라도 함
-        new SequenceNode([
-            new HasNotMovedNode(),
-            new FindMeleeStrategicTargetNode(engines),
-            new FindPathToTargetNode(engines),
-            new MoveToTargetNode(engines)
-        ])
-    ]);
-
-    // --- MBTI 기반 특수 행동들 ---
-    const survivalBehavior = new SequenceNode([
-        new IsHealthBelowThresholdNode(0.35),
-        {
-            async evaluate(unit) {
-                debugMBTIManager.logDecisionStart('생존 본능', unit);
+    const setCurrentFromMovement = {
+        async evaluate(_unit, blackboard) {
+            const target = blackboard.get('movementTarget');
+            if (target) {
+                blackboard.set('currentTargetUnit', target);
                 return NodeState.SUCCESS;
             }
-        },
+            return NodeState.FAILURE;
+        }
+    };
+
+    const revengeBranch = new SequenceNode([
+        new JustRecoveredFromStunNode(),
+        new SetTargetToStunnerNode(),
+        new IsTargetValidNode(),
+        new FindPathToTargetNode(engines),
+        new MoveToTargetNode(engines),
+        new AttackTargetNode(engines)
+    ]);
+
+    const priorityAttackBranch = new SequenceNode([
+        new FindPriorityTargetNode(engines),
+        setCurrentFromMovement,
+        new IsTargetValidNode(),
         new SelectorNode([
             new SequenceNode([
-                new MBTIActionNode('I', engines),
-                {
-                    async evaluate() {
-                        debugMBTIManager.logAction('후퇴');
-                        return NodeState.SUCCESS;
-                    }
-                },
-                new FleeNode(engines),
-                new MoveToTargetNode(engines)
+                new IsTargetInRangeNode(engines),
+                new AttackTargetNode(engines)
             ]),
             new SequenceNode([
-                new MBTIActionNode('E', engines),
-                {
-                    async evaluate() {
-                        debugMBTIManager.logAction('최후의 발악');
-                        return NodeState.SUCCESS;
-                    }
-                },
-                new FindBestSkillByScoreNode(engines),
-                new FindTargetBySkillTypeNode(engines),
-                new UseSkillNode(engines)
+                new FindPathToTargetNode(engines),
+                new MoveToTargetNode(engines),
+                new AttackTargetNode(engines)
             ])
-        ]),
-        { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
+        ])
     ]);
 
-    const allyCareBehavior = new SequenceNode([
-        new FindNearestAllyInDangerNode(),
-        new MBTIActionNode('F', engines),
-        {
-            async evaluate(unit) {
-                debugMBTIManager.logDecisionStart('아군 보호', unit);
-                return NodeState.SUCCESS;
-            }
-        },
-        new HasNotMovedNode(),
-        new FindPathToAllyNode(engines),
-        new MoveToTargetNode(engines),
-        { async evaluate() { debugMBTIManager.logDecisionEnd(); return NodeState.SUCCESS; } }
+    const finishOffBranch = new SequenceNode([
+        new FindLowestHealthEnemyNode(engines),
+        new IsTargetValidNode(),
+        new SelectorNode([
+            new SequenceNode([
+                new IsTargetInRangeNode(engines),
+                new AttackTargetNode(engines)
+            ]),
+            new SequenceNode([
+                new FindPathToTargetNode(engines),
+                new MoveToTargetNode(engines),
+                new AttackTargetNode(engines)
+            ])
+        ])
     ]);
 
-    // --- 최종 행동 트리 구성 ---
-    const rootNode = new SelectorNode([
-        // 1순위: 특수한 상황 판단 및 행동 (생존, 아군보호 등)
-        survivalBehavior,
-        allyCareBehavior,
-        // ... 다른 MBTI 기반 고차원적 행동들 ...
-
-        // 2순위: 위 특수 행동들이 실행되지 않았다면, 반드시 기본 행동을 수행
-        basicActionBranch
+    const retreatBranch = new SequenceNode([
+        new IsHealthBelowThresholdNode(0.5),
+        new FindSafeRepositionNode(engines),
+        new MoveToTargetNode(engines)
     ]);
 
-    return new BehaviorTree(rootNode);
+    const root = new SelectorNode([
+        revengeBranch,
+        priorityAttackBranch,
+        finishOffBranch,
+        retreatBranch,
+        new SuccessNode()
+    ]);
+
+    return new BehaviorTree(root);
 }
 
 export { createMeleeAI };

--- a/src/game/utils/IconManager.js
+++ b/src/game/utils/IconManager.js
@@ -105,20 +105,25 @@ export class IconManager {
         // 1. 버프 아이콘 처리 (왼쪽 컨테이너)
         buffs.forEach((effect, index) => {
             const effectDef = statusEffects[effect.id] || skillCardDatabase[effect.id];
-            // 경로를 assets/images/에서 시작하도록 수정합니다.
-            const iconKey = effectDef
-                ? effectDef.iconPath
-                    ? effectDef.iconPath.replace(/^assets\/images\//, '')
-                    : effect.id
-                : effect.illustrationPath.replace(/^assets\/images\//, ''); // 패시브 스킬의 illustrationPath 직접 사용
+            const iconKey =
+                effectDef && this.scene.textures.exists(effectDef.id)
+                    ? effectDef.id
+                    : effect.illustrationPath
+                        ? effect.illustrationPath.replace(/^assets\/images\//, '')
+                        : effect.id;
+
+            if (!this.scene.textures.exists(iconKey)) {
+                console.error(`아이콘 텍스처를 찾을 수 없습니다: ${iconKey}`);
+                return;
+            }
 
             let iconData = display.buffIcons.get(effect.instanceId);
             if (!iconData) {
                 const iconContainer = this.scene.add.container(0, 0);
                 const icon = this.scene.add
                     .image(0, 0, iconKey)
-                    .setScale(0.5) // 이미지 크기를 0.5로 키웁니다.
-                    .setAlpha(0.7); // 투명도를 0.7로 설정합니다.
+                    .setScale(0.5)
+                    .setAlpha(0.7);
                 const turnText = this.scene.add
                     .text(0, 8, '', {
                         fontSize: '12px',
@@ -132,8 +137,9 @@ export class IconManager {
                 iconData = { icon: iconContainer, text: turnText };
                 display.buffIcons.set(effect.instanceId, iconData);
             } else {
-                if (iconData.icon.list[0].texture.key !== iconKey)
+                if (iconData.icon.list[0].texture.key !== iconKey) {
                     iconData.icon.list[0].setTexture(iconKey);
+                }
             }
             iconData.text.setText(effect.duration);
             // 세로 나열
@@ -146,20 +152,23 @@ export class IconManager {
         // 2. 디버프 아이콘 처리 (오른쪽 컨테이너)
         debuffs.forEach((effect, index) => {
             const effectDef = statusEffects[effect.id] || skillCardDatabase[effect.id];
-            // 경로를 assets/images/에서 시작하도록 수정합니다.
-            const iconKey = effectDef
-                ? effectDef.iconPath
-                    ? effectDef.iconPath.replace(/^assets\/images\//, '')
-                    : effect.id
-                : effect.id;
+            const iconKey =
+                effectDef && this.scene.textures.exists(effectDef.id)
+                    ? effectDef.id
+                    : effect.id;
+
+            if (!this.scene.textures.exists(iconKey)) {
+                console.error(`아이콘 텍스처를 찾을 수 없습니다: ${iconKey}`);
+                return;
+            }
 
             let iconData = display.debuffIcons.get(effect.instanceId);
             if (!iconData) {
                 const iconContainer = this.scene.add.container(0, 0);
                 const icon = this.scene.add
                     .image(0, 0, iconKey)
-                    .setScale(0.5) // 이미지 크기를 0.5로 키웁니다.
-                    .setAlpha(0.7); // 투명도를 0.7로 설정합니다.
+                    .setScale(0.5)
+                    .setAlpha(0.7);
                 const turnText = this.scene.add
                     .text(0, 8, '', {
                         fontSize: '12px',
@@ -173,8 +182,9 @@ export class IconManager {
                 iconData = { icon: iconContainer, text: turnText };
                 display.debuffIcons.set(effect.instanceId, iconData);
             } else {
-                if (iconData.icon.list[0].texture.key !== iconKey)
+                if (iconData.icon.list[0].texture.key !== iconKey) {
                     iconData.icon.list[0].setTexture(iconKey);
+                }
             }
             iconData.text.setText(effect.duration);
             // 세로 나열

--- a/src/game/utils/VFXManager.js
+++ b/src/game/utils/VFXManager.js
@@ -56,16 +56,18 @@ export class VFXManager {
         // ✨ 2. 체력/열망바 너비를 절반으로 줄입니다.
         const barWidth = 4;
         const barHeight = 80;
-        const xOffset = unit.sprite.displayWidth / 2 + barWidth;
+        const xOffset = unit.sprite.displayWidth / 2 + barWidth / 2;
+        const healthYOffset = 25;
+        const aspirationYOffset = 15;
 
         // 1. 체력 및 배리어 바 생성 (유닛 왼쪽)
         // ✨ 2. 투명도를 50%로 설정합니다.
-        const healthBar = this.createVerticalBar(unit.sprite, -xOffset, barHeight, barWidth, 0x282c34, 0x22c55e, 0.5);
-        const barrierBar = this.createVerticalBar(unit.sprite, -xOffset, barHeight, barWidth, 0x282c34, 0xffd700, 0.5);
+        const healthBar = this.createVerticalBar(unit.sprite, -xOffset, barHeight, barWidth, 0x282c34, 0x22c55e, 0.5, healthYOffset);
+        const barrierBar = this.createVerticalBar(unit.sprite, -xOffset, barHeight, barWidth, 0x282c34, 0xffd700, 0.5, healthYOffset);
 
         // 2. 열망 게이지 생성 (유닛 오른쪽)
         // ✨ 2. 투명도를 50%로 설정합니다.
-        const aspirationBar = this.createVerticalBar(unit.sprite, xOffset, barHeight, barWidth, 0x282c34, 0x8b5cf6, 0.5);
+        const aspirationBar = this.createVerticalBar(unit.sprite, xOffset, barHeight, barWidth, 0x282c34, 0x8b5cf6, 0.5, aspirationYOffset);
 
         this.unitBars.set(unitId, { healthBar, barrierBar, aspirationBar });
 
@@ -147,8 +149,8 @@ export class VFXManager {
      * @param {number} bgAlpha - 배경 투명도 (기본값 0.7)
      * @returns {{container: Phaser.GameObjects.Container, bar: Phaser.GameObjects.Graphics}}
      */
-    createVerticalBar(parentSprite, xOffset, height, width, bgColor, barColor, bgAlpha = 0.7) {
-        const container = this.scene.add.container(parentSprite.x + xOffset, parentSprite.y);
+    createVerticalBar(parentSprite, xOffset, height, width, bgColor, barColor, bgAlpha = 0.7, yOffset = 0) {
+        const container = this.scene.add.container(parentSprite.x + xOffset, parentSprite.y - yOffset);
         this.vfxLayer.add(container);
 
         const bg = this.scene.add.graphics().fillStyle(bgColor, bgAlpha).fillRect(-width / 2, -height / 2, width, height);


### PR DESCRIPTION
## Summary
- Use preloaded texture keys for status effect icons and validate their presence
- Move health/aspiration bars closer to unit sprites with configurable offsets
- Rework melee behavior tree to prioritize aggressive targeting before retreating

## Testing
- `npm run build`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688df6212c248327bd3282d4e229420e