### PR TITLE
Refine status icons and unify pathfinding rules

### DIFF
--- a/src/game/utils/IconManager.js
+++ b/src/game/utils/IconManager.js
@@ -72,7 +72,7 @@ export class IconManager {
         const activeEffects = statusEffectManager.activeEffects.get(unitId) || [];
         const existingBuffIconIds = new Set(display.buffIcons.keys());
         const existingDebuffIconIds = new Set(display.debuffIcons.keys());
-        const iconSpacing = 22; // 아이콘 간격
+        const iconSpacing = 12; // 아이콘 간격 (기존 22에서 축소)
 
         const buffs = [];
         const debuffs = [];
@@ -122,16 +122,16 @@ export class IconManager {
                 const iconContainer = this.scene.add.container(0, 0);
                 const icon = this.scene.add
                     .image(0, 0, iconKey)
-                    .setScale(0.5)
+                    .setScale(0.04) // 크기 대폭 축소
                     .setAlpha(0.7);
                 const turnText = this.scene.add
-                    .text(0, 8, '', {
-                        fontSize: '12px',
+                    .text(5, 0, '', {
+                        fontSize: '10px',
                         color: '#fff',
                         stroke: '#000',
                         strokeThickness: 2,
                     })
-                    .setOrigin(0.5);
+                    .setOrigin(0, 0.5);
                 iconContainer.add([icon, turnText]);
                 display.buffsContainer.add(iconContainer);
                 iconData = { icon: iconContainer, text: turnText };
@@ -167,16 +167,16 @@ export class IconManager {
                 const iconContainer = this.scene.add.container(0, 0);
                 const icon = this.scene.add
                     .image(0, 0, iconKey)
-                    .setScale(0.5)
+                    .setScale(0.04) // 크기 대폭 축소
                     .setAlpha(0.7);
                 const turnText = this.scene.add
-                    .text(0, 8, '', {
-                        fontSize: '12px',
+                    .text(5, 0, '', {
+                        fontSize: '10px',
                         color: '#fff',
                         stroke: '#000',
                         strokeThickness: 2,
                     })
-                    .setOrigin(0.5);
+                    .setOrigin(0, 0.5);
                 iconContainer.add([icon, turnText]);
                 display.debuffsContainer.add(iconContainer);
                 iconData = { icon: iconContainer, text: turnText };

--- a/src/game/utils/PathfinderEngine.js
+++ b/src/game/utils/PathfinderEngine.js
@@ -58,20 +58,9 @@ class PathfinderEngine {
                     return;
                 }
 
-                // ✨ [핵심 버그 수정] 유닛 점유에 따른 경로 탐색 규칙 강화
-                // 어떤 유닛이든 점유된 칸을 최종 목적지로 사용할 수 없습니다.
-                // 플라잉맨이 아닌 유닛은 점유된 칸을 통과할 수 없습니다.
+                // ✨ [핵심 수정] 모든 유닛이 점유된 칸을 통과할 수 없도록 간소화합니다.
                 if (cell.isOccupied) {
-                    const isEndNode = neighbor.col === endNode.col && neighbor.row === endNode.row;
-                    if (isEndNode) {
-                        return; // 목표 지점이 점유되어 있다면 경로를 찾지 않습니다.
-                    }
-
-                    // 플라잉맨은 점유된 칸을 통과할 수 있지만, 도착할 수는 없습니다.
-                    // 따라서 통과 시에는 isOccupied 체크를 건너뜁니다.
-                    if (unit.id !== 'flyingmen') {
-                        return;
-                    }
+                    return;
                 }
 
                 const newCost = currentNode.gCost + this._getDistance(currentNode, neighbor);

--- a/tests/pathfinder_flyingmen_bug_test.js
+++ b/tests/pathfinder_flyingmen_bug_test.js
@@ -48,10 +48,10 @@ const path1 = pathfinderEngine.findPath(flyingman, { col: 1, row: 1 }, { col: 1,
 assert.strictEqual(path1, null, '테스트 1 실패: 플라잉맨이 점유된 칸으로의 경로를 생성했습니다.');
 console.log('✅ 테스트 1 통과: 플라잉맨은 점유된 칸에 도착할 수 없습니다.');
 
-// 테스트 2: 플라잉맨이 장애물이 있는 (1,2) 칸을 '통과'하여 (1,3)으로 갈 수 있는지 확인
+// 테스트 2: 플라잉맨이 장애물이 있는 (1,2) 칸을 '통과'하여 (1,3)으로 갈 수 없는지 확인
 const path2 = pathfinderEngine.findPath(flyingman, { col: 1, row: 1 }, { col: 1, row: 3 });
-assert(path2 && path2.length > 0, '테스트 2 실패: 플라잉맨이 점유된 칸을 통과하는 경로를 찾지 못했습니다.');
-console.log('✅ 테스트 2 통과: 플라잉맨은 점유된 칸을 통과할 수 있습니다.');
+assert.strictEqual(path2, null, '테스트 2 실패: 플라잉맨이 점유된 칸을 통과하는 경로를 생성했습니다.');
+console.log('✅ 테스트 2 통과: 플라잉맨은 점유된 칸을 통과할 수 없습니다.');
 
 // 테스트 3: 일반 유닛(전사)이 장애물이 있는 (1,2) 칸을 '통과'할 수 없는지 확인
 const path3 = pathfinderEngine.findPath(warrior, { col: 1, row: 1 }, { col: 1, row: 3 });


### PR DESCRIPTION
## Summary
- Shrink buff/debuff icons for clearer status displays
- Remove flying unit exception so occupied tiles block all units
- Adjust pathfinder test to match new movement rules

## Testing
- `for file in tests/*_test.js; do node $file; done > /tmp/test.log && tail -n 20 /tmp/test.log`
- `node tests/pathfinder_flyingmen_bug_test.js`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e2fce7dc88327b1b8e5b1daf5dde2