### PR TITLE
feat: add ENTP AI archetype and scoring adjustments

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -10,6 +10,8 @@ import { createINTJ_AI } from './behaviors/createINTJ_AI.js';
 import { createINTP_AI } from './behaviors/createINTP_AI.js';
 // ✨ [신규] ENTJ AI import
 import { createENTJ_AI } from './behaviors/createENTJ_AI.js';
+// ✨ [신규] ENTP AI import
+import { createENTP_AI } from './behaviors/createENTP_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -51,6 +53,7 @@ class AIManager {
                 case 'INTJ': return createINTJ_AI(this.aiEngines);
                 case 'INTP': return createINTP_AI(this.aiEngines);
                 case 'ENTJ': return createENTJ_AI(this.aiEngines);
+                case 'ENTP': return createENTP_AI(this.aiEngines);
                 // 다른 MBTI 유형은 여기서 추가 가능
             }
         }

--- a/src/ai/behaviors/createENTP_AI.js
+++ b/src/ai/behaviors/createENTP_AI.js
@@ -1,0 +1,70 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+// ✨ ENTP 전용으로 만든 신규 노드들을 import 합니다.
+import FindHighValueTargetNode from '../nodes/FindHighValueTargetNode.js';
+import FindPullPositionNode from '../nodes/FindPullPositionNode.js';
+
+/**
+ * ENTP: 변론가 아키타입 행동 트리
+ * 우선순위:
+ * 1. (교란) 가치 있는 목표(토큰/버프 많은 적)에게 최적의 스킬(디버프/관성/지연) 사용
+ * 2. (위치 선정) '끌어당기기'를 위해 아군과 거리를 벌리는 위치로 이동
+ * 3. (기본 공격) 위치 선정이 필요 없다면, 가치 있는 목표를 공격
+ * 4. (재배치) 위 모든 행동이 불가능하면 안전한 위치로 이동
+ */
+function createENTP_AI(engines = {}) {
+    // 스킬 하나를 실행하는 공통 로직 (이동 포함)
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([new IsSkillInRangeNode(engines), new UseSkillNode(engines)]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 가치 있는 목표를 찾아 교란 스킬 사용
+        new SequenceNode([
+            new FindHighValueTargetNode(engines),
+            new FindBestSkillByScoreNode(engines), // SkillScoreEngine이 교란 스킬에 높은 점수를 주도록 설정 필요
+            executeSkillBranch
+        ]),
+
+        // 2순위: 다음 턴의 '끌어당기기'를 위한 위치 선정
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindHighValueTargetNode(engines), // 끌어당길 대상을 먼저 정하고
+            new FindPullPositionNode(engines),   // 그 대상 기준으로 위치 탐색
+            new MoveToTargetNode(engines)
+        ]),
+
+        // 3순위: 기본 공격 (이미 위치가 좋거나 위치 선정이 실패했을 때)
+        new SequenceNode([
+            new FindHighValueTargetNode(engines),
+            new FindBestSkillByScoreNode(engines),
+            executeSkillBranch
+        ]),
+
+        // 4순위: 모든 행동이 불가능할 때의 안전한 재배치
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines),
+            new MoveToTargetNode(engines)
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createENTP_AI };

