### PR TITLE
feat: introduce mechanic mercenary class

### DIFF
--- a/src/game/data/classGrades.js
+++ b/src/game/data/classGrades.js
@@ -30,6 +30,14 @@ export const classGrades = {
         rangedDefense: 3,
         magicDefense: 1,
     },
+    mechanic: {
+        meleeAttack: 2,
+        rangedAttack: 1,
+        magicAttack: 2,
+        meleeDefense: 2,
+        rangedDefense: 2,
+        magicDefense: 2,
+    },
     medic: {
         meleeAttack: 1,
         rangedAttack: 1,

--- a/src/game/data/classProficiencies.js
+++ b/src/game/data/classProficiencies.js
@@ -18,6 +18,13 @@ export const classProficiencies = {
         SKILL_TAGS.KINETIC,
         SKILL_TAGS.FIXED,
     ],
+    mechanic: [
+        SKILL_TAGS.MELEE,
+        SKILL_TAGS.PHYSICAL,
+        SKILL_TAGS.SUMMON,
+        SKILL_TAGS.AID,
+        SKILL_TAGS.BUFF,
+    ],
     medic: [
         SKILL_TAGS.AID,
         SKILL_TAGS.HEAL,

--- a/src/game/data/classSpecializations.js
+++ b/src/game/data/classSpecializations.js
@@ -31,6 +31,19 @@ export const classSpecializations = {
             }
         }
     ],
+    mechanic: [
+        {
+            tag: SKILL_TAGS.SUMMON,
+            description: "'소환' 태그 스킬 사용 시, 자신이 소환한 모든 소환물의 모든 스탯을 5%씩 영구적으로 향상시킵니다.",
+            effect: {
+                id: 'mechanicSummonBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 99,
+                isGlobal: true,
+                modifiers: { stat: 'all_stats', type: 'percentage', value: 0.05 }
+            }
+        }
+    ],
     medic: [
         {
             tag: SKILL_TAGS.HEAL,

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -44,6 +44,28 @@ export const mercenaryData = {
             weight: 12
         }
     },
+    mechanic: {
+        id: 'mechanic',
+        name: '메카닉',
+        ai_archetype: 'ranged',
+        uiImage: 'assets/images/unit/mechanic-ui.png',
+        battleSprite: 'mechanic',
+        sprites: {
+            idle: 'mechanic',
+            attack: 'mechanic',
+            hitted: 'mechanic',
+            cast: 'mechanic',
+            'status-effects': 'mechanic',
+        },
+        description: '"나의 창조물들이 전장을 파괴할 것이다."',
+        baseStats: {
+            hp: 100, valor: 8, strength: 12, endurance: 10,
+            agility: 8, intelligence: 12, wisdom: 10, luck: 8,
+            attackRange: 1,
+            movement: 2,
+            weight: 16
+        }
+    },
     medic: {
         id: 'medic',
         name: '메딕',

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -61,6 +61,7 @@ export class Preloader extends Scene
         // 유닛 기본 스프라이트 로드
         this.load.image('warrior', 'images/unit/warrior.png');
         this.load.image('gunner', 'images/unit/gunner.png');
+        this.load.image('mechanic', 'images/unit/mechanic.png');
         this.load.image('medic', 'images/unit/medic.png');
         this.load.image('nanomancer', 'images/unit/nanomancer.png');
         this.load.image('flyingmen', 'images/unit/flyingmen.png');
@@ -74,6 +75,7 @@ export class Preloader extends Scene
         // UI용 이미지 로드
         this.load.image('warrior-ui', 'images/territory/warrior-ui.png');
         this.load.image('gunner-ui', 'images/territory/gunner-ui.png');
+        this.load.image('mechanic-ui', 'images/unit/mechanic-ui.png');
         this.load.image('medic-ui', 'images/territory/medic-ui.png');
         this.load.image('nanomancer-ui', 'images/unit/nanomancer-ui.png');
         this.load.image('flyingmen-ui', 'images/unit/flyingmen-ui.png');
@@ -147,7 +149,7 @@ export class Preloader extends Scene
     {
         // 전투 씬에서 사용될 주요 이미지들의 텍스처 필터링 모드를 설정하여 품질을 향상시킵니다.
         const battleTextures = [
-            'warrior', 'gunner', 'medic', 'nanomancer', 'flyingmen', 'esper', 'commander', 'clown', 'android', 'plague-doctor', 'zombie', 'ancestor-peor',
+            'warrior', 'gunner', 'mechanic', 'medic', 'nanomancer', 'flyingmen', 'esper', 'commander', 'clown', 'android', 'plague-doctor', 'zombie', 'ancestor-peor',
             'battle-stage-cursed-forest', 'battle-stage-arena'
         ];
 

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -47,4 +47,5 @@ export const SKILL_TAGS = {
     STRATEGY: '전략',   // ✨ 커맨더를 위한 '전략' 태그
     BIND: '속박',      // ✨ 광대를 위한 '속박' 태그
     SACRIFICE: '희생', // ✨ 안드로이드를 위한 '희생' 태그
+    SUMMON: '소환',     // ✨ 소환수를 다루는 태그
 };


### PR DESCRIPTION
## Summary
- add mechanic base data, combat grades, proficiencies and specialization
- preload mechanic unit and UI images and register battle textures
- expose SUMMON skill tag for summon-oriented classes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689079a92c7883279ec884e770880a02