### PR TITLE
Fix combat damage and buff handling

### DIFF
--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -1,3 +1,4 @@
+import { statusEffectManager } from "../utils/StatusEffectManager.js";
 import { stackManager } from "../utils/StackManager.js";
 import { FIXED_DAMAGE_TYPES } from "../utils/FixedDamageManager.js";
 
@@ -16,9 +17,19 @@ export const statusEffects = {
             unit.isStunned = true;
         },
         onRemove: (unit) => {
-            console.log(`${unit.instanceName}의 기절이 풀렸습니다.`);
-            unit.isStunned = false;
-            unit.justRecoveredFromStun = true;
+            console.log(`${unit.instanceName}의 기절 효과 중 하나가 해제됩니다.`);
+            // 현재 유닛에게 적용된 다른 'stun' 효과가 있는지 확인합니다.
+            const remainingStuns = (statusEffectManager.activeEffects.get(unit.uniqueId) || [])
+                .filter(effect => effect.id === 'stun').length;
+
+            // 남아있는 기절 효과가 없다면, 그때 상태를 해제합니다.
+            if (remainingStuns === 0) {
+                console.log(`${unit.instanceName}의 모든 기절이 풀렸습니다.`);
+                unit.isStunned = false;
+                unit.justRecoveredFromStun = true;
+            } else {
+                console.log(`${unit.instanceName}에게 아직 ${remainingStuns}개의 기절 효과가 남아있습니다.`);
+            }
         },
     },
     // 전투의 함성: 일시적으로 근접 공격 등급을 상승시킵니다.

--- a/src/game/utils/StatusEffectManager.js
+++ b/src/game/utils/StatusEffectManager.js
@@ -34,16 +34,22 @@ class StatusEffectManager {
         for (const [unitId, effects] of this.activeEffects.entries()) {
             const remainingEffects = [];
             for (const effect of effects) {
-                effect.duration--;
-                if (effect.duration > 0) {
-                    remainingEffects.push(effect);
-                } else {
-                    const effectDefinition = statusEffects[effect.id];
-                    if (effectDefinition && effectDefinition.onRemove) {
-                        const unit = this.findUnitById(unitId);
-                        if (unit) effectDefinition.onRemove(unit);
+                // duration이 숫자인 경우에만 감소시킵니다.
+                if (typeof effect.duration === 'number') {
+                    effect.duration--;
+                    if (effect.duration > 0) {
+                        remainingEffects.push(effect);
+                    } else {
+                        const effectDefinition = statusEffects[effect.id];
+                        if (effectDefinition && effectDefinition.onRemove) {
+                            const unit = this.findUnitById(unitId);
+                            if (unit) effectDefinition.onRemove(unit);
+                        }
+                        debugStatusEffectManager.logEffectExpired(unitId, effect);
                     }
-                    debugStatusEffectManager.logEffectExpired(unitId, effect);
+                } else {
+                    // duration이 없으면(스택 기반 효과 등) 그대로 유지합니다.
+                    remainingEffects.push(effect);
                 }
             }
             this.activeEffects.set(unitId, remainingEffects);


### PR DESCRIPTION
## Summary
- handle magic vs physical attack stats and apply attacker buffs in damage formula
- ensure durationless status effects persist and stun only clears when all stacks expire

## Testing
- `npm test` *(fails: Missing script)*
- `bash -lc 'for f in tests/*.js; do echo "Running $f"; node $f; echo; done'` (see tail)
- `npm run build-nolog`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e02feb0108327bae57adc305aa6d6