### PR TITLE
feat: add placeholder manager for missing images

### DIFF
--- a/src/game/data/items.js
+++ b/src/game/data/items.js
@@ -29,7 +29,7 @@ export const itemBaseData = {
         id: 'baseballBat',
         name: '야구 방망이',
         type: EQUIPMENT_SLOTS.WEAPON,
-        illustrationPath: 'assets/images/item/baseball-bat.png',
+        illustrationPath: null,
         baseStats: {
             physicalAttack: { min: 6, max: 9 }
         },

--- a/src/game/dom/EquipmentManagementDOMEngine.js
+++ b/src/game/dom/EquipmentManagementDOMEngine.js
@@ -5,6 +5,7 @@ import { equipmentManager } from '../utils/EquipmentManager.js';
 import { itemInventoryManager } from '../utils/ItemInventoryManager.js';
 import { ItemTooltipManager } from './ItemTooltipManager.js';
 import { EQUIPMENT_SLOTS } from '../data/items.js';
+import { placeholderManager } from '../utils/PlaceholderManager.js';
 // 새로 만든 장비 자동 장착기를 불러옵니다.
 import { mercenaryEquipmentSelector } from '../utils/MercenaryEquipmentSelector.js';
 
@@ -164,7 +165,7 @@ export class EquipmentManagementDOMEngine {
         slot.ondrop = e => this.onDropOnSlot(e);
         
         if (item) {
-            slot.style.backgroundImage = `url(${item.illustrationPath})`;
+            slot.style.backgroundImage = `url(${placeholderManager.getPath(item.illustrationPath)})`;
             slot.draggable = true;
             slot.dataset.instanceId = item.instanceId;
             slot.ondragstart = e => this.onDragStart(e, { source: 'slot', instanceId: item.instanceId, slotType: slotType });
@@ -203,7 +204,7 @@ export class EquipmentManagementDOMEngine {
         inventory.forEach(item => {
             const itemCard = document.createElement('div');
             itemCard.className = `item-inventory-card grade-${item.grade.toLowerCase()}`;
-            itemCard.style.backgroundImage = `url(${item.illustrationPath})`;
+            itemCard.style.backgroundImage = `url(${placeholderManager.getPath(item.illustrationPath)})`;
             itemCard.draggable = true;
             itemCard.dataset.instanceId = item.instanceId;
             

--- a/src/game/dom/ItemTooltipManager.js
+++ b/src/game/dom/ItemTooltipManager.js
@@ -1,3 +1,5 @@
+import { placeholderManager } from '../utils/PlaceholderManager.js';
+
 /**
  * 장비 아이템 위에 마우스를 올렸을 때 상세 정보 툴팁을 표시하는 매니저
  */
@@ -31,7 +33,7 @@ export class ItemTooltipManager {
         socketsHTML += '</div>';
 
         tooltip.innerHTML = `
-            <div class="item-illustration-large" style="background-image: url(${itemData.illustrationPath})"></div>
+            <div class="item-illustration-large" style="background-image: url(${placeholderManager.getPath(itemData.illustrationPath)})"></div>
             <div class="item-info-large">
                 <div class="item-name-large">${itemData.name}</div>
                 <div class="item-type-synergy-large">

--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -9,6 +9,7 @@ import { skillModifierEngine } from '../utils/SkillModifierEngine.js';
 import { SKILL_TAGS } from '../utils/SkillTagManager.js';
 import { mercenaryCardSelector } from '../utils/MercenaryCardSelector.js';
 import { mercenaryData } from '../data/mercenaries.js';
+import { placeholderManager } from '../utils/PlaceholderManager.js';
 
 export class SkillManagementDOMEngine {
     constructor(scene) {
@@ -245,7 +246,7 @@ export class SkillManagementDOMEngine {
             // 등급별 테두리 클래스를 부여합니다.
             slot.classList.add(`grade-${instanceData.grade.toLowerCase()}`);
 
-            slot.style.backgroundImage = `url(${modifiedSkill.illustrationPath})`;
+            slot.style.backgroundImage = `url(${placeholderManager.getPath(modifiedSkill.illustrationPath)})`;
             slot.dataset.instanceId = instanceId;
             slot.draggable = true;
             slot.ondragstart = e => this.onDragStart(e, { source: 'slot', instanceId, slotIndex: index });
@@ -302,7 +303,7 @@ export class SkillManagementDOMEngine {
             }
             // --- ▲ [신규] 장착 불가 카드 시각적 처리 ▲ ---
 
-            card.style.backgroundImage = `url(${data.illustrationPath})`;
+            card.style.backgroundImage = `url(${placeholderManager.getPath(data.illustrationPath)})`;
             card.draggable = true;
             card.dataset.instanceId = instance.instanceId;
             card.ondragstart = e => this.onDragStart(e, { source: 'inventory', instanceId: instance.instanceId });

--- a/src/game/dom/SkillTooltipManager.js
+++ b/src/game/dom/SkillTooltipManager.js
@@ -3,6 +3,7 @@ import { SKILL_TYPES } from '../utils/SkillEngine.js';
 import { classProficiencies } from '../data/classProficiencies.js';
 import { classSpecializations } from '../data/classSpecializations.js';
 import { mercenaryData } from '../data/mercenaries.js';
+import { placeholderManager } from '../utils/PlaceholderManager.js';
 
 /**
  * 스킬 카드 위에 마우스를 올렸을 때 TCG 스타일의 큰 툴팁을 표시하는 매니저
@@ -34,7 +35,7 @@ export class SkillTooltipManager {
         const rangeText = skillData.range !== undefined ? `사거리 ${skillData.range}` : '기본 사거리';
 
         tooltip.innerHTML = `
-            <div class="skill-illustration-large" style="background-image: url(${skillData.illustrationPath})"></div>
+            <div class="skill-illustration-large" style="background-image: url(${placeholderManager.getPath(skillData.illustrationPath)})"></div>
             <div class="skill-info-large">
                 <div class="skill-name-large">${skillNameHTML}</div>
                 <div class="skill-type-cost-large">

--- a/src/game/utils/PlaceholderManager.js
+++ b/src/game/utils/PlaceholderManager.js
@@ -1,0 +1,31 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+const DEFAULT_PLACEHOLDER = 'assets/images/placeholder.png';
+
+/**
+ * 이미지 경로가 유효하지 않을 때 기본 플레이스홀더 경로를 제공하는 유틸리티
+ */
+class PlaceholderManager {
+    constructor() {
+        this.name = 'PlaceholderManager';
+        debugLogEngine.log(this.name, '플레이스홀더 매니저가 초기화되었습니다.');
+    }
+
+    /**
+     * 이미지 경로를 받아 유효하면 그대로 반환하고,
+     * 유효하지 않으면 기본 플레이스홀더 경로를 반환합니다.
+     * @param {string | null | undefined} originalPath - 확인할 원본 이미지 경로
+     * @returns {string} - 최종적으로 사용될 이미지 경로
+     */
+    getPath(originalPath) {
+        if (originalPath && typeof originalPath === 'string' && originalPath.trim() !== '') {
+            return originalPath;
+        }
+        // 경로가 유효하지 않으면 플레이스홀더를 반환하고 로그를 남깁니다.
+        debugLogEngine.warn(this.name, `유효하지 않은 이미지 경로 감지. 플레이스홀더로 대체합니다.`);
+        return DEFAULT_PLACEHOLDER;
+    }
+}
+
+export const placeholderManager = new PlaceholderManager();
+


### PR DESCRIPTION
## Summary
- add placeholder manager utility that logs and replaces bad image paths
- run item and skill DOM engines through placeholder manager to avoid broken images
- set baseball bat illustration path to null as a placeholder test

## Testing
- `for f in tests/*.js; do node $f; done > /tmp/test.log && tail -n 20 /tmp/test.log`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`
- `kill %1`

------
https://chatgpt.com/codex/tasks/task_e_688e830db24083279f03f6dc4068eb5f