### PR TITLE
feat: add esper class with mind-based passive

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -447,6 +447,34 @@ body {
     font-weight: bold;
 }
 
+/* --- 클래스 패시브 UI 스타일 --- */
+.class-passive-section {
+    margin-top: 15px;
+}
+
+.passive-skill-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background-color: rgba(0,0,0,0.2);
+    padding: 8px;
+    border-radius: 4px;
+    cursor: help;
+}
+
+.passive-skill-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 4px;
+    border: 1px solid #555;
+}
+
+.passive-skill-name {
+    font-size: 16px;
+    font-weight: bold;
+    color: #fff;
+}
+
 .equip-slot {
     width: 80px;
     height: 100px;

--- a/src/game/data/classProficiencies.js
+++ b/src/game/data/classProficiencies.js
@@ -36,5 +36,12 @@ export const classProficiencies = {
         SKILL_TAGS.CHARGE,
         SKILL_TAGS.THROWING,
     ],
+    esper: [
+        SKILL_TAGS.MAGIC,
+        SKILL_TAGS.RANGED,
+        SKILL_TAGS.DEBUFF,
+        SKILL_TAGS.PROHIBITION,
+        SKILL_TAGS.MIND,
+    ],
     // '좀비'와 같은 몬스터는 숙련도 보너스를 받지 않으므로 정의하지 않습니다.
 };

--- a/src/game/data/classSpecializations.js
+++ b/src/game/data/classSpecializations.js
@@ -66,5 +66,17 @@ export const classSpecializations = {
                 modifiers: { stat: 'physicalEvadeChance', type: 'percentage', value: 0.03 }
             }
         }
+    ],
+    esper: [
+        {
+            tag: SKILL_TAGS.MIND,
+            description: "'정신' 태그 스킬 사용 시, 1턴간 상태이상 적용 확률 5% 증가 (중첩 가능)",
+            effect: {
+                id: 'esperMindBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: { stat: 'statusEffectApplication', type: 'percentage', value: 0.05 }
+            }
+        }
     ]
 };

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -112,5 +112,33 @@ export const mercenaryData = {
             movement: 5,
             weight: 11
         }
+    },
+    esper: {
+        id: 'esper',
+        name: '에스퍼',
+        hireImage: 'assets/images/unit/esper-hire.png',
+        uiImage: 'assets/images/unit/esper-ui.png',
+        battleSprite: 'esper',
+        sprites: {
+            idle: 'esper',
+            attack: 'esper-attack',
+            hitted: 'esper-hitted',
+            cast: 'esper-cast',
+            'status-effects': 'esper-status-effects',
+        },
+        description: '"당신의 정신은 제 손바닥 위에서 춤추게 될 겁니다."',
+        baseStats: {
+            hp: 85, valor: 8, strength: 5, endurance: 6,
+            agility: 11, intelligence: 18, wisdom: 15, luck: 12,
+            attackRange: 3,
+            movement: 3,
+            weight: 15
+        },
+        classPassive: {
+            id: 'mindExplosion',
+            name: '정신 폭발',
+            description: '자신의 주위 3타일 내에 [마법] 숙련도를 가진 아군 유닛의 수만큼 자신의 지능이 3%씩 증가합니다.',
+            iconPath: 'assets/images/skills/mind-explosion.png'
+        }
     }
 };

