### PR TITLE
Add INTJ AI behavior and supporting nodes

### DIFF
--- a/src/ai/behaviors/createINTJ_AI.js
+++ b/src/ai/behaviors/createINTJ_AI.js
@@ -1,0 +1,79 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import IsTargetTooCloseNode from '../nodes/IsTargetTooCloseNode.js';
+import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import FindYinYangTargetNode from '../nodes/FindYinYangTargetNode.js';
+import FindUniqueDebuffTargetNode from '../nodes/FindUniqueDebuffTargetNode.js';
+import FindAllyMagicClusterNode from '../nodes/FindAllyMagicClusterNode.js';
+
+/**
+ * INTJ: 전략가 아키타입 행동 트리
+ * 우선순위:
+ * 1. (이동) 아군 마법사 근처의 안전한 위치로 자리 잡기
+ * 2. (공격) '음' 지수가 높은 적 중, 아직 내 디버프에 걸리지 않은 대상에게 스킬 사용
+ * 3. (생존) 적이 너무 가까우면 카이팅
+ * 4. (기본) 일반적인 원거리 공격 또는 안전한 위치로 재배치
+ */
+function createINTJ_AI(engines = {}) {
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([new IsSkillInRangeNode(engines), new UseSkillNode(engines)]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 아군 마법사 클러스터로 이동 (패시브 극대화)
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindAllyMagicClusterNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+
+        // 2순위: 핵심 타겟에게 중복되지 않는 디버프 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindYinYangTargetNode(engines),
+            new FindUniqueDebuffTargetNode(engines),
+            executeSkillBranch
+        ]),
+
+        // 3순위: 생존을 위한 카이팅
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new IsTargetTooCloseNode({ ...engines, dangerZone: 3 }),
+            new FindKitingPositionNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        
+        // 4순위: 기본 원거리 공격 또는 안전한 위치로 재배치
+        new SelectorNode([
+            new SequenceNode([
+                new FindBestSkillByScoreNode(engines),
+                new FindYinYangTargetNode(engines),
+                executeSkillBranch
+            ]),
+            new SequenceNode([
+                new HasNotMovedNode(),
+                new FindSafeRepositionNode(engines),
+                new MoveToTargetNode(engines)
+            ])
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createINTJ_AI };

--- a/src/ai/nodes/FindAllyMagicClusterNode.js
+++ b/src/ai/nodes/FindAllyMagicClusterNode.js
@@ -1,0 +1,73 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { classProficiencies } from '../../game/data/classProficiencies.js';
+import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
+
+/**
+ * [마법] 숙련도 태그를 가진 아군 클러스터의 중심점으로 이동 경로를 설정하는 노드.
+ * 자신을 제외하고 마법 아군이 1명 이상일 때만 작동합니다.
+ */
+class FindAllyMagicClusterNode extends Node {
+    constructor({ pathfinderEngine, formationEngine }) {
+        super();
+        this.pathfinderEngine = pathfinderEngine;
+        this.formationEngine = formationEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const allies = blackboard.get('allyUnits');
+
+        // 1. 자신을 제외한 마법 숙련도 아군 필터링
+        const magicAllies = allies.filter(ally => {
+            if (ally.uniqueId === unit.uniqueId) return false;
+            const proficiencies = classProficiencies[ally.id] || [];
+            return proficiencies.includes(SKILL_TAGS.MAGIC);
+        });
+
+        if (magicAllies.length < 1) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '주변에 마법 아군이 부족함');
+            return NodeState.FAILURE;
+        }
+
+        // 2. 마법 아군 클러스터의 평균 위치(중심점) 계산
+        const totalPos = magicAllies.reduce((acc, ally) => {
+            acc.col += ally.gridX;
+            acc.row += ally.gridY;
+            return acc;
+        }, { col: 0, row: 0 });
+
+        const centerPos = {
+            col: Math.round(totalPos.col / magicAllies.length),
+            row: Math.round(totalPos.row / magicAllies.length),
+        };
+
+        // 3. 중심점 주변의 가장 가까운 빈 셀 찾기
+        const availableCells = this.formationEngine.grid.gridCells.filter(c => !c.isOccupied);
+        if (availableCells.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '이동할 빈 셀이 없음');
+            return NodeState.FAILURE;
+        }
+
+        availableCells.sort((a, b) => {
+            const distA = Math.abs(a.col - centerPos.col) + Math.abs(a.row - centerPos.row);
+            const distB = Math.abs(b.col - centerPos.col) + Math.abs(b.row - centerPos.row);
+            return distA - distB;
+        });
+        const bestCell = availableCells[0];
+
+        // 4. 해당 위치로의 경로 탐색 및 블랙보드에 저장
+        const path = this.pathfinderEngine.findPath(unit, { col: unit.gridX, row: unit.gridY }, { col: bestCell.col, row: bestCell.row });
+
+        if (path && path.length > 0) {
+            blackboard.set('movementPath', path);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `마법 아군 클러스터(${bestCell.col}, ${bestCell.row})로 경로 설정`);
+            return NodeState.SUCCESS;
+        }
+        
+        debugAIManager.logNodeResult(NodeState.FAILURE, '클러스터로의 경로 탐색 실패');
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindAllyMagicClusterNode;

