### PR TITLE
feat: add plague doctor mercenary

### DIFF
--- a/src/game/data/classGrades.js
+++ b/src/game/data/classGrades.js
@@ -95,5 +95,15 @@ export const classGrades = {
         meleeDefense: 1,
         rangedDefense: 1,
         magicDefense: 1,
+    },
+    // --- ▼ [신규] 역병 의사 등급 추가 ▼ ---
+    plagueDoctor: {
+        meleeAttack: 2,  // 근접 공격은 보통
+        rangedAttack: 1, // 원거리 공격은 약함
+        magicAttack: 3,  // 마법(독) 공격에 강함
+        meleeDefense: 2, // 근접 방어는 보통
+        rangedDefense: 2, // 원거리 방어도 보통
+        magicDefense: 3, // 마법 저항력은 높음
     }
+    // --- ▲ [신규] 역병 의사 등급 추가 ▲ ---
 };

--- a/src/game/data/classProficiencies.js
+++ b/src/game/data/classProficiencies.js
@@ -65,5 +65,15 @@ export const classProficiencies = {
         SKILL_TAGS.WILL_GUARD,
         SKILL_TAGS.SACRIFICE,
     ],
+    // --- ▼ [신규] 역병 의사 숙련도 태그 추가 ▼ ---
+    plagueDoctor: [
+        SKILL_TAGS.PHYSICAL,
+        SKILL_TAGS.MELEE,
+        SKILL_TAGS.DEBUFF,
+        SKILL_TAGS.PROHIBITION,
+        SKILL_TAGS.AID,
+        SKILL_TAGS.HEAL,
+    ],
+    // --- ▲ [신규] 역병 의사 숙련도 태그 추가 ▲ ---
     // '좀비'와 같은 몬스터는 숙련도 보너스를 받지 않으므로 정의하지 않습니다.
 };

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -232,5 +232,29 @@ export const mercenaryData = {
             description: '자신이 [희생] 태그 스킬을 사용하거나, 아군이 사망할 때마다 [강화 학습] 버프를 1 얻습니다. 이 버프는 중첩될 때마다 모든 기본 스탯(힘, 인내 등)을 1씩 올려주며, 전투가 끝나면 사라집니다.',
             iconPath: 'assets/images/skills/reinforcement-learning.png'
         }
+    },
+    // --- ▼ [신규] 역병 의사 클래스 데이터 추가 ▼ ---
+    plagueDoctor: {
+        id: 'plagueDoctor',
+        name: '역병 의사',
+        ai_archetype: 'healer', // 기본 AI는 메딕과 유사한 'healer' 타입
+        uiImage: 'assets/images/unit/plague-doctor-ui.png',
+        battleSprite: 'plague-doctor',
+        sprites: {
+            idle: 'plague-doctor',
+            attack: 'plague-doctor',
+            hitted: 'plague-doctor',
+            cast: 'plague-doctor',
+            'status-effects': 'plague-doctor',
+        },
+        description: '"죽음이야말로 가장 확실한 치료법이지."',
+        baseStats: {
+            hp: 85, valor: 6, strength: 8, endurance: 7,
+            agility: 11, intelligence: 14, wisdom: 13, luck: 11,
+            attackRange: 1, // 사거리 1
+            movement: 3,    // 이동거리 3
+            weight: 13
+        }
     }
+    // --- ▲ [신규] 역병 의사 클래스 데이터 추가 ▲ ---
 };

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -68,6 +68,8 @@ export class Preloader extends Scene
         this.load.image('commander', 'images/unit/commander.png');
         this.load.image('clown', 'images/unit/clown.png'); // 추가
         this.load.image('android', 'images/unit/android.png'); // 추가
+        // ✨ [추가] 역병 의사 스프라이트 로드
+        this.load.image('plague-doctor', 'images/unit/plague-doctor.png');
 
         // UI용 이미지 로드
         this.load.image('warrior-ui', 'images/territory/warrior-ui.png');
@@ -79,6 +81,8 @@ export class Preloader extends Scene
         this.load.image('commander-ui', 'images/unit/commander-ui.png');
         this.load.image('clown-ui', 'images/unit/clown-ui.png'); // 추가
         this.load.image('android-ui', 'images/unit/android-ui.png'); // 추가
+        // ✨ [추가] 역병 의사 UI 이미지 로드
+        this.load.image('plague-doctor-ui', 'images/unit/plague-doctor-ui.png');
 
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
@@ -140,7 +144,7 @@ export class Preloader extends Scene
     {
         // 전투 씬에서 사용될 주요 이미지들의 텍스처 필터링 모드를 설정하여 품질을 향상시킵니다.
         const battleTextures = [
-            'warrior', 'gunner', 'medic', 'nanomancer', 'flyingmen', 'esper', 'commander', 'clown', 'android', 'zombie', 'ancestor-peor',
+            'warrior', 'gunner', 'medic', 'nanomancer', 'flyingmen', 'esper', 'commander', 'clown', 'android', 'plague-doctor', 'zombie', 'ancestor-peor',
             'battle-stage-cursed-forest', 'battle-stage-arena'
         ];
 


### PR DESCRIPTION
## Summary
- add plague doctor mercenary stats and description
- include plague doctor combat grades and skill tags
- load plague doctor sprites in preloader

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &` (kill later)
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68905eb290648327a1ca6ba313294df1