--- a/src/game/dom/UnitDetailDOM.js
+++ b/src/game/dom/UnitDetailDOM.js
@@ -146,10 +146,24 @@ export class UnitDetailDOM {
             </div>
         `;
         // --- ▲ [핵심 변경] 스탯 표시 영역 구조 변경 ---
+        // ✨ --- [신규] 클래스 패시브 표시 로직 추가 ---
+        let classPassiveHTML = '';
+        if (unitData.classPassive) {
+            classPassiveHTML = `
+                <div class="class-passive-section">
+                    <div class="section-title">클래스 패시브</div>
+                    <div class="passive-skill-item" data-tooltip="${unitData.classPassive.description}">
+                        <img src="${unitData.classPassive.iconPath}" class="passive-skill-icon"/>
+                        <span class="passive-skill-name">${unitData.classPassive.name}</span>
+                    </div>
+                </div>
+            `;
+        }
 
         leftSection.innerHTML = `
             ${gradeDisplayHTML}
             ${statsContainerHTML}
+            ${classPassiveHTML}
         `;
 
         const rightSection = document.createElement('div');

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -105,6 +105,16 @@ export class Preloader extends Scene
         this.load.image('flyingmen-ui', 'images/unit/flyingmen-ui.png');
         // --- ▲ [신규] 플라잉맨 관련 이미지 로드 추가 ▲ ---
 
+        // --- ▼ [신규] 에스퍼 관련 이미지 로드 추가 ▼ ---
+        this.load.image('esper', 'images/unit/esper.png');
+        this.load.image('esper-attack', 'images/unit/esper-attack.png');
+        this.load.image('esper-hitted', 'images/unit/esper-hitted.png');
+        this.load.image('esper-cast', 'images/unit/esper-cast.png');
+        this.load.image('esper-status-effects', 'images/unit/esper-status-effects.png');
+        this.load.image('esper-hire', 'images/unit/esper-hire.png');
+        this.load.image('esper-ui', 'images/unit/esper-ui.png');
+        // --- ▲ [신규] 에스퍼 관련 이미지 로드 추가 ▲ ---
+
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
 
@@ -166,7 +176,7 @@ export class Preloader extends Scene
     {
         // 전투 씬에서 사용될 주요 이미지들의 텍스처 필터링 모드를 설정하여 품질을 향상시킵니다.
         const battleTextures = [
-            'warrior', 'gunner', 'medic', 'nanomancer', 'flyingmen', 'zombie', 'ancestor-peor',
+            'warrior', 'gunner', 'medic', 'nanomancer', 'flyingmen', 'esper', 'zombie', 'ancestor-peor',
             'battle-stage-cursed-forest', 'battle-stage-arena'
         ];
 

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -34,6 +34,7 @@ import { comboManager } from './ComboManager.js';
 // ✨ YinYangEngine을 import 합니다.
 import { yinYangEngine } from './YinYangEngine.js';
 import { aspirationEngine } from './AspirationEngine.js'; // ✨ AspirationEngine import
+import { statEngine } from './StatEngine.js';
 
 // 그림자 생성을 담당하는 매니저
 import { ShadowManager } from './ShadowManager.js';
@@ -119,10 +120,17 @@ export class BattleSimulatorEngine {
 
         this._setupUnits(allUnits);
 
+        // ✨ [신규] 유닛 배치 및 기본 스탯 계산 후, 동적 패시브 적용
         allUnits.forEach(unit => {
-            if (unit.name === '거너') {
-                aiManager.registerUnit(unit, createRangedAI(this.aiEngines));
-            } else if (unit.name === '나노맨서') {
+            if (unit.team === 'ally') {
+                statEngine.applyDynamicPassives(unit, allies);
+            } else {
+                statEngine.applyDynamicPassives(unit, enemies);
+            }
+        });
+
+        allUnits.forEach(unit => {
+            if (unit.name === '거너' || unit.name === '나노맨서' || unit.name === '에스퍼') {
                 aiManager.registerUnit(unit, createRangedAI(this.aiEngines));
             } else if (unit.name === '전사' || unit.name === '좀비') {
                 aiManager.registerUnit(unit, createMeleeAI(this.aiEngines));

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -42,4 +42,5 @@ export const SKILL_TAGS = {
     PRODUCTION: '생산', // 공유 자원을 생성하는 스킬
     THROWING: '투척',   // 무기나 물체를 던지는 컨셉
     SPECIAL: '특수 스킬',// 특수 슬롯 전용 스킬
+    MIND: '정신',       // ✨ 에스퍼를 위한 '정신' 태그
 };


### PR DESCRIPTION
## Summary
- add MIND skill tag and esper proficiency/specialization
- introduce esper mercenary with mind explosion passive and assets
- implement dynamic passive logic and show class passives in unit details

## Testing
- `node tests/proficiency_specialization_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e46a8a7948327abe7914b81807993