### PR TITLE
feat: add pulling skill and status effects

### DIFF
--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -564,4 +564,82 @@ export const activeSkills = {
     },
     // --- ▲ [신규] '낙인' 스킬을 DEBUFF에서 ACTIVE로 이동 및 수정 ▲ ---
     // --- ▲ [신규] 크리티컬 샷 스킬 추가 ▲ ---
+    // --- ▼ [신규] 끌어당기기 스킬 추가 ▼ ---
+    pulling: {
+        yinYangValue: -3,
+        NORMAL: {
+            id: 'pulling',
+            name: '끌어당기기',
+            type: 'ACTIVE',
+            requiredClass: 'clown',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.PHYSICAL, SKILL_TAGS.BIND, SKILL_TAGS.KINETIC],
+            cost: 3,
+            targetType: 'enemy',
+            description: '5타일 내의 적을 자신의 바로 앞으로 끌어옵니다. (쿨타임 5턴)',
+            illustrationPath: null,
+            cooldown: 5,
+            range: 5,
+            pull: true
+        },
+        RARE: {
+            id: 'pulling',
+            name: '끌어당기기 [R]',
+            type: 'ACTIVE',
+            requiredClass: 'clown',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.PHYSICAL, SKILL_TAGS.BIND, SKILL_TAGS.KINETIC],
+            cost: 3,
+            targetType: 'enemy',
+            description: '5타일 내의 적을 자신의 바로 앞으로 끌어오고, 1턴간 이동력을 1 감소시킵니다. (쿨타임 5턴)',
+            illustrationPath: null,
+            cooldown: 5,
+            range: 5,
+            pull: true,
+            effect: {
+                id: 'slow',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 1,
+                modifiers: { stat: 'movement', type: 'flat', value: -1 }
+            }
+        },
+        EPIC: {
+            id: 'pulling',
+            name: '끌어당기기 [E]',
+            type: 'ACTIVE',
+            requiredClass: 'clown',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.PHYSICAL, SKILL_TAGS.BIND, SKILL_TAGS.KINETIC],
+            cost: 2,
+            targetType: 'enemy',
+            description: '5타일 내의 적을 자신의 바로 앞으로 끌어오고, 1턴간 이동력을 1 감소시킵니다. (쿨타임 4턴)',
+            illustrationPath: null,
+            cooldown: 4,
+            range: 5,
+            pull: true,
+            effect: {
+                id: 'slow',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 1,
+                modifiers: { stat: 'movement', type: 'flat', value: -1 }
+            }
+        },
+        LEGENDARY: {
+            id: 'pulling',
+            name: '끌어당기기 [L]',
+            type: 'ACTIVE',
+            requiredClass: 'clown',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.PHYSICAL, SKILL_TAGS.BIND, SKILL_TAGS.KINETIC],
+            cost: 2,
+            targetType: 'enemy',
+            description: '5타일 내의 적을 자신의 바로 앞으로 끌어오고, 2턴간 [속박](이동 불가) 상태로 만듭니다. (쿨타임 4턴)',
+            illustrationPath: null,
+            cooldown: 4,
+            range: 5,
+            pull: true,
+            effect: {
+                id: 'bind',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 2
+            }
+        }
+    },
+    // --- ▲ [신규] 끌어당기기 스킬 추가 ▲ ---
 };

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -32,6 +32,25 @@ export const statusEffects = {
             }
         },
     },
+    // ✨ [신규] 이동력 감소(slow) 및 속박(bind) 효과 추가
+    slow: {
+        id: 'slow',
+        name: '둔화',
+        description: '이동력이 감소합니다.',
+        iconPath: 'assets/images/status-effects/slow.png',
+    },
+    bind: {
+        id: 'bind',
+        name: '속박',
+        description: '이동할 수 없습니다.',
+        iconPath: 'assets/images/status-effects/bind.png',
+        onApply: (unit) => {
+            unit.isBound = true;
+        },
+        onRemove: (unit) => {
+            unit.isBound = false;
+        },
+    },
     // 전투의 함성: 일시적으로 근접 공격 등급을 상승시킵니다.
     battleCryBuff: {
         id: 'battleCryBuff',

--- a/src/game/utils/FormationEngine.js
+++ b/src/game/utils/FormationEngine.js
@@ -283,6 +283,46 @@ class FormationEngine {
             }
         }
     }
