### PR TITLE
feat(ai): add ENFP archetype for gunner

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -16,6 +16,8 @@ import { createENTP_AI } from './behaviors/createENTP_AI.js';
 import { createINFJ_AI } from './behaviors/createINFJ_AI.js';
 // ✨ [추가] INFP AI import
 import { createINFP_AI } from './behaviors/createINFP_AI.js';
+// ✨ [신규] ENFP AI import
+import { createENFP_AI } from './behaviors/createENFP_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -62,11 +64,14 @@ class AIManager {
                 case 'INFJ': return createINFJ_AI(this.aiEngines);
                 // ✨ [추가] INFP 케이스 추가
                 case 'INFP': return createINFP_AI(this.aiEngines);
+                // ✨ [신규] ENFP 케이스 추가
+                case 'ENFP': return createENFP_AI(this.aiEngines);
                 // 다른 MBTI 유형은 여기서 추가 가능
             }
         }
 
         const unitBaseData = mercenaryData[unit.id];
+        // ✨ [수정] 거너(gunner)가 ai_archetype을 사용하도록 수정
         if (unitBaseData && unitBaseData.ai_archetype) {
             switch (unitBaseData.ai_archetype) {
                 case 'ranged':
@@ -75,6 +80,9 @@ class AIManager {
                     return createHealerAI(this.aiEngines);
                 case 'assassin':
                     return createFlyingmanAI(this.aiEngines);
+                // ✨ [신규] 거너가 ENFP AI를 사용하도록 연결
+                case 'gunner':
+                    return createENFP_AI(this.aiEngines);
                 case 'melee':
                 default:
                     return createMeleeAI(this.aiEngines);

--- a/src/ai/behaviors/createENFP_AI.js
+++ b/src/ai/behaviors/createENFP_AI.js
@@ -1,0 +1,65 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
+
+/**
+ * ENFP: 활동가 아키타입 행동 트리 (거너)
+ * 우선순위:
+ * 1. (핵심 저격) 우선순위가 높은 적(원거리/힐러)에게 가장 강력한 단일 대상 스킬(확정/콤보)을 사용합니다.
+ * 2. (위치 변경) 공격 후에는 다른 안전한 위치로 이동하여 다음 기회를 노립니다.
+ * 3. (일반 공격) 저격할 상황이 아니라면, 일반적인 최적 스킬을 사용합니다.
+ * 4. (재배치) 할 행동이 없다면, 끊임없이 위치를 바꾸며 적을 교란합니다.
+ */
+function createENFP_AI(engines = {}) {
+    // 스킬 하나를 실행하는 공통 로직 (이동 포함)
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 우선순위 타겟에게 '확정' 또는 '콤보' 스킬 저격
+        new SequenceNode([
+            new FindPriorityTargetNode(engines), // 힐러, 원거리 딜러 등 위협적인 적을 먼저 찾음
+            // SkillScoreEngine이 CHARGE, KINETIC, FIXED, COMBO 태그에 매우 높은 점수를 주도록 설정해야 함
+            new FindBestSkillByScoreNode(engines),
+            executeSkillBranch
+        ]),
+
+        // 2순위: 일반적인 최적 스킬 사용
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+
+        // 3순위: 끊임없는 위치 변경 (재배치)
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines), // 단순히 안전한 곳으로 계속 이동
+            new MoveToTargetNode(engines)
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createENFP_AI };

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -24,7 +24,8 @@ export const mercenaryData = {
     gunner: {
         id: 'gunner',
         name: '거너',
-        ai_archetype: 'ranged',
+        // ✨ [수정] ai_archetype을 'gunner'로 명시하여 ENFP AI와 연결
+        ai_archetype: 'gunner',
         uiImage: 'assets/images/territory/gunner-ui.png',
         battleSprite: 'gunner',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -102,6 +102,15 @@ class SkillScoreEngine {
                 if (tags.includes(SKILL_TAGS.BIND)) mbtiScore += 25; // 끌어당기기 스킬 선호
                 if (skillData.type === 'DEBUFF') mbtiScore += 15;
             }
+
+            // ✨ [신규] ENFP 성향 보너스
+            if (mbtiString === 'ENFP') {
+                const tags = skillData.tags || [];
+                if (tags.includes(SKILL_TAGS.FIXED)) mbtiScore += 30; // 확정 스킬 매우 선호
+                if (tags.includes(SKILL_TAGS.COMBO)) mbtiScore += 25; // 콤보 스킬 선호
+                if (tags.includes(SKILL_TAGS.CHARGE)) mbtiScore += 20; // 돌진 스킬도 선호
+                if (tags.includes(SKILL_TAGS.KINETIC)) mbtiScore += 15; // 관성(넉백) 스킬 선호
+            }
         }
 
         // ✨ 3. 음양 시스템 점수 계산 로직 추가


### PR DESCRIPTION
## Summary
- add ENFP behavior tree for gunner units
- wire ENFP AI into AIManager and gunner data
- reward ENFP units for fixed/combo/charge/kinetic skills in scoring engine

## Testing
- `node tests/gunner_skill_integration_test.js`
- `for f in tests/*.js; do node "$f"; done | tail -n 20`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6890b0e9336c8327af549742739d2603