### PR TITLE
feat: add android class with sacrifice tag

### DIFF
--- a/src/game/data/classGrades.js
+++ b/src/game/data/classGrades.js
@@ -64,6 +64,14 @@ export const classGrades = {
         rangedDefense: 1,
         magicDefense: 1,
     },
+    android: {
+        meleeAttack: 3,
+        rangedAttack: 1,
+        magicAttack: 1,
+        meleeDefense: 3,
+        rangedDefense: 2,
+        magicDefense: 2, // 전사보다 마법 방어에 조금 더 강함
+    },
     // --- 다른 클래스 추가 예정 ---
     zombie: {
         meleeAttack: 2,

--- a/src/game/data/classProficiencies.js
+++ b/src/game/data/classProficiencies.js
@@ -58,5 +58,12 @@ export const classProficiencies = {
         SKILL_TAGS.DELAY,
         SKILL_TAGS.BIND,
     ],
+    android: [
+        SKILL_TAGS.MELEE,
+        SKILL_TAGS.PHYSICAL,
+        SKILL_TAGS.WILL,
+        SKILL_TAGS.WILL_GUARD,
+        SKILL_TAGS.SACRIFICE,
+    ],
     // '좀비'와 같은 몬스터는 숙련도 보너스를 받지 않으므로 정의하지 않습니다.
 };

--- a/src/game/data/classSpecializations.js
+++ b/src/game/data/classSpecializations.js
@@ -108,5 +108,20 @@ export const classSpecializations = {
                 ]
             }
         }
+    ],
+    android: [
+        {
+            tag: SKILL_TAGS.SACRIFICE,
+            description: "'희생' 태그 스킬 사용 시, 자신은 최대 체력의 5% 피해를 입고 주변 2칸 내 모든 아군에게 1턴간 '받는 데미지 10% 감소' 효과를 부여합니다.",
+            effect: {
+                id: 'androidSacrificeBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                isGlobal: false, // 광역이지만 전체는 아님
+                radius: 2,       // 주변 2칸
+                selfDamage: { type: 'percentage', value: 0.05 }, // 자신에게 주는 피해
+                modifiers: { stat: 'damageReduction', type: 'percentage', value: 0.10 }
+            }
+        }
     ]
 };

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -205,5 +205,26 @@ export const mercenaryData = {
             description: '주위 3타일 내 디버프에 걸린 유닛 하나당 자신의 치명타율 5%, 약점 공격 확률 5%, 공격력 5%가 증가합니다 (아군, 적군 포함).',
             iconPath: 'assets/images/skills/clown-s-joke.png'
         }
+    },
+    android: {
+        id: 'android',
+        name: '안드로이드',
+        ai_archetype: 'melee', // 기본 AI는 전사와 동일한 근접 타입
+        uiImage: 'assets/images/unit/android-ui.png',
+        battleSprite: 'android',
+        sprites: {
+            idle: 'android',
+            attack: 'android',
+            hitted: 'android',
+            cast: 'android',
+            'status-effects': 'android',
+        },
+        description: '"나의 파괴는, 모두의 생존을 위함이다."',
+        baseStats: {
+            hp: 110, valor: 12, strength: 14, endurance: 14,
+            agility: 7, intelligence: 5, wisdom: 8, luck: 6,
+            movement: 3,
+            weight: 12
+        }
     }
 };

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -67,6 +67,7 @@ export class Preloader extends Scene
         this.load.image('esper', 'images/unit/esper.png');
         this.load.image('commander', 'images/unit/commander.png');
         this.load.image('clown', 'images/unit/clown.png'); // 추가
+        this.load.image('android', 'images/unit/android.png'); // 추가
 
         // UI용 이미지 로드
         this.load.image('warrior-ui', 'images/territory/warrior-ui.png');
@@ -77,6 +78,7 @@ export class Preloader extends Scene
         this.load.image('esper-ui', 'images/unit/esper-ui.png');
         this.load.image('commander-ui', 'images/unit/commander-ui.png');
         this.load.image('clown-ui', 'images/unit/clown-ui.png'); // 추가
+        this.load.image('android-ui', 'images/unit/android-ui.png'); // 추가
 
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
@@ -138,7 +140,7 @@ export class Preloader extends Scene
     {
         // 전투 씬에서 사용될 주요 이미지들의 텍스처 필터링 모드를 설정하여 품질을 향상시킵니다.
         const battleTextures = [
-            'warrior', 'gunner', 'medic', 'nanomancer', 'flyingmen', 'esper', 'commander', 'clown', 'zombie', 'ancestor-peor',
+            'warrior', 'gunner', 'medic', 'nanomancer', 'flyingmen', 'esper', 'commander', 'clown', 'android', 'zombie', 'ancestor-peor',
             'battle-stage-cursed-forest', 'battle-stage-arena'
         ];
 

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -46,4 +46,5 @@ export const SKILL_TAGS = {
     COMBO: '콤보',      // ✨ INTP를 위한 '콤보' 태그
     STRATEGY: '전략',   // ✨ 커맨더를 위한 '전략' 태그
     BIND: '속박',      // ✨ 광대를 위한 '속박' 태그
+    SACRIFICE: '희생', // ✨ 안드로이드를 위한 '희생' 태그
 };


### PR DESCRIPTION
## Summary
- add SACRIFICE skill tag for android
- define android class stats, proficiencies, and specialization
- load android assets in preloader

## Testing
- `for f in tests/*_test.js; do echo "Running $f"; node $f | tail -n 1; done`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688f4eae390083278d11c0f70b4589f3