### PR TITLE
feat: add clown class with bind specialty

### DIFF
--- a/src/game/data/classGrades.js
+++ b/src/game/data/classGrades.js
@@ -56,6 +56,14 @@ export const classGrades = {
         magicDefense: 2,
     },
     // --- ▲ [신규] 플라잉맨 등급 추가 ▲ ---
+    clown: {
+        meleeAttack: 2,
+        rangedAttack: 2,
+        magicAttack: 1,
+        meleeDefense: 2,
+        rangedDefense: 1,
+        magicDefense: 1,
+    },
     // --- 다른 클래스 추가 예정 ---
     zombie: {
         meleeAttack: 2,

--- a/src/game/data/classProficiencies.js
+++ b/src/game/data/classProficiencies.js
@@ -50,5 +50,13 @@ export const classProficiencies = {
         SKILL_TAGS.WILL,
         SKILL_TAGS.STRATEGY,
     ],
+    clown: [
+        SKILL_TAGS.PHYSICAL,
+        SKILL_TAGS.MELEE,
+        SKILL_TAGS.DEBUFF,
+        SKILL_TAGS.KINETIC,
+        SKILL_TAGS.DELAY,
+        SKILL_TAGS.BIND,
+    ],
     // '좀비'와 같은 몬스터는 숙련도 보너스를 받지 않으므로 정의하지 않습니다.
 };

--- a/src/game/data/classSpecializations.js
+++ b/src/game/data/classSpecializations.js
@@ -93,5 +93,20 @@ export const classSpecializations = {
                 modifiers: { stat: 'valor', type: 'flat', value: 2 }
             }
         }
+    ],
+    clown: [
+        {
+            tag: SKILL_TAGS.BIND,
+            description: "'속박' 태그 스킬 사용 시, 1턴간 치명타율 2% 및 상태이상 적용 확률 4%가 증가합니다 (중첩 가능).",
+            effect: {
+                id: 'clownBindBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: [
+                    { stat: 'criticalChance', type: 'percentage', value: 0.02 },
+                    { stat: 'statusEffectApplication', type: 'percentage', value: 0.04 }
+                ]
+            }
+        }
     ]
 };

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -175,5 +175,28 @@ export const mercenaryData = {
             description: '[전략] 태그가 붙은 스킬의 재사용 대기시간이 1/10로 감소합니다.',
             iconPath: 'assets/images/skills/commanders-shout.png'
         }
+    },
+    // ✨ [신규] 광대 클래스 데이터 추가
+    clown: {
+        id: 'clown',
+        name: '광대',
+        ai_archetype: 'assassin',
+        uiImage: 'assets/images/unit/clown-ui.png',
+        battleSprite: 'clown',
+        sprites: {
+            idle: 'clown',
+            attack: 'clown',
+            hitted: 'clown',
+            cast: 'clown',
+            'status-effects': 'clown',
+        },
+        description: '"가장 화려한 무대는 가장 큰 비극 위에 피어나는 법이지."',
+        baseStats: {
+            hp: 95, valor: 8, strength: 10, endurance: 7,
+            agility: 16, intelligence: 10, wisdom: 8, luck: 15,
+            attackRange: 2,
+            movement: 4,
+            weight: 9
+        }
     }
 };

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -66,6 +66,7 @@ export class Preloader extends Scene
         this.load.image('flyingmen', 'images/unit/flyingmen.png');
         this.load.image('esper', 'images/unit/esper.png');
         this.load.image('commander', 'images/unit/commander.png');
+        this.load.image('clown', 'images/unit/clown.png'); // 추가
 
         // UI용 이미지 로드
         this.load.image('warrior-ui', 'images/territory/warrior-ui.png');
@@ -75,6 +76,7 @@ export class Preloader extends Scene
         this.load.image('flyingmen-ui', 'images/unit/flyingmen-ui.png');
         this.load.image('esper-ui', 'images/unit/esper-ui.png');
         this.load.image('commander-ui', 'images/unit/commander-ui.png');
+        this.load.image('clown-ui', 'images/unit/clown-ui.png'); // 추가
 
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
@@ -135,7 +137,7 @@ export class Preloader extends Scene
     {
         // 전투 씬에서 사용될 주요 이미지들의 텍스처 필터링 모드를 설정하여 품질을 향상시킵니다.
         const battleTextures = [
-            'warrior', 'gunner', 'medic', 'nanomancer', 'flyingmen', 'esper', 'commander', 'zombie', 'ancestor-peor',
+            'warrior', 'gunner', 'medic', 'nanomancer', 'flyingmen', 'esper', 'commander', 'clown', 'zombie', 'ancestor-peor',
             'battle-stage-cursed-forest', 'battle-stage-arena'
         ];
 

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -45,4 +45,5 @@ export const SKILL_TAGS = {
     MIND: '정신',       // ✨ 에스퍼를 위한 '정신' 태그
     COMBO: '콤보',      // ✨ INTP를 위한 '콤보' 태그
     STRATEGY: '전략',   // ✨ 커맨더를 위한 '전략' 태그
+    BIND: '속박',      // ✨ 광대를 위한 '속박' 태그
 };

--- a/tests/clown_skill_integration_test.js
+++ b/tests/clown_skill_integration_test.js
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import { skillModifierEngine } from '../src/game/utils/SkillModifierEngine.js';
+
+const bindTrickBase = {
+    NORMAL: { id: 'bindTrick', type: 'DEBUFF', cost: 1, cooldown: 1, effect: { id: 'bind', type: 'STATUS_EFFECT', duration: 1 } },
+    RARE: { id: 'bindTrick', type: 'DEBUFF', cost: 1, cooldown: 1, effect: { id: 'bind', type: 'STATUS_EFFECT', duration: 1 } },
+    EPIC: { id: 'bindTrick', type: 'DEBUFF', cost: 0, cooldown: 1, effect: { id: 'bind', type: 'STATUS_EFFECT', duration: 1 } },
+    LEGENDARY: { id: 'bindTrick', type: 'DEBUFF', cost: 0, cooldown: 1, effect: { id: 'bind', type: 'STATUS_EFFECT', duration: 2 } },
+};
+
+const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
+for (const grade of grades) {
+    const skill = skillModifierEngine.getModifiedSkill(bindTrickBase[grade], grade);
+    if (grade === 'NORMAL' || grade === 'RARE') {
+        assert.strictEqual(skill.cost, 1);
+    } else {
+        assert.strictEqual(skill.cost, 0);
+    }
+    if (grade === 'LEGENDARY') {
+        assert.strictEqual(skill.effect.duration, 2);
+    } else {
+        assert.strictEqual(skill.effect.duration, 1);
+    }
+}
+
+console.log('Clown skills integration test passed.');


### PR DESCRIPTION
## Summary
- add `BIND` skill tag and clown class data
- define clown specialization and proficiencies
- load clown assets and include integration test

## Testing
- `node tests/clown_skill_integration_test.js`
- `for f in tests/*_test.js; do node $f; done | tail -n 20`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688f12ad15708327967e19f0d945483d