### PR TITLE
feat: modularize AI archetype selection

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -10,6 +10,8 @@ import { createINTJ_AI } from './behaviors/createINTJ_AI.js';
 import { createINTP_AI } from './behaviors/createINTP_AI.js';
 // ✨ [신규] ENTJ AI import
 import { createENTJ_AI } from './behaviors/createENTJ_AI.js';
+// ✨ 용병 데이터에서 ai_archetype을 참조합니다.
+import { mercenaryData } from '../game/data/mercenaries.js';
 
 /**
  * 게임 내 모든 AI 유닛을 관리하고, 각 유닛의 행동 트리를 실행합니다.
@@ -39,31 +41,37 @@ class AIManager {
      */
     _createAIFromArchetype(unit) {
         const mbti = unit.mbti;
-        if (!mbti) return createMeleeAI(this.aiEngines);
+        if (mbti) {
+            const mbtiString = (mbti.E > mbti.I ? 'E' : 'I') +
+                               (mbti.S > mbti.N ? 'S' : 'N') +
+                               (mbti.T > mbti.F ? 'T' : 'F') +
+                               (mbti.J > mbti.P ? 'J' : 'P');
 
-        const mbtiString = (mbti.E > mbti.I ? 'E' : 'I') +
-                           (mbti.S > mbti.N ? 'S' : 'N') +
-                           (mbti.T > mbti.F ? 'T' : 'F') +
-                           (mbti.J > mbti.P ? 'J' : 'P');
-
-        switch (mbtiString) {
-            case 'INTJ': return createINTJ_AI(this.aiEngines);
-            // ✨ [신규] INTP 케이스 추가
-            case 'INTP': return createINTP_AI(this.aiEngines);
-            // ✨ [신규] ENTJ 케이스 추가
-            case 'ENTJ': return createENTJ_AI(this.aiEngines);
-            default:
-                if (unit.name === '거너' || unit.name === '나노맨서' || unit.name === '에스퍼') {
-                    return createRangedAI(this.aiEngines);
-                } else if (unit.name === '전사' || unit.name === '좀비' || unit.name === '커맨더') {
-                    return createMeleeAI(this.aiEngines);
-                } else if (unit.name === '메딕') {
-                    return createHealerAI(this.aiEngines);
-                } else if (unit.name === '플라잉맨') {
-                    return createFlyingmanAI(this.aiEngines);
-                }
-                return createMeleeAI(this.aiEngines);
+            switch (mbtiString) {
+                case 'INTJ': return createINTJ_AI(this.aiEngines);
+                case 'INTP': return createINTP_AI(this.aiEngines);
+                case 'ENTJ': return createENTJ_AI(this.aiEngines);
+                // 다른 MBTI 유형은 여기서 추가 가능
+            }
         }
+
+        const unitBaseData = mercenaryData[unit.id];
+        if (unitBaseData && unitBaseData.ai_archetype) {
+            switch (unitBaseData.ai_archetype) {
+                case 'ranged':
+                    return createRangedAI(this.aiEngines);
+                case 'healer':
+                    return createHealerAI(this.aiEngines);
+                case 'assassin':
+                    return createFlyingmanAI(this.aiEngines);
+                case 'melee':
+                default:
+                    return createMeleeAI(this.aiEngines);
+            }
+        }
+
+        // 모든 조건에 해당하지 않으면 기본적으로 근접 AI 사용
+        return createMeleeAI(this.aiEngines);
     }
 
     /**

--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -2,88 +2,90 @@ import BehaviorTree from '../BehaviorTree.js';
 import SelectorNode from '../nodes/SelectorNode.js';
 import SequenceNode from '../nodes/SequenceNode.js';
 import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
-import AttackTargetNode from '../nodes/AttackTargetNode.js';
-import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
-import JustRecoveredFromStunNode from '../nodes/JustRecoveredFromStunNode.js';
-import SetTargetToStunnerNode from '../nodes/SetTargetToStunnerNode.js';
 import IsTargetValidNode from '../nodes/IsTargetValidNode.js';
 import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
-import IsTargetInRangeNode from '../nodes/IsTargetInRangeNode.js';
 import FindLowestHealthEnemyNode from '../nodes/FindLowestHealthEnemyNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import IsHealthBelowThresholdNode from '../nodes/IsHealthBelowThresholdNode.js';
-import SuccessNode from '../nodes/SuccessNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 import { NodeState } from '../nodes/Node.js';
 
+/**
+ * MeleeAI: 근접 공격형 AI 행동 트리 (개선 버전)
+ * 우선순위:
+ * 1. (생존) 체력이 35% 미만이면 안전한 위치로 후퇴합니다.
+ * 2. (마무리) 공격 가능한 체력이 가장 낮은 적을 찾아 공격합니다.
+ * 3. (전략) 우선순위 타겟(원거리/힐러)을 찾아 공격합니다.
+ * 4. (기본) 위 모든 행동이 불가능할 경우, 가장 가까운 적을 공격합니다.
+ */
 function createMeleeAI(engines = {}) {
-    const setCurrentFromMovement = {
+    // 현재 타겟을 스킬 타겟으로 동기화하는 헬퍼 노드
+    const syncSkillTarget = {
         async evaluate(_unit, blackboard) {
-            const target = blackboard.get('movementTarget');
+            const target = blackboard.get('currentTargetUnit');
             if (target) {
-                blackboard.set('currentTargetUnit', target);
+                blackboard.set('skillTarget', target);
                 return NodeState.SUCCESS;
             }
             return NodeState.FAILURE;
         }
     };
 
-    const revengeBranch = new SequenceNode([
-        new JustRecoveredFromStunNode(),
-        new SetTargetToStunnerNode(),
+    // 스킬 하나를 실행하는 공통 로직 (이동 포함)
+    const executeSkillBranch = new SequenceNode([
+        new FindBestSkillByScoreNode(engines), // 가장 적절한 스킬 선택
         new IsTargetValidNode(),
-        new FindPathToTargetNode(engines),
-        new MoveToTargetNode(engines),
-        new AttackTargetNode(engines)
-    ]);
-
-    const priorityAttackBranch = new SequenceNode([
-        new FindPriorityTargetNode(engines),
-        setCurrentFromMovement,
-        new IsTargetValidNode(),
+        syncSkillTarget,
         new SelectorNode([
             new SequenceNode([
-                new IsTargetInRangeNode(engines),
-                new AttackTargetNode(engines)
+                new IsSkillInRangeNode(engines),
+                new UseSkillNode(engines)
             ]),
             new SequenceNode([
-                new FindPathToTargetNode(engines),
+                new HasNotMovedNode(),
+                new FindPathToSkillRangeNode(engines),
                 new MoveToTargetNode(engines),
-                new AttackTargetNode(engines)
+                new IsSkillInRangeNode(engines),
+                new UseSkillNode(engines)
             ])
         ])
     ]);
 
-    const finishOffBranch = new SequenceNode([
-        new FindLowestHealthEnemyNode(engines),
-        new IsTargetValidNode(),
-        new SelectorNode([
-            new SequenceNode([
-                new IsTargetInRangeNode(engines),
-                new AttackTargetNode(engines)
-            ]),
-            new SequenceNode([
-                new FindPathToTargetNode(engines),
-                new MoveToTargetNode(engines),
-                new AttackTargetNode(engines)
-            ])
+    const rootNode = new SelectorNode([
+        // 1순위: 생존 본능 (체력이 35% 미만일 때 후퇴)
+        new SequenceNode([
+            new IsHealthBelowThresholdNode(0.35),
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+
+        // 2순위: 체력이 가장 낮은 적 마무리
+        new SequenceNode([
+            new FindLowestHealthEnemyNode(engines),
+            executeSkillBranch
+        ]),
+
+        // 3순위: 우선순위 타겟(원거리/힐러) 공격
+        new SequenceNode([
+            new FindPriorityTargetNode(engines),
+            executeSkillBranch
+        ]),
+
+        // 4순위: 기본 공격 (가장 가까운 적)
+        new SequenceNode([
+            new FindTargetNode(engines), // TargetManager의 기본 findNearestEnemy 사용
+            executeSkillBranch
         ])
     ]);
 
-    const retreatBranch = new SequenceNode([
-        new IsHealthBelowThresholdNode(0.5),
-        new FindSafeRepositionNode(engines),
-        new MoveToTargetNode(engines)
-    ]);
-
-    const root = new SelectorNode([
-        revengeBranch,
-        priorityAttackBranch,
-        finishOffBranch,
-        retreatBranch,
-        new SuccessNode()
-    ]);
-
-    return new BehaviorTree(root);
+    return new BehaviorTree(rootNode);
 }
 
 export { createMeleeAI };
+

--- a/src/ai/nodes/FindPathToSkillRangeNode.js
+++ b/src/ai/nodes/FindPathToSkillRangeNode.js
@@ -1,11 +1,13 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+// FindPathToTargetNode의 경로 탐색 로직을 재사용합니다.
+import FindPathToTargetNode from './FindPathToTargetNode.js';
 
 class FindPathToSkillRangeNode extends Node {
-    constructor({ pathfinderEngine, formationEngine } = {}) {
+    constructor(engines = {}) {
         super();
-        this.pathfinderEngine = pathfinderEngine;
-        this.formationEngine = formationEngine;
+        // 내부적으로 FindPathToTargetNode 인스턴스를 생성하여 로직을 위임합니다.
+        this.pathfinderNode = new FindPathToTargetNode(engines);
     }
 
     async evaluate(unit, blackboard) {
@@ -21,7 +23,12 @@ class FindPathToSkillRangeNode extends Node {
         // 스킬 range가 없으면 유닛의 기본 attackRange 사용, 기본값은 1
         const skillRange = skillData.range ?? unit.finalStats.attackRange ?? 1;
 
-        const path = this._findPathToUnit(unit, target, skillRange);
+        // FindPathToTargetNode의 로직을 활용하기 위해 임시로 attackRange를 조정합니다.
+        const originalAttackRange = unit.finalStats.attackRange;
+        unit.finalStats.attackRange = skillRange;
+        const path = this.pathfinderNode._findPathToUnit(unit, target);
+        unit.finalStats.attackRange = originalAttackRange;
+
         if (path) {
             blackboard.set('movementPath', path);
             debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skillData.name}] 사용 위치로 경로 설정`);
@@ -31,44 +38,6 @@ class FindPathToSkillRangeNode extends Node {
         debugAIManager.logNodeResult(NodeState.FAILURE, '스킬 사용 위치로의 경로 탐색 실패');
         return NodeState.FAILURE;
     }
-
-    _findPathToUnit(unit, target, range) {
-        const start = { col: unit.gridX, row: unit.gridY };
-        const targetPos = { col: target.gridX, row: target.gridY };
-
-        const distanceToTarget = Math.abs(start.col - targetPos.col) + Math.abs(start.row - targetPos.row);
-        if (distanceToTarget <= range) {
-            return [];
-        }
-
-        const potentialCells = [];
-        for (let r = 0; r < this.formationEngine.grid.rows; r++) {
-            for (let c = 0; c < this.formationEngine.grid.cols; c++) {
-                const distance = Math.abs(c - targetPos.col) + Math.abs(r - targetPos.row);
-                if (distance <= range) {
-                    const cell = this.formationEngine.grid.getCell(c, r);
-                    if (cell && (!cell.isOccupied || (c === start.col && r === start.row))) {
-                        potentialCells.push(cell);
-                    }
-                }
-            }
-        }
-
-        if (potentialCells.length === 0) return null;
-
-        potentialCells.sort((a, b) => {
-            const distA = Math.abs(a.col - start.col) + Math.abs(a.row - start.row);
-            const distB = Math.abs(b.col - start.col) + Math.abs(b.row - start.row);
-            return distA - distB;
-        });
-
-        for (const bestCell of potentialCells) {
-            const path = this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
-            if (path && path.length > 0) {
-                return path;
-            }
-        }
-        return null;
-    }
 }
 export default FindPathToSkillRangeNode;
+

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -2,6 +2,7 @@ export const mercenaryData = {
     warrior: {
         id: 'warrior',
         name: '전사',
+        ai_archetype: 'melee',
         uiImage: 'assets/images/territory/warrior-ui.png',
         battleSprite: 'warrior',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -23,6 +24,7 @@ export const mercenaryData = {
     gunner: {
         id: 'gunner',
         name: '거너',
+        ai_archetype: 'ranged',
         uiImage: 'assets/images/territory/gunner-ui.png',
         battleSprite: 'gunner',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -45,6 +47,7 @@ export const mercenaryData = {
     medic: {
         id: 'medic',
         name: '메딕',
+        ai_archetype: 'healer',
         uiImage: 'assets/images/territory/medic-ui.png',
         battleSprite: 'medic',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -67,6 +70,7 @@ export const mercenaryData = {
     nanomancer: {
         id: 'nanomancer',
         name: '나노맨서',
+        ai_archetype: 'ranged',
         uiImage: 'assets/images/unit/nanomancer-ui.png',
         battleSprite: 'nanomancer',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -95,6 +99,7 @@ export const mercenaryData = {
     flyingmen: {
         id: 'flyingmen',
         name: '플라잉맨',
+        ai_archetype: 'assassin',
         uiImage: 'assets/images/unit/flyingmen-ui.png',
         battleSprite: 'flyingmen',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -117,6 +122,7 @@ export const mercenaryData = {
     esper: {
         id: 'esper',
         name: '에스퍼',
+        ai_archetype: 'ranged',
         uiImage: 'assets/images/unit/esper-ui.png',
         battleSprite: 'esper',
         sprites: {
@@ -145,6 +151,7 @@ export const mercenaryData = {
     commander: {
         id: 'commander',
         name: '커맨더',
+        ai_archetype: 'melee',
         uiImage: 'assets/images/unit/commander-ui.png',
         battleSprite: 'commander',
         sprites: {


### PR DESCRIPTION
## Summary
- Extend mercenary data with `ai_archetype` and use it in AIManager for flexible AI assignment
- Rework melee behavior tree to choose skills via scoring, move, and attack targets strategically
- Deduplicate pathfinding by having FindPathToSkillRangeNode reuse FindPathToTargetNode logic

## Testing
- `for f in tests/*.js; do node $f >/tmp/test.log && tail -n 2 /tmp/test.log; done`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688f0e56e11c832795c116e726ae571c