### PR TITLE
Use correct attack stat for magic skills

### DIFF
--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -44,10 +44,15 @@ class CombatCalculationEngine {
             return { damage: 0, hitType: '무효', comboCount: 0 };
         }
 
+        // ✨ [핵심 수정] 마법, 원거리, 근접 순으로 공격 타입을 명확히 구분합니다.
+        const isMagic = skill.tags?.includes(SKILL_TAGS.MAGIC);
         const isRanged = skill.tags?.includes(SKILL_TAGS.RANGED) && skill.tags?.includes(SKILL_TAGS.PHYSICAL);
-        const baseAttack = isRanged
-            ? (attacker.finalStats?.rangedAttack || 0)
-            : (attacker.finalStats?.physicalAttack || 0);
+
+        const baseAttack = isMagic
+            ? (attacker.finalStats?.magicAttack || 0)
+            : isRanged
+                ? (attacker.finalStats?.rangedAttack || 0)
+                : (attacker.finalStats?.physicalAttack || 0);
 
         // 콤보 배율 계산을 위한 정보
         let comboMultiplier = 1.0;


### PR DESCRIPTION
## Summary
- prioritize magic, then ranged, then melee attack stats during damage calculation

## Testing
- `for f in tests/*.js; do node $f >/tmp/test.log && tail -n 1 /tmp/test.log; done`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688dfa45bcf88327b39379df8f88d252