### PR TITLE
Add combat and status effect integration tests

### DIFF
--- a/tests/combat_calculation_test.js
+++ b/tests/combat_calculation_test.js
@@ -1,0 +1,81 @@
+// tests/combat_calculation_test.js
+
+import assert from 'assert';
+
+// Node 환경에서 IndexedDB를 사용하지 않으므로 간단한 스텁을 제공합니다.
+globalThis.indexedDB = { open: () => ({}) };
+
+const { combatCalculationEngine } = await import('../src/game/utils/CombatCalculationEngine.js');
+const { statusEffectManager } = await import('../src/game/utils/StatusEffectManager.js');
+
+console.log('--- 전투 계산 엔진 통합 테스트 시작 ---');
+
+// --- 테스트용 Mock 객체 및 데이터 ---
+
+// Mock 공격자 (전사)
+const mockWarrior = {
+    uniqueId: 1,
+    instanceName: 'Test Warrior',
+    team: 'ally',
+    finalStats: { physicalAttack: 20, magicAttack: 5, criticalChance: 10 },
+    currentBarrier: 0,
+    maxBarrier: 0
+};
+
+// Mock 마법 공격자 (나노맨서)
+const mockNanomancer = {
+    uniqueId: 2,
+    instanceName: 'Test Nanomancer',
+    team: 'ally',
+    finalStats: { physicalAttack: 5, magicAttack: 25, criticalChance: 5 },
+    currentBarrier: 0,
+    maxBarrier: 0
+};
+
+// Mock 방어자 (좀비)
+const mockZombie = {
+    uniqueId: 3,
+    instanceName: 'Test Zombie',
+    team: 'enemy',
+    finalStats: { physicalDefense: 10, magicDefense: 5 },
+    currentHp: 100
+};
+
+// Mock 스킬 데이터
+const physicalSkill = { name: 'Test Strike', tags: ['물리'], damageMultiplier: 1.0 };
+const magicSkill = { name: 'Test Bolt', tags: ['마법'], damageMultiplier: 1.0 };
+
+// --- 테스트 케이스 실행 ---
+
+// 1. 기본 물리 데미지 테스트
+statusEffectManager.activeEffects.clear(); // 테스트 전 상태 초기화
+let result = combatCalculationEngine.calculateDamage(mockWarrior, mockZombie, physicalSkill);
+// 예상 데미지: (공격력 20 - 방어력 10) * 1.0 = 10
+assert.strictEqual(result.damage, 10, '테스트 1 실패: 기본 물리 데미지 계산이 올바르지 않습니다.');
+console.log('✅ 테스트 1 통과: 기본 물리 데미지 계산이 정확합니다.');
+
+// 2. 마법 데미지 테스트 (이전 버그 수정 검증)
+result = combatCalculationEngine.calculateDamage(mockNanomancer, mockZombie, magicSkill);
+// 예상 데미지: (마법 공격력 25 - 마법 방어력 5) * 1.0 = 20
+assert.strictEqual(result.damage, 20, '테스트 2 실패: 마법 데미지가 마법 공격력/방어력으로 계산되지 않았습니다.');
+console.log('✅ 테스트 2 통과: 마법 데미지 계산이 정확합니다.');
+
+// 3. 공격자 버프 적용 테스트 (이전 버그 수정 검증)
+// '숯돌 갈기'와 유사한 +50% 공격력 버프를 전사에게 적용
+const attackBuff = {
+    id: 'testAttackBuff',
+    sourceSkillName: 'Test Buff',
+    type: 'BUFF',
+    duration: 1,
+    modifiers: { stat: 'physicalAttack', type: 'percentage', value: 0.50 }
+};
+statusEffectManager.activeEffects.set(mockWarrior.uniqueId, [attackBuff]);
+
+result = combatCalculationEngine.calculateDamage(mockWarrior, mockZombie, physicalSkill);
+// 예상 데미지: (공격력 20 * 1.5 - 방어력 10) * 1.0 = 20
+assert.strictEqual(result.damage, 20, '테스트 3 실패: 공격자 버프가 데미지 계산에 적용되지 않았습니다.');
+console.log('✅ 테스트 3 통과: 공격력 버프가 정상적으로 적용됩니다.');
+
+statusEffectManager.activeEffects.clear(); // 테스트 후 상태 초기화
+
+console.log('--- 모든 전투 계산 테스트 완료 ---');

