### PR TITLE
feat(ai): add INFJ archetype behavior tree

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -12,6 +12,8 @@ import { createINTP_AI } from './behaviors/createINTP_AI.js';
 import { createENTJ_AI } from './behaviors/createENTJ_AI.js';
 // ✨ [신규] ENTP AI import
 import { createENTP_AI } from './behaviors/createENTP_AI.js';
+// ✨ [신규] INFJ AI import
+import { createINFJ_AI } from './behaviors/createINFJ_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -54,6 +56,8 @@ class AIManager {
                 case 'INTP': return createINTP_AI(this.aiEngines);
                 case 'ENTJ': return createENTJ_AI(this.aiEngines);
                 case 'ENTP': return createENTP_AI(this.aiEngines);
+                // ✨ [추가] INFJ 케이스 추가
+                case 'INFJ': return createINFJ_AI(this.aiEngines);
                 // 다른 MBTI 유형은 여기서 추가 가능
             }
         }

--- a/src/ai/behaviors/createINFJ_AI.js
+++ b/src/ai/behaviors/createINFJ_AI.js
@@ -1,0 +1,75 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindSafeHealingPositionNode from '../nodes/FindSafeHealingPositionNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import FindNearestAllyInDangerNode from '../nodes/FindNearestAllyInDangerNode.js';
+import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
+
+/**
+ * INFJ: 옹호자 아키타입 행동 트리
+ * 우선순위:
+ * 1. (아군 보호) 체력이 35% 미만인 가장 가까운 아군에게 지원 스킬(AID, BUFF) 사용
+ * 2. (위협 제거) 아군을 위협하는 우선순위 높은 적(원거리/힐러) 공격
+ * 3. (기본 행동) 그 외 상황에서는 점수가 가장 높은 스킬 사용
+ * 4. (위치 선정) 할 행동이 없으면 아군 근처의 안전한 위치로 이동
+ */
+function createINFJ_AI(engines = {}) {
+    // 스킬 하나를 실행하는 공통 로직 (이동 포함)
+    const executeSkillBranch = new SelectorNode([
+        // 사거리 내에 있으면 즉시 사용
+        new SequenceNode([
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ]),
+        // 사거리 밖이면 안전한 위치를 찾아 이동 후 사용
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeHealingPositionNode(engines), // 아군 지원에 최적화된 위치 탐색
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 위험에 처한 아군 보호
+        new SequenceNode([
+            new FindNearestAllyInDangerNode(0.35), // 체력 35% 이하 아군 탐색
+            new FindBestSkillByScoreNode(engines), // AID, BUFF, WILL_GUARD 스킬에 높은 점수 부여
+            executeSkillBranch
+        ]),
+
+        // 2순위: 위협적인 적 제거 (MeleeAI와 유사)
+        new SequenceNode([
+            new FindPriorityTargetNode(engines), // 원거리/힐러 우선 타겟팅
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        
+        // 3순위: 일반적인 최적 스킬 사용
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+
+        // 4순위: 안전한 위치로 재배치
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines),
+            new MoveToTargetNode(engines)
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createINFJ_AI };

--- a/src/game/data/skillScores.js
+++ b/src/game/data/skillScores.js
@@ -17,11 +17,12 @@ export const SCORE_BY_TYPE = {
 // 스킬 태그별 추가 점수
 export const SCORE_BY_TAG = {
     FIXED: 10,       // 확정 효과
-    WILL_GUARD: 9,   // 피해 무효화 및 방어 스택
+    WILL_GUARD: 12,  // 의지 방패 (점수 상향)
     DELAY: 8,        // 행동 지연
     PROHIBITION: 7,  // 행동 금지
-    HEAL: 5,         // 치유
+    HEAL: 8,         // 치유 (점수 상향)
     CHARGE: 4,       // 돌진
-    KINETIC: 4       // 넉백
+    KINETIC: 4,      // 넉백
+    SACRIFICE: 9     // ✨ 희생 태그 추가
     // 기타 태그는 필요에 따라 추가할 수 있습니다.
 };


### PR DESCRIPTION
## Summary
- add INFJ behavior tree prioritizing ally protection and safe repositioning
- wire INFJ archetype into AI manager selection
- boost protective skill scores and include sacrifice tag

## Testing
- `for file in tests/*_test.js; do node $file; done`
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68902746e2b4832787a42364a0967b4c