### PR TITLE
feat: add INFP behavior tree

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -14,6 +14,8 @@ import { createENTJ_AI } from './behaviors/createENTJ_AI.js';
 import { createENTP_AI } from './behaviors/createENTP_AI.js';
 // ✨ [신규] INFJ AI import
 import { createINFJ_AI } from './behaviors/createINFJ_AI.js';
+// ✨ [추가] INFP AI import
+import { createINFP_AI } from './behaviors/createINFP_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -58,6 +60,8 @@ class AIManager {
                 case 'ENTP': return createENTP_AI(this.aiEngines);
                 // ✨ [추가] INFJ 케이스 추가
                 case 'INFJ': return createINFJ_AI(this.aiEngines);
+                // ✨ [추가] INFP 케이스 추가
+                case 'INFP': return createINFP_AI(this.aiEngines);
                 // 다른 MBTI 유형은 여기서 추가 가능
             }
         }

--- a/src/ai/behaviors/createINFP_AI.js
+++ b/src/ai/behaviors/createINFP_AI.js
@@ -1,0 +1,108 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import IsHealthBelowThresholdNode from '../nodes/IsHealthBelowThresholdNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import FindEnemyMedicNode from '../nodes/FindEnemyMedicNode.js';
+import FindBuffedEnemyNode from '../nodes/FindBuffedEnemyNode.js';
+import FindNearestAllyInDangerNode from '../nodes/FindNearestAllyInDangerNode.js';
+import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
+
+/**
+ * INFP: 중재자 아키타입 행동 트리
+ * 우선순위:
+ * 1. (생존) 체력이 40% 미만이면 가장 안전한 위치로 후퇴합니다.
+ * 2. (전략적 방해) 적 메딕에게 '낙인'을 걸거나, 위협적인 버프를 가진 적에게 디버프를 겁니다.
+ * 3. (아군 지원) 위험에 처한 아군을 치유합니다.
+ * 4. (안전한 공격) 적과 안전거리를 유지하며(카이팅) 공격합니다.
+ */
+function createINFP_AI(engines = {}) {
+    // 스킬 하나를 실행하는 공통 로직 (이동 포함)
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    // 대상을 블랙보드의 특정 키('skillTarget')로 설정하는 헬퍼 노드
+    const setSkillTarget = (key) => ({
+        async evaluate(_unit, blackboard) {
+            const target = blackboard.get(key);
+            if (target) {
+                blackboard.set('skillTarget', target);
+                return 'SUCCESS';
+            }
+            return 'FAILURE';
+        }
+    });
+
+    const rootNode = new SelectorNode([
+        // 1순위: 생존 본능
+        new SequenceNode([
+            new IsHealthBelowThresholdNode(0.4), // 체력 40% 미만일 때
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines), // 가장 안전한 위치 탐색
+            new MoveToTargetNode(engines)
+        ]),
+
+        // 2순위: 전략적 방해
+        new SelectorNode([
+            // 2-1: 적 메딕에게 '낙인' 시도
+            new SequenceNode([
+                new FindEnemyMedicNode(engines),
+                setSkillTarget('enemyMedic'),
+                new FindBestSkillByScoreNode(engines), // SkillScoreEngine이 PROHIBITION 태그에 높은 점수를 주도록 설정
+                executeSkillBranch
+            ]),
+            // 2-2: 위협적인 버프를 가진 적에게 디버프
+            new SequenceNode([
+                new FindBuffedEnemyNode(engines), // 예: 전투의 함성 버프를 가진 적
+                setSkillTarget('buffedEnemy'),
+                new FindBestSkillByScoreNode(engines), // DEBUFF 스킬 선호
+                executeSkillBranch
+            ]),
+        ]),
+
+        // 3순위: 아군 지원
+        new SequenceNode([
+            new FindNearestAllyInDangerNode(0.6), // 체력 60% 이하 아군 탐색
+            setSkillTarget('allyInDanger'),
+            new FindBestSkillByScoreNode(engines), // HEAL, AID 스킬 선호
+            executeSkillBranch
+        ]),
+
+        // 4순위: 안전한 기본 공격 (카이팅)
+        new SequenceNode([
+            new FindTargetBySkillTypeNode(engines), // 일반적인 타겟 선정
+            new SelectorNode([
+                 // 이미 안전하면 바로 공격
+                executeSkillBranch,
+                // 안전하지 않으면 카이팅 위치로 이동
+                new SequenceNode([
+                    new HasNotMovedNode(),
+                    new FindKitingPositionNode(engines),
+                    new MoveToTargetNode(engines)
+                ])
+            ])
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createINFP_AI };


### PR DESCRIPTION
## Summary
- add INFP archetype behavior tree emphasizing survival, strategic disruption, ally support, and kiting attacks
- wire INFP MBTI units to use new AI in AIManager

## Testing
- `npm test` *(fails: Missing script "test")*
- `for file in tests/*.js; do node "$file" || break; done` *(Warrior skill integration test passed and all preceding tests completed)*
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689065677dd0832780e3a9b6bc2dd19a