### PR TITLE
refactor: streamline mercenary hiring and sprite loading

### DIFF
--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -2,7 +2,6 @@ export const mercenaryData = {
     warrior: {
         id: 'warrior',
         name: '전사',
-        hireImage: 'assets/images/territory/warrior-hire.png',
         uiImage: 'assets/images/territory/warrior-ui.png',
         battleSprite: 'warrior',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -24,7 +23,6 @@ export const mercenaryData = {
     gunner: {
         id: 'gunner',
         name: '거너',
-        hireImage: 'assets/images/territory/gunner-hire.png',
         uiImage: 'assets/images/territory/gunner-ui.png',
         battleSprite: 'gunner',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -47,7 +45,6 @@ export const mercenaryData = {
     medic: {
         id: 'medic',
         name: '메딕',
-        hireImage: 'assets/images/territory/medic-hire.png',
         uiImage: 'assets/images/territory/medic-ui.png',
         battleSprite: 'medic',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -70,7 +67,6 @@ export const mercenaryData = {
     nanomancer: {
         id: 'nanomancer',
         name: '나노맨서',
-        hireImage: 'assets/images/unit/nanomancer-hire.png',
         uiImage: 'assets/images/unit/nanomancer-ui.png',
         battleSprite: 'nanomancer',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -99,7 +95,6 @@ export const mercenaryData = {
     flyingmen: {
         id: 'flyingmen',
         name: '플라잉맨',
-        hireImage: 'assets/images/unit/flyingmen-hire.png',
         uiImage: 'assets/images/unit/flyingmen-ui.png',
         battleSprite: 'flyingmen',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -122,15 +117,14 @@ export const mercenaryData = {
     esper: {
         id: 'esper',
         name: '에스퍼',
-        hireImage: 'assets/images/unit/esper-hire.png',
         uiImage: 'assets/images/unit/esper-ui.png',
         battleSprite: 'esper',
         sprites: {
             idle: 'esper',
-            attack: 'esper-attack',
-            hitted: 'esper-hitted',
-            cast: 'esper-cast',
-            'status-effects': 'esper-status-effects',
+            attack: 'esper',
+            hitted: 'esper',
+            cast: 'esper',
+            'status-effects': 'esper',
         },
         description: '"당신의 정신은 제 손바닥 위에서 춤추게 될 겁니다."',
         baseStats: {
@@ -151,15 +145,14 @@ export const mercenaryData = {
     commander: {
         id: 'commander',
         name: '커맨더',
-        hireImage: 'assets/images/unit/commander-hire.png',
         uiImage: 'assets/images/unit/commander-ui.png',
         battleSprite: 'commander',
         sprites: {
             idle: 'commander',
-            attack: 'commander-attack',
-            hitted: 'commander-hitted',
-            cast: 'commander-cast',
-            'status-effects': 'commander-status-effects',
+            attack: 'commander',
+            hitted: 'commander',
+            cast: 'commander',
+            'status-effects': 'commander',
         },
         description: '"나의 방패는 동료를 위하고, 나의 검은 적을 향한다."',
         baseStats: {

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -16,12 +16,9 @@ export class TerritoryDOMEngine {
         this.container = document.getElementById('territory-container');
         this.grid = null;
         this.tavernView = null;
-        this.hireModal = null;
         this.unitDetailView = null;
 
         this.mercenaries = mercenaryData;
-        this.mercenaryList = Object.values(this.mercenaries);
-        this.currentMercenaryIndex = 0;
 
         this.createGrid();
         this.addBuilding(0, 0, 'tavern-icon', '[여관]');
@@ -210,21 +207,6 @@ export class TerritoryDOMEngine {
         tavernGrid.id = 'tavern-grid';
         this.tavernView.appendChild(tavernGrid);
 
-        const hireButton = document.createElement('div');
-        hireButton.className = 'tavern-button';
-        hireButton.style.backgroundImage = `url(assets/images/territory/hire-icon.png)`;
-        hireButton.addEventListener('click', () => {
-            this.showHireModal();
-        });
-        hireButton.addEventListener('mouseover', (event) => {
-            this.domEngine.showTooltip(event.clientX, event.clientY, '[용병 고용]');
-        });
-        hireButton.addEventListener('mouseout', () => {
-            this.domEngine.hideTooltip();
-        });
-
-        tavernGrid.appendChild(hireButton);
-
         // --- ▼ [신규] 랜덤 12명 고용 버튼 추가 ▼ ---
         const hireRandomButton = document.createElement('div');
         hireRandomButton.className = 'tavern-button';
@@ -255,89 +237,6 @@ export class TerritoryDOMEngine {
         // --- ▲ [신규] 랜덤 12명 고용 버튼 추가 ▲ ---
     }
 
-    showHireModal() {
-        if (this.hireModal) return;
-
-        this.hireModal = document.createElement('div');
-        // ✨ [수정] ID 대신 클래스를 사용합니다.
-        this.hireModal.className = 'modal-overlay';
-        
-        const modalContent = document.createElement('div');
-        modalContent.id = 'hire-modal-content';
-
-        const imageViewer = document.createElement('div');
-        imageViewer.id = 'hire-image-viewer';
-        
-        const mercenaryImage = document.createElement('img');
-        mercenaryImage.id = 'mercenary-image';
-
-        mercenaryImage.onclick = () => {
-            const baseMercenaryData = this.mercenaryList[this.currentMercenaryIndex];
-            const newInstance = mercenaryEngine.hireMercenary(baseMercenaryData, 'ally');
-            
-            this.hideHireModal();
-            this.showUnitDetails(newInstance);
-        };
-
-        const leftArrow = document.createElement('div');
-        leftArrow.className = 'hire-arrow';
-        leftArrow.innerText = '<';
-        leftArrow.onclick = () => this.changeMercenary(-1);
-
-        const rightArrow = document.createElement('div');
-        rightArrow.className = 'hire-arrow';
-        rightArrow.innerText = '>';
-        rightArrow.onclick = () => this.changeMercenary(1);
-
-        const closeButton = document.createElement('div');
-        closeButton.id = 'hire-modal-close';
-        closeButton.innerText = 'X';
-        closeButton.onclick = () => this.hideHireModal();
-        
-        const hireEnemyButton = document.createElement('div');
-        hireEnemyButton.id = 'hire-enemy-button';
-        hireEnemyButton.innerText = '[적군 생성]';
-        hireEnemyButton.onclick = (event) => {
-            const baseMercenaryData = this.mercenaryList[this.currentMercenaryIndex];
-            mercenaryEngine.hireMercenary(baseMercenaryData, 'enemy');
-            this.domEngine.showTooltip(event.clientX, event.clientY, `적군 ${baseMercenaryData.name} 생성됨!`);
-            setTimeout(() => this.domEngine.hideTooltip(), 1000);
-        };
-        
-        imageViewer.appendChild(leftArrow);
-        imageViewer.appendChild(mercenaryImage);
-        imageViewer.appendChild(rightArrow);
-
-        modalContent.appendChild(closeButton);
-        modalContent.appendChild(imageViewer);
-        modalContent.appendChild(hireEnemyButton);
-        this.hireModal.appendChild(modalContent);
-        this.container.appendChild(this.hireModal);
-
-        // ✨ [추가] fade-in 애니메이션을 트리거합니다.
-        requestAnimationFrame(() => {
-            this.hireModal.classList.add('visible');
-        });
-
-        this.hireModal.addEventListener('wheel', (event) => {
-            event.preventDefault();
-            this.changeMercenary(event.deltaY > 0 ? 1 : -1);
-        });
-
-        this.updateMercenaryImage();
-    }
-    
-    hideHireModal() {
-        if (this.hireModal) {
-            // ✨ [수정] fade-out 애니메이션을 트리거하고, 끝나면 DOM에서 제거합니다.
-            this.hireModal.classList.remove('visible');
-            this.hireModal.addEventListener('transitionend', () => {
-                if (this.hireModal) this.hireModal.remove();
-                this.hireModal = null;
-            }, { once: true });
-        }
-    }
-
     hideTavernView() {
         if (this.tavernView) {
             this.tavernView.remove();
@@ -345,27 +244,6 @@ export class TerritoryDOMEngine {
         }
         this.container.style.backgroundImage = `url(assets/images/territory/city-1.png)`;
         this.grid.style.display = 'grid';
-    }
-
-    changeMercenary(direction) {
-        this.currentMercenaryIndex += direction;
-
-        if (this.currentMercenaryIndex >= this.mercenaryList.length) {
-            this.currentMercenaryIndex = 0;
-        } else if (this.currentMercenaryIndex < 0) {
-            this.currentMercenaryIndex = this.mercenaryList.length - 1;
-        }
-
-        this.updateMercenaryImage();
-    }
-
-    updateMercenaryImage() {
-        const mercenaryImage = document.getElementById('mercenary-image');
-        if (mercenaryImage) {
-            const newMercenary = this.mercenaryList[this.currentMercenaryIndex];
-            mercenaryImage.src = newMercenary.hireImage;
-            mercenaryImage.alt = newMercenary.name;
-        }
     }
 
     showUnitDetails(unitData) {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -58,74 +58,23 @@ export class Preloader extends Scene
         // 로고 이미지를 로드합니다.
         this.load.image('logo', 'logo.png');
 
-        // 게임 씬에서 사용할 전사 이미지를 로드합니다.
+        // 유닛 기본 스프라이트 로드
         this.load.image('warrior', 'images/unit/warrior.png');
         this.load.image('gunner', 'images/unit/gunner.png');
-
-        // --- 전사의 행동별 스프라이트 로드 ---
-        this.load.image('warrior-attack', 'images/unit/warrior-attack.png');
-        this.load.image('warrior-hitted', 'images/unit/warrior-hitted.png');
-        this.load.image('warrior-cast', 'images/unit/warrior-cast.png');
-        // 상태이상 표현 스프라이트
-        this.load.image('warrior-status-effects', 'images/unit/warrior-status-effects.png');
-
-        // --- 거너의 행동별 스프라이트 로드 ---
-        this.load.image('gunner-attack', 'images/unit/gunner-attack.png');
-        this.load.image('gunner-hitted', 'images/unit/gunner-hitted.png');
-        this.load.image('gunner-cast', 'images/unit/gunner-cast.png');
-        this.load.image('gunner-status-effects', 'images/unit/gunner-status-effects.png');
-
-        // --- ▼ [신규] 메딕 관련 이미지 로드 추가 ▼ ---
         this.load.image('medic', 'images/unit/medic.png');
-        this.load.image('medic-attack', 'images/unit/medic-attack.png');
-        this.load.image('medic-hitted', 'images/unit/medic-hitted.png');
-        this.load.image('medic-cast', 'images/unit/medic-cast.png');
-        this.load.image('medic-status-effects', 'images/unit/medic-status-effects.png');
-        this.load.image('medic-hire', 'images/territory/medic-hire.png');
-        this.load.image('medic-ui', 'images/territory/medic-ui.png');
-        // --- ▲ [신규] 메딕 관련 이미지 로드 추가 ▲ ---
-
-        // --- ▼ [신규] 나노맨서 관련 이미지 로드 추가 ▼ ---
         this.load.image('nanomancer', 'images/unit/nanomancer.png');
-        this.load.image('nanomancer-attack', 'images/unit/nanomancer-attack.png');
-        this.load.image('nanomancer-hitted', 'images/unit/nanomancer-hitted.png');
-        this.load.image('nanomancer-cast', 'images/unit/nanomancer-cast.png');
-        this.load.image('nanomancer-status-effects', 'images/unit/nanomancer-status-effects.png');
-        this.load.image('nanomancer-hire', 'images/unit/nanomancer-hire.png');
-        this.load.image('nanomancer-ui', 'images/unit/nanomancer-ui.png');
-        // --- ▲ [신규] 나노맨서 관련 이미지 로드 추가 ▲ ---
-
-        // --- ▼ [신규] 플라잉맨 관련 이미지 로드 추가 ▼ ---
         this.load.image('flyingmen', 'images/unit/flyingmen.png');
-        this.load.image('flyingmen-attack', 'images/unit/flyingmen-attack.png');
-        this.load.image('flyingmen-hitted', 'images/unit/flyingmen-hitted.png');
-        this.load.image('flyingmen-cast', 'images/unit/flyingmen-cast.png');
-        this.load.image('flyingmen-status-effects', 'images/unit/flyingmen-status-effects.png');
-        this.load.image('flyingmen-hire', 'images/unit/flyingmen-hire.png');
-        this.load.image('flyingmen-ui', 'images/unit/flyingmen-ui.png');
-        // --- ▲ [신규] 플라잉맨 관련 이미지 로드 추가 ▲ ---
-
-        // --- ▼ [신규] 에스퍼 관련 이미지 로드 추가 ▼ ---
         this.load.image('esper', 'images/unit/esper.png');
-        this.load.image('esper-attack', 'images/unit/esper-attack.png');
-        this.load.image('esper-hitted', 'images/unit/esper-hitted.png');
-        this.load.image('esper-cast', 'images/unit/esper-cast.png');
-        this.load.image('esper-status-effects', 'images/unit/esper-status-effects.png');
-        this.load.image('esper-hire', 'images/unit/esper-hire.png');
-        this.load.image('esper-ui', 'images/unit/esper-ui.png');
-        // --- ▲ [신규] 에스퍼 관련 이미지 로드 추가 ▲ ---
-
-        // --- ▼ [신규] 커맨더 관련 이미지 로드 추가 ▼ ---
         this.load.image('commander', 'images/unit/commander.png');
-        // 업로드되지 않은 스프라이트는 기본 이미지를 재사용합니다.
-        this.load.image('commander-attack', 'images/unit/commander.png');
-        this.load.image('commander-hitted', 'images/unit/commander.png');
-        this.load.image('commander-cast', 'images/unit/commander.png');
-        this.load.image('commander-status-effects', 'images/unit/commander.png');
-        this.load.image('commander-hire', 'images/unit/commander-hire.png');
+
+        // UI용 이미지 로드
+        this.load.image('warrior-ui', 'images/territory/warrior-ui.png');
+        this.load.image('gunner-ui', 'images/territory/gunner-ui.png');
+        this.load.image('medic-ui', 'images/territory/medic-ui.png');
+        this.load.image('nanomancer-ui', 'images/unit/nanomancer-ui.png');
+        this.load.image('flyingmen-ui', 'images/unit/flyingmen-ui.png');
+        this.load.image('esper-ui', 'images/unit/esper-ui.png');
         this.load.image('commander-ui', 'images/unit/commander-ui.png');
-        this.load.image('commanders-shout', 'images/skills/commanders-shout.png');
-        // --- ▲ [신규] 커맨더 관련 이미지 로드 추가 ▲ ---
 
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
@@ -135,11 +84,6 @@ export class Preloader extends Scene
 
         // --- 추가된 애셋들 ---
         this.load.image('tavern-scene', 'images/territory/tavern-scene.png');
-        this.load.image('hire-icon', 'images/territory/hire-icon.png');
-        this.load.image('warrior-hire', 'images/territory/warrior-hire.png');
-        this.load.image('gunner-hire', 'images/territory/gunner-hire.png');
-        this.load.image('warrior-ui', 'images/territory/warrior-ui.png');
-        this.load.image('gunner-ui', 'images/territory/gunner-ui.png');
         this.load.image('dungeon-icon', 'images/territory/dungeon-icon.png');
         this.load.image('dungeon-scene', 'images/territory/dungeon-scene.png');
         this.load.image('cursed-forest', 'images/territory/cursed-forest.png');
@@ -159,6 +103,7 @@ export class Preloader extends Scene
         this.load.image('stigma', 'images/skills/stigma.png');
         this.load.image('nanobeam', 'images/skills/nanobeam.png');
         this.load.image('axe-strike', 'images/skills/axe-strike.png');
+        this.load.image('commanders-shout', 'images/skills/commanders-shout.png');
         // 공통 패널 배경 이미지
         this.load.image('panel-background', 'images/ui-panel.png');
         this.load.image('battle-stage-arena', 'images/battle/battle-stage-arena.png');


### PR DESCRIPTION
## Summary
- drop individual hire modal; tavern now only supports bulk random hiring
- unify mercenary sprite definitions and remove hire images
- load only base unit sprites in preloader, removing motion-specific assets

## Testing
- `node tests/combat_calculation_test.js`
- `for file in tests/*_test.js; do echo "Running $file"; node $file; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e80d30c4883278a8ebcf65aca8a04