### PR TITLE
feat: add plague doctor specialization

### DIFF
--- a/src/game/data/classSpecializations.js
+++ b/src/game/data/classSpecializations.js
@@ -123,5 +123,19 @@ export const classSpecializations = {
                 modifiers: { stat: 'damageReduction', type: 'percentage', value: 0.10 }
             }
         }
+    ],
+    // --- ▼ [신규] 역병 의사 특화 태그 추가 ▼ ---
+    plagueDoctor: [
+        {
+            tag: SKILL_TAGS.POISON,
+            description: "'독' 태그 스킬 사용 시, 1턴간 상태이상 적용 확률 5% 증가 (중첩 가능)",
+            effect: {
+                id: 'poisonAttributeBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: { stat: 'statusEffectApplication', type: 'percentage', value: 0.05 }
+            }
+        }
     ]
+    // --- ▲ [신규] 역병 의사 특화 태그 추가 ▲ ---
 };

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -177,5 +177,13 @@ export const statusEffects = {
         name: '신속',
         iconPath: 'assets/images/skills/charge.png',
     },
+    // --- ▼ [신규] 역병 의사 특화 보너스 효과 추가 ▼ ---
+    poisonAttributeBonus: {
+        id: 'poisonAttributeBonus',
+        name: '맹독 확산',
+        description: '상태이상 적용 확률이 증가합니다.',
+        iconPath: 'assets/images/skills/antidote.png', // 임시 아이콘, 추후 전용 아이콘으로 교체 가능
+    },
+    // --- ▲ [신규] 역병 의사 특화 보너스 효과 추가 ▲ ---
     // --- ▲ [신규] 클래스 특화 보너스 효과 추가 ▲ ---
 };


### PR DESCRIPTION
## Summary
- add poison Attribute Bonus buff for plague doctors
- grant plague doctors stacking status effect application bonus when using Poison-tag skills

## Testing
- `npm test` (fails: Missing script: "test")
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689064283b008327b4241443252430f6