--- a/tests/status_effect_interaction_test.js
+++ b/tests/status_effect_interaction_test.js
@@ -1,0 +1,67 @@
+// tests/status_effect_interaction_test.js
+
+import assert from 'assert';
+
+// IndexedDB를 사용하지 않는 Node 테스트 환경을 위한 스텁
+globalThis.indexedDB = { open: () => ({}) };
+
+const { statusEffectManager } = await import('../src/game/utils/StatusEffectManager.js');
+
+console.log('--- 상태 효과 상호작용 테스트 시작 ---');
+
+// --- 테스트용 Mock 객체 ---
+const mockUnit = {
+    uniqueId: 10,
+    instanceName: 'Test Unit',
+    isStunned: false,
+    justRecoveredFromStun: false
+};
+
+// statusEffectManager가 유닛을 찾을 수 있도록 Mock Simulator 환경 설정
+statusEffectManager.setBattleSimulator({
+    turnQueue: [mockUnit],
+    findUnitById(id) {
+        return this.turnQueue.find(u => u.uniqueId === id);
+    }
+});
+
+// --- 테스트 케이스 실행 ---
+
+// 1. 기절 중첩 테스트
+statusEffectManager.activeEffects.clear();
+mockUnit.isStunned = false;
+
+// 기절 효과 2개를 추가 (하나는 1턴, 다른 하나는 2턴 지속)
+const stunSkill1 = { name: 'Stun 1', effect: { id: 'stun', duration: 1 } };
+const stunSkill2 = { name: 'Stun 2', effect: { id: 'stun', duration: 2 } };
+statusEffectManager.addEffect(mockUnit, stunSkill1);
+statusEffectManager.addEffect(mockUnit, stunSkill2);
+
+assert.strictEqual(mockUnit.isStunned, true, '테스트 1-1 실패: 기절 효과가 적용되지 않았습니다.');
+
+// 1턴 경과
+statusEffectManager.onTurnEnd();
+assert.strictEqual(mockUnit.isStunned, true, '테스트 1-2 실패: 기절 중첩 시 조기에 효과가 해제되었습니다.');
+console.log('✅ 테스트 1 통과: 기절 효과가 올바르게 중첩됩니다.');
+
+// 2턴 경과 (모든 기절 해제)
+statusEffectManager.onTurnEnd();
+assert.strictEqual(mockUnit.isStunned, false, '테스트 1-3 실패: 모든 기절 효과 만료 후에도 상태가 해제되지 않았습니다.');
+assert.strictEqual(mockUnit.justRecoveredFromStun, true, '테스트 1-4 실패: 기절에서 막 회복한 상태 플래그가 설정되지 않았습니다.');
+
+// 2. 지속시간 없는 버프 테스트 (Will Guard)
+statusEffectManager.activeEffects.clear();
+const willGuardSkill = { name: 'Will Guard', effect: { id: 'willGuard' } }; // duration 없음
+statusEffectManager.addEffect(mockUnit, willGuardSkill);
+
+// 1턴 경과
+statusEffectManager.onTurnEnd();
+const effects = statusEffectManager.activeEffects.get(mockUnit.uniqueId) || [];
+assert.strictEqual(effects.length, 1, '테스트 2-1 실패: 지속시간 없는 버프가 조기에 만료되었습니다.');
+assert.strictEqual(effects[0].id, 'willGuard', '테스트 2-2 실패: 남아있는 버프가 올바르지 않습니다.');
+console.log('✅ 테스트 2 통과: 지속시간 없는 버프가 턴이 지나도 유지됩니다.');
+
+
+statusEffectManager.activeEffects.clear(); // 테스트 후 상태 초기화
+
+console.log('--- 모든 상태 효과 상호작용 테스트 완료 ---');


### PR DESCRIPTION
## Summary
- add combat calculation integration test
- add status effect interaction test
- fix status effect expiry logic to update remaining effects before cleanup

## Testing
- `node tests/combat_calculation_test.js`
- `node tests/status_effect_interaction_test.js`
- `for f in tests/*.js; do echo "Running $f"; node $f; done`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e07f2d61c8327b53cb80f2caaeb4a