+
+    /**
+     * ✨ [신규] 특정 유닛을 공격자 주변의 빈 칸으로 끌어당깁니다.
+     * @param {object} targetUnit - 끌려올 대상 유닛
+     * @param {object} pullerUnit - 끌어당기는 유닛
+     * @param {AnimationEngine} animationEngine - 애니메이션 엔진
+     * @returns {Promise<void>}
+     */
+    async pullUnit(targetUnit, pullerUnit, animationEngine) {
+        if (!targetUnit || !pullerUnit) return;
+
+        const { gridX, gridY } = pullerUnit;
+        const directions = [
+            { col: 0, row: -1 }, { col: 0, row: 1 }, { col: -1, row: 0 }, { col: 1, row: 0 },
+            { col: -1, row: -1 }, { col: 1, row: -1 }, { col: -1, row: 1 }, { col: 1, row: 1 }
+        ];
+
+        let bestCell = null;
+        let minDistance = Infinity;
+
+        for (const dir of directions) {
+            const checkCol = gridX + dir.col;
+            const checkRow = gridY + dir.row;
+            const cell = this.grid.getCell(checkCol, checkRow);
+
+            if (cell && !cell.isOccupied) {
+                const dist = Math.abs(targetUnit.gridX - checkCol) + Math.abs(targetUnit.gridY - checkRow);
+                if (dist < minDistance) {
+                    minDistance = dist;
+                    bestCell = cell;
+                }
+            }
+        }
+
+        if (bestCell) {
+            await this.moveUnitOnGrid(targetUnit, { col: bestCell.col, row: bestCell.row }, animationEngine, 400);
+        } else {
+            debugLogEngine.log('FormationEngine', `끌어당기기 실패: ${pullerUnit.instanceName} 주변에 빈 공간이 없습니다.`);
+        }
+    }
 }
 
 export const formationEngine = new FormationEngine();

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -152,6 +152,9 @@ class SkillEffectProcessor {
         if (skill.push > 0) {
             await formationEngine.pushUnit(target, unit, skill.push, this.animationEngine);
         }
+        if (skill.pull) {
+            await formationEngine.pullUnit(target, unit, this.animationEngine);
+        }
         if (skill.restoresBarrierPercent && unit.maxBarrier > 0) {
             const healAmount = Math.round(unit.maxBarrier * skill.restoresBarrierPercent);
             unit.currentBarrier = Math.min(unit.maxBarrier, unit.currentBarrier + healAmount);

--- a/tests/clown_skill_integration_test.js
+++ b/tests/clown_skill_integration_test.js
@@ -8,6 +8,13 @@ const bindTrickBase = {
     LEGENDARY: { id: 'bindTrick', type: 'DEBUFF', cost: 0, cooldown: 1, effect: { id: 'bind', type: 'STATUS_EFFECT', duration: 2 } },
 };
 
+const pullingBase = {
+    NORMAL: { id: 'pulling', type: 'ACTIVE', cost: 3, cooldown: 5, pull: true },
+    RARE: { id: 'pulling', type: 'ACTIVE', cost: 3, cooldown: 5, pull: true, effect: { id: 'slow', duration: 1 } },
+    EPIC: { id: 'pulling', type: 'ACTIVE', cost: 2, cooldown: 4, pull: true, effect: { id: 'slow', duration: 1 } },
+    LEGENDARY: { id: 'pulling', type: 'ACTIVE', cost: 2, cooldown: 4, pull: true, effect: { id: 'bind', duration: 2 } },
+};
+
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 for (const grade of grades) {
     const skill = skillModifierEngine.getModifiedSkill(bindTrickBase[grade], grade);
@@ -20,6 +27,25 @@ for (const grade of grades) {
         assert.strictEqual(skill.effect.duration, 2);
     } else {
         assert.strictEqual(skill.effect.duration, 1);
+    }
+}
+
+for (const grade of grades) {
+    const skill = skillModifierEngine.getModifiedSkill(pullingBase[grade], grade);
+    if (grade === 'NORMAL' || grade === 'RARE') {
+        assert.strictEqual(skill.cost, 3);
+        assert.strictEqual(skill.cooldown, 5);
+    } else {
+        assert.strictEqual(skill.cost, 2);
+        assert.strictEqual(skill.cooldown, 4);
+    }
+    if (grade === 'RARE' || grade === 'EPIC') {
+        assert.strictEqual(skill.effect.id, 'slow');
+        assert.strictEqual(skill.effect.duration, 1);
+    }
+    if (grade === 'LEGENDARY') {
+        assert.strictEqual(skill.effect.id, 'bind');
+        assert.strictEqual(skill.effect.duration, 2);
     }
 }
 


### PR DESCRIPTION
## Summary
- add pulling skill with slow/bind debuffs across grades
- support slow and bind status effects
- enable pulling mechanic in formation and skill processors

## Testing
- `for f in tests/*.js; do node $f; done`
- `node tests/clown_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688f40461a6c8327bd7874e5fe3a81fa