### PR TITLE
feat(ai): add ENTJ archetype behavior

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -8,6 +8,8 @@ import { createFlyingmanAI } from './behaviors/createFlyingmanAI.js';
 import { createINTJ_AI } from './behaviors/createINTJ_AI.js';
 // ✨ [신규] INTP AI import
 import { createINTP_AI } from './behaviors/createINTP_AI.js';
+// ✨ [신규] ENTJ AI import
+import { createENTJ_AI } from './behaviors/createENTJ_AI.js';
 
 /**
  * 게임 내 모든 AI 유닛을 관리하고, 각 유닛의 행동 트리를 실행합니다.
@@ -48,6 +50,8 @@ class AIManager {
             case 'INTJ': return createINTJ_AI(this.aiEngines);
             // ✨ [신규] INTP 케이스 추가
             case 'INTP': return createINTP_AI(this.aiEngines);
+            // ✨ [신규] ENTJ 케이스 추가
+            case 'ENTJ': return createENTJ_AI(this.aiEngines);
             default:
                 if (unit.name === '거너' || unit.name === '나노맨서' || unit.name === '에스퍼') {
                     return createRangedAI(this.aiEngines);

--- a/src/ai/behaviors/createENTJ_AI.js
+++ b/src/ai/behaviors/createENTJ_AI.js
@@ -1,0 +1,61 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import IsEarlyBattleNode from '../nodes/IsEarlyBattleNode.js';
+import FindStrategySkillNode from '../nodes/FindStrategySkillNode.js';
+import FindAllyClusterCenterNode from '../nodes/FindAllyClusterCenterNode.js';
+
+/**
+ * ENTJ: 통솔관 아키타입 행동 트리
+ * 우선순위:
+ * 1. (전략) 전투 초반에 강력한 전략 스킬 사용
+ * 2. (위치) 아군 진형의 중심으로 이동
+ * 3. (일반) 점수가 가장 높은 스킬 사용
+ */
+function createENTJ_AI(engines = {}) {
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([new IsSkillInRangeNode(engines), new UseSkillNode(engines)]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 전투 초반에 전략 스킬 사용
+        new SequenceNode([
+            new IsEarlyBattleNode(2), // 1~2턴 동안만 시도
+            new FindStrategySkillNode(engines),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+
+        // 2순위: 아군 클러스터 중심으로 이동
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindAllyClusterCenterNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+
+        // 3순위: 일반적인 최적 스킬 사용
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createENTJ_AI };

--- a/src/ai/nodes/FindAllyClusterCenterNode.js
+++ b/src/ai/nodes/FindAllyClusterCenterNode.js
@@ -1,0 +1,60 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 모든 아군 유닛들의 평균 위치(중심점) 근처의 가장 가까운 빈 셀로 이동 경로를 설정하는 노드.
+ */
+class FindAllyClusterCenterNode extends Node {
+    constructor({ pathfinderEngine, formationEngine } = {}) {
+        super();
+        this.pathfinderEngine = pathfinderEngine;
+        this.formationEngine = formationEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const allies = blackboard.get('allyUnits');
+
+        // 자신을 제외한 아군이 1명 이상 있어야 의미가 있음
+        if (!allies || allies.length < 2) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '클러스터를 형성할 아군이 부족함');
+            return NodeState.FAILURE;
+        }
+
+        const totalPos = allies.reduce((acc, ally) => {
+            acc.col += ally.gridX;
+            acc.row += ally.gridY;
+            return acc;
+        }, { col: 0, row: 0 });
+
+        const centerPos = {
+            col: Math.round(totalPos.col / allies.length),
+            row: Math.round(totalPos.row / allies.length),
+        };
+
+        const availableCells = this.formationEngine.grid.gridCells.filter(c => !c.isOccupied || (c.col === unit.gridX && c.row === unit.gridY));
+        if (availableCells.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '이동할 빈 셀이 없음');
+            return NodeState.FAILURE;
+        }
+
+        availableCells.sort((a, b) => {
+            const distA = Math.abs(a.col - centerPos.col) + Math.abs(a.row - centerPos.row);
+            const distB = Math.abs(b.col - centerPos.col) + Math.abs(b.row - centerPos.row);
+            return distA - distB;
+        });
+        const bestCell = availableCells[0];
+
+        const path = this.pathfinderEngine.findPath(unit, { col: unit.gridX, row: unit.gridY }, { col: bestCell.col, row: bestCell.row });
+        if (path && path.length > 0) {
+            blackboard.set('movementPath', path);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `아군 중심(${bestCell.col}, ${bestCell.row})으로 경로 설정`);
+            return NodeState.SUCCESS;
+        }
+        
+        debugAIManager.logNodeResult(NodeState.FAILURE, '아군 중심점으로의 경로 탐색 실패');
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindAllyClusterCenterNode;

--- a/src/ai/nodes/FindStrategySkillNode.js
+++ b/src/ai/nodes/FindStrategySkillNode.js
@@ -1,0 +1,37 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { ownedSkillsManager } from '../../game/utils/OwnedSkillsManager.js';
+import { skillInventoryManager } from '../../game/utils/SkillInventoryManager.js';
+import { skillEngine } from '../../game/utils/SkillEngine.js';
+import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
+
+/**
+ * 사용 가능한 [전략] 태그 스킬을 찾아 블랙보드에 설정합니다.
+ */
+class FindStrategySkillNode extends Node {
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const equippedSkillInstances = ownedSkillsManager.getEquippedSkills(unit.uniqueId);
+        const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
+
+        for (const instanceId of equippedSkillInstances) {
+            if (!instanceId || usedSkills.has(instanceId)) continue;
+
+            const instData = skillInventoryManager.getInstanceData(instanceId);
+            const skillData = skillInventoryManager.getSkillData(instData.skillId, instData.grade);
+
+            if ((skillData.tags || []).includes(SKILL_TAGS.STRATEGY) && skillEngine.canUseSkill(unit, skillData)) {
+                blackboard.set('currentTargetSkill', { skillData, instanceId });
+                blackboard.set('currentSkillData', skillData);
+                blackboard.set('currentSkillInstanceId', instanceId);
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `전략 스킬 [${skillData.name}] 찾음`);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '사용 가능한 전략 스킬 없음');
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindStrategySkillNode;

--- a/src/ai/nodes/IsEarlyBattleNode.js
+++ b/src/ai/nodes/IsEarlyBattleNode.js
@@ -1,0 +1,27 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 현재 턴이 지정된 턴 수 이하인지 확인하는 조건 노드입니다.
+ */
+class IsEarlyBattleNode extends Node {
+    constructor(maxTurn = 2) {
+        super();
+        this.maxTurn = maxTurn;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const currentTurn = blackboard.get('currentTurnNumber');
+
+        if (currentTurn <= this.maxTurn) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `전투 초반(현재 ${currentTurn}턴)`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, `전투 초반이 아님(현재 ${currentTurn}턴)`);
+        return NodeState.FAILURE;
+    }
+}
+
+export default IsEarlyBattleNode;

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -203,6 +203,12 @@ export class BattleSimulatorEngine {
         while (this.isRunning && !this.isBattleOver()) {
             const currentUnit = this.turnQueue[this.currentTurnIndex];
 
+            // ✨ AI가 현재 턴을 인식할 수 있도록 블랙보드에 기록
+            const aiData = aiManager.unitData.get(currentUnit.uniqueId);
+            if (aiData) {
+                aiData.behaviorTree.blackboard.set('currentTurnNumber', this.currentTurnNumber);
+            }
+
             // 턴 시작 시 콤보 정보를 초기화합니다.
             comboManager.startTurn(currentUnit.uniqueId);
 


### PR DESCRIPTION
## Summary
- create ENTJ-specific behavior tree prioritizing early strategy skills and formation-centric movement
- add reusable nodes for ally cluster center, early battle turn check, and strategy skill search
- notify AI blackboards of current turn and enable ENTJ archetype in AI manager

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e73e33e0c8327b6e9d1205c5201ba