--- a/src/ai/nodes/FindHighValueTargetNode.js
+++ b/src/ai/nodes/FindHighValueTargetNode.js
@@ -1,0 +1,57 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { tokenEngine } from '../../game/utils/TokenEngine.js';
+import { statusEffectManager } from '../../game/utils/StatusEffectManager.js';
+
+/**
+ * 체력, 토큰, 버프 수를 종합하여 가장 '가치 있는' 적을 찾는 노드.
+ * ENTP 아키타입을 위해 설계되었습니다.
+ */
+class FindHighValueTargetNode extends Node {
+    constructor(engines = {}) {
+        super();
+        this.tokenEngine = engines.tokenEngine || tokenEngine;
+        this.statusEffectManager = engines.statusEffectManager || statusEffectManager;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const enemies = blackboard.get('enemyUnits')?.filter(e => e.currentHp > 0);
+
+        if (!enemies || enemies.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '대상이 될 적이 없음');
+            return NodeState.FAILURE;
+        }
+
+        let bestTarget = null;
+        let maxScore = -Infinity;
+
+        enemies.forEach(enemy => {
+            const tokenCount = this.tokenEngine.getTokens(enemy.uniqueId);
+            const effects = this.statusEffectManager.activeEffects.get(enemy.uniqueId) || [];
+            const buffCount = effects.filter(e => e.type === 'BUFF').length;
+            const healthRatio = enemy.currentHp / enemy.finalStats.hp;
+
+            // 토큰 1개당 10점, 버프 1개당 15점, 체력 비율 1%당 0.5점 등으로 가치 계산
+            const score = (tokenCount * 10) + (buffCount * 15) + (healthRatio * 50);
+
+            if (score > maxScore) {
+                maxScore = score;
+                bestTarget = enemy;
+            }
+        });
+
+        if (bestTarget) {
+            blackboard.set('currentTargetUnit', bestTarget);
+            // 다른 노드들이 이 타겟을 사용하도록 skillTarget도 설정
+            blackboard.set('skillTarget', bestTarget);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `가치 높은 타겟 [${bestTarget.instanceName}] 설정 (점수: ${maxScore.toFixed(0)})`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '가치 있는 타겟을 찾지 못함');
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindHighValueTargetNode;

--- a/src/ai/nodes/FindPullPositionNode.js
+++ b/src/ai/nodes/FindPullPositionNode.js
@@ -1,0 +1,70 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 적에게는 가깝지만, 아군과는 1칸의 거리를 유지하는 최적의 위치를 찾는 노드.
+ * ENTP의 '끌어당기기' 스킬 사용을 위한 사전 포석입니다.
+ */
+class FindPullPositionNode extends Node {
+    constructor(engines = {}) {
+        super();
+        this.formationEngine = engines.formationEngine;
+        this.pathfinderEngine = engines.pathfinderEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const target = blackboard.get('currentTargetUnit');
+        const allies = blackboard.get('allyUnits');
+        if (!target || !allies) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '타겟 또는 아군 정보 없음');
+            return NodeState.FAILURE;
+        }
+
+        const availableCells = this.formationEngine.grid.gridCells.filter(
+            cell => !cell.isOccupied || (cell.col === unit.gridX && cell.row === unit.gridY)
+        );
+
+        let bestCell = null;
+        let maxScore = -Infinity;
+
+        availableCells.forEach(cell => {
+            const distToTarget = Math.abs(cell.col - target.gridX) + Math.abs(cell.row - target.gridY);
+
+            const nearestAllyDist = Math.min(
+                ...allies
+                    .filter(a => a.uniqueId !== unit.uniqueId)
+                    .map(a => Math.abs(cell.col - a.gridX) + Math.abs(cell.row - a.gridY))
+            );
+
+            // 점수 계산: 타겟과는 가까울수록, 아군과는 1칸 떨어져 있을수록 높음
+            let score = -distToTarget; // 타겟과 가까울수록 점수 증가
+            if (nearestAllyDist > 1) {
+                score += 10; // 아군과 1칸 이상 떨어져 있으면 큰 보너스
+            }
+
+            if (score > maxScore) {
+                maxScore = score;
+                bestCell = cell;
+            }
+        });
+
+        if (bestCell) {
+            const path = this.pathfinderEngine.findPath(
+                unit,
+                { col: unit.gridX, row: unit.gridY },
+                { col: bestCell.col, row: bestCell.row }
+            );
+            if (path && path.length > 0) {
+                blackboard.set('movementPath', path);
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `끌어당기기 위치 (${bestCell.col}, ${bestCell.row})로 경로 설정`);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '적절한 위치 탐색 실패');
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindPullPositionNode;

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -93,6 +93,15 @@ class SkillScoreEngine {
                     mbtiScore += 10; // 생산 스킬에도 추가 점수
                 }
             }
+
+            // ✨ ENTP 성향 보너스
+            if (mbtiString === 'ENTP') {
+                const tags = skillData.tags || [];
+                if (tags.includes(SKILL_TAGS.DELAY)) mbtiScore += 20;
+                if (tags.includes(SKILL_TAGS.KINETIC)) mbtiScore += 20;
+                if (tags.includes(SKILL_TAGS.BIND)) mbtiScore += 25; // 끌어당기기 스킬 선호
+                if (skillData.type === 'DEBUFF') mbtiScore += 15;
+            }
         }
 
         // ✨ 3. 음양 시스템 점수 계산 로직 추가


### PR DESCRIPTION
## Summary
- add ENTP-specific nodes for high-value targeting and pull positioning
- compose ENTP behavior tree and register in AIManager
- weight delay, kinetic, bind, and debuff skills higher for ENTP units

## Testing
- `for file in tests/*.js; do node $file >/tmp/test.log && tail -n 20 /tmp/test.log; done`
- `python3 -m http.server 8000 &` and `curl -s http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688f17dfd9648327a484e2a470bfc513