### PR TITLE
feat: add damage type manager

### DIFF
--- a/src/game/debug/DebugDamageTypeManager.js
+++ b/src/game/debug/DebugDamageTypeManager.js
@@ -1,0 +1,26 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+class DebugDamageTypeManager {
+    constructor() {
+        this.name = 'DebugDamageType';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 특정 스킬에서 식별된 데미지 타입들을 로그로 남깁니다.
+     * @param {string} skillName - 스킬의 이름
+     * @param {Array<string>} types - 식별된 데미지 타입 배열
+     */
+    logDamageTypes(skillName, types) {
+        if (types.length === 0) return;
+
+        const typeString = types.join(', ');
+        debugLogEngine.log(
+            this.name,
+            `스킬 [${skillName}]에서 다음 데미지 타입을 식별했습니다: %c${typeString}`,
+            'color: #2dd4bf; font-weight: bold;'
+        );
+    }
+}
+
+export const debugDamageTypeManager = new DebugDamageTypeManager();

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -24,6 +24,8 @@ import { FIXED_DAMAGE_TYPES } from './FixedDamageManager.js';
 // ✨ AIMemoryEngine 추가
 import { aiMemoryEngine } from './AIMemoryEngine.js';
 import { aspirationEngine } from './AspirationEngine.js';
+// ▼▼▼ [추가] 새로 만든 데미지 타입 매니저를 import 합니다. ▼▼▼
+import { damageTypeManager } from './DamageTypeManager.js';
 
 /**
  * 실제 전투 데미지 계산을 담당하는 엔진
@@ -37,6 +39,13 @@ class CombatCalculationEngine {
      * @returns {number} 최종 적용될 데미지
      */
     calculateDamage(attacker = {}, defender = {}, skill = {}, instanceId, grade = 'NORMAL') {
+        // ▼▼▼ [추가] 데미지 계산 시작점에 이 코드를 추가합니다. ▼▼▼
+        const damageTypes = damageTypeManager.identifyDamageTypes(skill);
+        // 이제 'damageTypes' 배열에는 이 공격의 모든 속성 정보가 담겨 있습니다.
+        // 추후 이 정보를 사용해 특정 속성 저항 등을 계산할 수 있습니다.
+        // (예: if (damageTypes.includes(DAMAGE_TYPES.FIRE) && defender.fireResistance > 0) { ... })
+        // ▲▲▲ [추가 끝] ▲▲▲
+
         // ✨ --- [신규] 피해 무효화 효과 최우선 처리 --- ✨
         if (stackManager.hasStack(defender.uniqueId, FIXED_DAMAGE_TYPES.DAMAGE_IMMUNITY)) {
             stackManager.consumeStack(defender.uniqueId, FIXED_DAMAGE_TYPES.DAMAGE_IMMUNITY);

--- a/src/game/utils/DamageTypeManager.js
+++ b/src/game/utils/DamageTypeManager.js
@@ -1,0 +1,52 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+import { SKILL_TAGS } from './SkillTagManager.js';
+// 새로 만들 디버그 매니저를 미리 import 합니다.
+import { debugDamageTypeManager } from '../debug/DebugDamageTypeManager.js';
+
+/**
+ * 게임 내 모든 데미지 유형을 정의하는 상수 객체입니다.
+ * SKILL_TAGS와 연동하여 사용됩니다.
+ */
+export const DAMAGE_TYPES = {
+    PHYSICAL: SKILL_TAGS.PHYSICAL,
+    MAGIC: SKILL_TAGS.MAGIC,
+    FIRE: SKILL_TAGS.FIRE,
+    WATER: SKILL_TAGS.WATER,
+    WIND: SKILL_TAGS.WIND,
+    EARTH: SKILL_TAGS.EARTH,
+    LIGHT: SKILL_TAGS.LIGHT,
+    DARK: SKILL_TAGS.DARK,
+    IRON: SKILL_TAGS.IRON,
+    POISON: SKILL_TAGS.POISON,
+    // 상태이상으로 인한 지속 데미지 등은 추후 확장 가능
+};
+
+class DamageTypeManager {
+    constructor() {
+        this.name = 'DamageTypeManager';
+        debugLogEngine.register(this);
+
+        // DAMAGE_TYPES의 값들을 Set으로 만들어 빠른 조회를 가능하게 합니다.
+        this.damageTypeTags = new Set(Object.values(DAMAGE_TYPES));
+    }
+
+    /**
+     * 스킬 데이터의 태그를 분석하여 포함된 모든 데미지 타입을 배열로 반환합니다.
+     * @param {object} skillData - 분석할 스킬 데이터
+     * @returns {Array<string>} - 데미지 타입 태그의 배열 (예: ['물리', '불'])
+     */
+    identifyDamageTypes(skillData) {
+        if (!skillData || !skillData.tags) {
+            return [];
+        }
+
+        const identifiedTypes = skillData.tags.filter(tag => this.damageTypeTags.has(tag));
+
+        // 식별된 데미지 타입을 디버그 로그로 남깁니다.
+        debugDamageTypeManager.logDamageTypes(skillData.name, identifiedTypes);
+
+        return identifiedTypes;
+    }
+}
+
+export const damageTypeManager = new DamageTypeManager();


### PR DESCRIPTION
## Summary
- add DamageTypeManager to centralize damage type identification
- log detected damage types with DebugDamageTypeManager
- integrate damage type detection at start of CombatCalculationEngine.calculateDamage

## Testing
- `npm test` (fails: Missing script "test")
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e056e68f4832792ee6928830b2e9f