--- a/src/ai/nodes/FindUniqueDebuffTargetNode.js
+++ b/src/ai/nodes/FindUniqueDebuffTargetNode.js
@@ -1,0 +1,50 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { statusEffectManager } from '../../game/utils/StatusEffectManager.js';
+
+/**
+ * 현재 선택된 스킬의 디버프 효과가 없는 적을 우선적으로 찾아 타겟으로 설정하는 노드.
+ * 적합한 대상이 없으면 실패를 반환합니다.
+ */
+class FindUniqueDebuffTargetNode extends Node {
+    constructor({ targetManager }) {
+        super();
+        this.targetManager = targetManager;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const skillData = blackboard.get('currentSkillData');
+        const enemies = blackboard.get('enemyUnits');
+
+        if (!skillData || !skillData.effect || !enemies || enemies.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '디버프 스킬, 효과 또는 적 유닛 없음');
+            return NodeState.FAILURE;
+        }
+
+        const debuffId = skillData.effect.id;
+
+        // 1. 해당 디버프가 아직 없는 적들을 필터링합니다.
+        const potentialTargets = enemies.filter(enemy => {
+            const activeEffects = statusEffectManager.activeEffects.get(enemy.uniqueId) || [];
+            return !activeEffects.some(effect => effect.id === debuffId);
+        });
+
+        if (potentialTargets.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, `모든 적이 이미 [${debuffId}] 효과를 가지고 있음`);
+            return NodeState.FAILURE;
+        }
+
+        // 2. 필터링된 대상 중에서 가장 가까운 적을 최종 타겟으로 선정합니다.
+        const target = this.targetManager.findNearestEnemy(unit, potentialTargets);
+        if (target) {
+            blackboard.set('skillTarget', target);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `중복되지 않는 디버프 대상 [${target.instanceName}] 설정`);
+            return NodeState.SUCCESS;
+        }
+
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindUniqueDebuffTargetNode;

--- a/src/ai/nodes/FindYinYangTargetNode.js
+++ b/src/ai/nodes/FindYinYangTargetNode.js
@@ -1,0 +1,43 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { yinYangEngine } from '../../game/utils/YinYangEngine.js';
+
+/**
+ * 음양 지수에서 '음' 값이 높은(음수가 큰) 적을 찾아 스킬 타겟으로 설정하는 노드.
+ */
+class FindYinYangTargetNode extends Node {
+    constructor() {
+        super();
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const enemies = blackboard.get('enemyUnits');
+        if (!enemies || enemies.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '적 유닛 없음');
+            return NodeState.FAILURE;
+        }
+
+        const candidates = enemies.filter(e => yinYangEngine.getBalance(e.uniqueId) < 0);
+        if (candidates.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '음 지수가 높은 적 없음');
+            return NodeState.FAILURE;
+        }
+
+        let best = candidates[0];
+        let bestBalance = yinYangEngine.getBalance(best.uniqueId);
+        for (const enemy of candidates.slice(1)) {
+            const bal = yinYangEngine.getBalance(enemy.uniqueId);
+            if (bal < bestBalance) {
+                best = enemy;
+                bestBalance = bal;
+            }
+        }
+
+        blackboard.set('skillTarget', best);
+        debugAIManager.logNodeResult(NodeState.SUCCESS, `음 지수 타겟 [${best.instanceName}] 설정`);
+        return NodeState.SUCCESS;
+    }
+}
+
+export default FindYinYangTargetNode;

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -8,11 +8,6 @@ import { TerminationManager } from './TerminationManager.js';
 import { SummoningEngine } from './SummoningEngine.js';
 
 import { aiManager } from '../../ai/AIManager.js';
-import { createMeleeAI } from '../../ai/behaviors/MeleeAI.js';
-import { createRangedAI } from '../../ai/behaviors/RangedAI.js';
-// ✨ 메딕을 위한 Healer AI를 import 합니다.
-import { createHealerAI } from '../../ai/behaviors/createHealerAI.js';
-import { createFlyingmanAI } from '../../ai/behaviors/createFlyingmanAI.js';
 
 import { targetManager } from './TargetManager.js';
 import { pathfinderEngine } from './PathfinderEngine.js';
@@ -129,16 +124,10 @@ export class BattleSimulatorEngine {
             }
         });
 
+        // AI 엔진 패키지를 AIManager에 전달하고 각 유닛을 등록합니다.
+        aiManager.aiEngines = this.aiEngines;
         allUnits.forEach(unit => {
-            if (unit.name === '거너' || unit.name === '나노맨서' || unit.name === '에스퍼') {
-                aiManager.registerUnit(unit, createRangedAI(this.aiEngines));
-            } else if (unit.name === '전사' || unit.name === '좀비') {
-                aiManager.registerUnit(unit, createMeleeAI(this.aiEngines));
-            } else if (unit.name === '메딕') {
-                aiManager.registerUnit(unit, createHealerAI(this.aiEngines));
-            } else if (unit.name === '플라잉맨') {
-                aiManager.registerUnit(unit, createFlyingmanAI(this.aiEngines));
-            }
+            aiManager.registerUnit(unit);
         });
 
         this.turnQueue = turnOrderManager.createTurnQueue(allUnits);

--- a/src/game/utils/SummoningEngine.js
+++ b/src/game/utils/SummoningEngine.js
@@ -5,7 +5,6 @@ import { getMonsterBase } from '../data/monster.js';
 import { getSummonBase } from '../data/summon.js';
 // AI 매니저와 근접 AI를 불러와 소환된 유닛을 즉시 등록할 수 있도록 합니다.
 import { aiManager } from '../../ai/AIManager.js';
-import { createMeleeAI } from '../../ai/behaviors/MeleeAI.js';
 // 소환된 유닛을 토큰 시스템에 등록하기 위해 토큰 엔진을 불러옵니다.
 import { tokenEngine } from './TokenEngine.js';
 
@@ -74,10 +73,8 @@ class SummoningEngine {
         this.battleSimulator._setupUnits([summonedUnit]);
 
         // 5. AI 매니저에 새 유닛을 등록하여 즉시 행동 트리를 갖게 합니다.
-        if (summonedUnit.className === '전사' || summonedUnit.name === '선조 페오르') {
-            aiManager.registerUnit(summonedUnit, createMeleeAI(this.battleSimulator.aiEngines));
-            debugLogEngine.log('SummoningEngine', `${summonedUnit.instanceName}에게 MeleeAI를 등록했습니다.`);
-        }
+        aiManager.registerUnit(summonedUnit);
+        debugLogEngine.log('SummoningEngine', `${summonedUnit.instanceName} AI 등록`);
 
         // 6. 소환사에게 체력 페널티 적용
         const penalty = Math.round(summoner.finalStats.hp * (summonSkillData.healthCostPercent || 0.1)); // 기본 10%


### PR DESCRIPTION
## Summary
- Target enemies lacking a debuff and avoid duplicates
- Seek clusters of allied magic users for strategic positioning
- Introduce INTJ archetype behavior tree and MBTI-aware AI registration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e48cd352083278e67d2cc87c77d1d