### PR TITLE
Add Sentinel class with guardian mechanics

### DIFF
--- a/src/game/data/classGrades.js
+++ b/src/game/data/classGrades.js
@@ -112,6 +112,17 @@ export const classGrades = {
         meleeDefense: 2, // 근접 방어는 보통
         rangedDefense: 2, // 원거리 방어도 보통
         magicDefense: 3, // 마법 저항력은 높음
-    }
+    },
     // --- ▲ [신규] 역병 의사 등급 추가 ▲ ---
+
+    // --- ▼ [신규] 센티넬 등급 추가 ▼ ---
+    sentinel: {
+        meleeAttack: 2,
+        rangedAttack: 1,
+        magicAttack: 1,
+        meleeDefense: 3,
+        rangedDefense: 3,
+        magicDefense: 2,
+    }
+    // --- ▲ [신규] 센티넬 등급 추가 ▲ ---
 };

--- a/src/game/data/classProficiencies.js
+++ b/src/game/data/classProficiencies.js
@@ -82,5 +82,15 @@ export const classProficiencies = {
         SKILL_TAGS.HEAL,
     ],
     // --- ▲ [신규] 역병 의사 숙련도 태그 추가 ▲ ---
+
+    // --- ▼ [신규] 센티넬 숙련도 태그 추가 ▼ ---
+    sentinel: [
+        SKILL_TAGS.MELEE,
+        SKILL_TAGS.PHYSICAL,
+        SKILL_TAGS.WILL,
+        SKILL_TAGS.WILL_GUARD,
+        SKILL_TAGS.GUARDIAN,
+    ],
+    // --- ▲ [신규] 센티넬 숙련도 태그 추가 ▲ ---
     // '좀비'와 같은 몬스터는 숙련도 보너스를 받지 않으므로 정의하지 않습니다.
 };

--- a/src/game/data/classSpecializations.js
+++ b/src/game/data/classSpecializations.js
@@ -149,6 +149,25 @@ export const classSpecializations = {
                 modifiers: { stat: 'statusEffectApplication', type: 'percentage', value: 0.05 }
             }
         }
-    ]
+    ],
     // --- ▲ [신규] 역병 의사 특화 태그 추가 ▲ ---
+
+    // --- ▼ [신규] 센티넬 특화 태그 추가 ▼ ---
+    sentinel: [
+        {
+            tag: SKILL_TAGS.GUARDIAN,
+            description: "'가디언' 태그 스킬 사용 시, 1턴간 자신의 모든 방어 등급(+1)이 오릅니다.",
+            effect: {
+                id: 'sentinelGuardianBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 1,
+                modifiers: [
+                    { stat: 'meleeDefense', type: 'flat', value: 1 },
+                    { stat: 'rangedDefense', type: 'flat', value: 1 },
+                    { stat: 'magicDefense', type: 'flat', value: 1 }
+                ]
+            }
+        }
+    ]
+    // --- ▲ [신규] 센티넬 특화 태그 추가 ▲ ---
 };

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -1,3 +1,5 @@
+import { sentinelSkills } from './skills/sentinel.js';
+
 export const mercenaryData = {
     warrior: {
         id: 'warrior',
@@ -302,6 +304,38 @@ export const mercenaryData = {
             iconPath: 'assets/images/skills/antidote.png'
         }
         // --- ▲ [신규] 클래스 패시브 정보 추가 ▲ ---
-    }
+    },
     // --- ▲ [신규] 역병 의사 클래스 데이터 추가 ▲ ---
+
+    // --- ▼ [신규] 센티넬 클래스 데이터 추가 ▼ ---
+    sentinel: {
+        id: 'sentinel',
+        name: '센티넬',
+        ai_archetype: 'melee',
+        uiImage: 'assets/images/unit/sentinel-ui.png',
+        battleSprite: 'sentinel',
+        sprites: {
+            idle: 'sentinel',
+            attack: 'sentinel',
+            hitted: 'sentinel',
+            cast: 'sentinel',
+            'status-effects': 'sentinel',
+        },
+        description: '"이 방벽을 넘을 순 없다."',
+        baseStats: {
+            hp: 130, valor: 12, strength: 14, endurance: 16,
+            agility: 6, intelligence: 5, wisdom: 8, luck: 7,
+            movement: 3,
+            attackRange: 1,
+            weight: 20
+        },
+        classPassive: {
+            id: 'sentryDuty',
+            name: '전방 주시',
+            description: '센티넬에게 공격받은 적은 전투가 끝날 때까지 [전방 주시] 디버프를 받습니다. 이 디버프는 센티넬에게 가하는 피해량을 5% 감소시키며, 최대 3번까지 중첩됩니다.',
+            iconPath: 'assets/images/skills/eye-of-guard.png',
+            effect: sentinelSkills.sentryDuty.effect
+        }
+    }
+    // --- ▲ [신규] 센티넬 클래스 데이터 추가 ▲ ---
 };

--- a/src/game/data/skills/SkillCardDatabase.js
+++ b/src/game/data/skills/SkillCardDatabase.js
@@ -5,6 +5,7 @@ import { passiveSkills } from './passive.js';
 import { aidSkills } from './aid.js';
 import { summonSkills } from './summon.js';
 import { strategySkills } from './strategy.js';
+import { sentinelSkills } from './sentinel.js';
 
 // 모든 스킬을 하나의 객체로 통합하여 쉽게 조회할 수 있도록 함
 export const skillCardDatabase = {
@@ -15,4 +16,5 @@ export const skillCardDatabase = {
     ...aidSkills,
     ...summonSkills,
     ...strategySkills,
+    ...sentinelSkills,
 };

--- a/src/game/data/skills/sentinel.js
+++ b/src/game/data/skills/sentinel.js
@@ -1,0 +1,24 @@
+import { EFFECT_TYPES } from '../../utils/EffectTypes.js';
+import { SKILL_TAGS } from '../../utils/SkillTagManager.js';
+
+export const sentinelSkills = {
+    sentryDuty: {
+        id: 'sentryDuty',
+        name: '전방 주시',
+        type: 'PASSIVE',
+        tags: [SKILL_TAGS.PASSIVE, SKILL_TAGS.GUARDIAN],
+        description: '센티넬에게 공격받은 적은 전투가 끝날 때까지 [전방 주시] 디버프를 받습니다. 이 디버프는 센티넬에게 가하는 피해량을 5% 감소시키며, 최대 3번까지 중첩됩니다.',
+        illustrationPath: 'assets/images/skills/eye-of-guard.png',
+        effect: {
+            id: 'sentryDutyDebuff',
+            type: EFFECT_TYPES.DEBUFF,
+            duration: 99, // 전투 내내 지속
+            maxStacks: 3,
+            modifiers: {
+                stat: 'damageToSentinel', // 센티넬에게 가하는 데미지
+                type: 'percentage',
+                value: -0.05
+            }
+        }
+    }
+};

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -183,6 +183,15 @@ export const statusEffects = {
         iconPath: 'assets/images/skills/reinforcement-learning.png',
         // 이 버프는 스택만 쌓고, 실제 스탯 보너스는 CombatCalculationEngine에서 동적으로 계산됩니다.
     },
+    // --- ▼ [신규] 전방 주시 디버프 효과 추가 ▼ ---
+    sentryDutyDebuff: {
+        id: 'sentryDutyDebuff',
+        name: '전방 주시',
+        type: EFFECT_TYPES.DEBUFF,
+        iconPath: 'assets/images/skills/eye-of-guard.png',
+        description: '이 유닛은 센티넬에게 가하는 피해량이 감소합니다.',
+    },
+    // --- ▲ [신규] 전방 주시 디버프 효과 추가 ▲ ---
     flyingmenChargeBonus: {
         id: 'flyingmenChargeBonus',
         name: '신속',

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -71,6 +71,8 @@ export class Preloader extends Scene
         this.load.image('android', 'images/unit/android.png'); // 추가
         // ✨ [추가] 역병 의사 스프라이트 로드
         this.load.image('plague-doctor', 'images/unit/plague-doctor.png');
+        // ✨ [추가] 센티넬 스프라이트 로드
+        this.load.image('sentinel', 'images/unit/sentinel.png');
 
         // UI용 이미지 로드
         this.load.image('warrior-ui', 'images/territory/warrior-ui.png');
@@ -85,6 +87,8 @@ export class Preloader extends Scene
         this.load.image('android-ui', 'images/unit/android-ui.png'); // 추가
         // ✨ [추가] 역병 의사 UI 이미지 로드
         this.load.image('plague-doctor-ui', 'images/unit/plague-doctor-ui.png');
+        // ✨ [추가] 센티넬 UI 이미지 로드
+        this.load.image('sentinel-ui', 'images/unit/sentinel-ui.png');
 
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
@@ -115,6 +119,8 @@ export class Preloader extends Scene
         // --- ▼ [신규] 역병 의사 패시브 아이콘 추가 ▼ ---
         this.load.image('antidote', 'images/skills/antidote.png');
         // --- ▲ [신규] 역병 의사 패시브 아이콘 추가 ▲ ---
+        // --- ✨ [추가] 센티넬 패시브 아이콘 로드 ---
+        this.load.image('eye-of-guard', 'images/skills/eye-of-guard.png');
         this.load.image('suppress-shot', 'images/skills/suppress-shot.png');
         this.load.image('stigma', 'images/skills/stigma.png');
         this.load.image('nanobeam', 'images/skills/nanobeam.png');
@@ -151,7 +157,7 @@ export class Preloader extends Scene
     {
         // 전투 씬에서 사용될 주요 이미지들의 텍스처 필터링 모드를 설정하여 품질을 향상시킵니다.
         const battleTextures = [
-            'warrior', 'gunner', 'mechanic', 'medic', 'nanomancer', 'flyingmen', 'esper', 'commander', 'clown', 'android', 'plague-doctor', 'zombie', 'ancestor-peor',
+            'warrior', 'gunner', 'mechanic', 'medic', 'nanomancer', 'flyingmen', 'esper', 'commander', 'clown', 'android', 'plague-doctor', 'sentinel', 'zombie', 'ancestor-peor',
             'battle-stage-cursed-forest', 'battle-stage-arena'
         ];
 

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -48,4 +48,5 @@ export const SKILL_TAGS = {
     BIND: '속박',      // ✨ 광대를 위한 '속박' 태그
     SACRIFICE: '희생', // ✨ 안드로이드를 위한 '희생' 태그
     SUMMON: '소환',     // ✨ 소환수를 다루는 태그
+    GUARDIAN: '가디언', // ✨ 센티넬을 위한 '가디언' 태그
 };

--- a/tests/sentinel_skill_integration_test.js
+++ b/tests/sentinel_skill_integration_test.js
@@ -1,0 +1,49 @@
+import assert from 'assert';
+import { mercenaryData } from '../src/game/data/mercenaries.js';
+import { statEngine } from '../src/game/utils/StatEngine.js';
+import { statusEffectManager } from '../src/game/utils/StatusEffectManager.js';
+import { EFFECT_TYPES } from '../src/game/utils/EffectTypes.js';
+
+console.log('--- 센티넬 클래스 통합 테스트 시작 ---');
+
+// 1. 기본 데이터 및 스탯 검증
+const sentinelBase = mercenaryData.sentinel;
+assert(sentinelBase, '센티넬 기본 데이터가 존재해야 합니다.');
+
+const finalStats = statEngine.calculateStats(sentinelBase, sentinelBase.baseStats, []);
+assert.strictEqual(finalStats.movement, 3, '이동 거리가 3이어야 합니다.');
+assert.strictEqual(finalStats.attackRange, 1, '공격 사거리가 1이어야 합니다.');
+assert(finalStats.physicalDefense > 18, '물리 방어력이 높아야 합니다.'); // 15 * 1.2 = 18
+
+console.log('✅ 기본 스탯 테스트 통과');
+
+// 2. 클래스 패시브("전방 주시") 로직 검증
+const sentinel = {
+    uniqueId: 1,
+    ...sentinelBase
+};
+const attacker = {
+    uniqueId: 2,
+    instanceName: 'Test Attacker'
+};
+
+// 가짜 공격 상황 시뮬레이션 (실제로는 BattleSimulatorEngine에서 처리)
+const passiveEffect = sentinel.classPassive.effect;
+statusEffectManager.addEffect(attacker, { name: sentinel.classPassive.name, effect: passiveEffect }, sentinel);
+
+let attackerEffects = statusEffectManager.activeEffects.get(attacker.uniqueId) || [];
+assert.strictEqual(attackerEffects.length, 1, '전방 주시 디버프가 적용되어야 합니다.');
+assert.strictEqual(attackerEffects[0].id, 'sentryDutyDebuff', '디버프 ID가 올바해야 합니다.');
+
+// 스택 중첩 테스트
+statusEffectManager.addEffect(attacker, { name: sentinel.classPassive.name, effect: passiveEffect }, sentinel);
+statusEffectManager.addEffect(attacker, { name: sentinel.classPassive.name, effect: passiveEffect }, sentinel);
+statusEffectManager.addEffect(attacker, { name: sentinel.classPassive.name, effect: passiveEffect }, sentinel); // 4번째, 중첩 안되어야 함
+
+attackerEffects = statusEffectManager.activeEffects.get(attacker.uniqueId) || [];
+// 참고: 현재 StatusEffectManager는 스택을 별도로 관리하지 않고 덮어쓰므로, 길이는 1이 됩니다.
+// 스택킹 로직은 CombatCalculationEngine에서 처리됩니다. 이 테스트는 디버프 적용 여부만 확인합니다.
+assert.strictEqual(attackerEffects.length, 1, '디버프는 중첩되어도 하나만 존재해야 합니다.');
+
+console.log('✅ 클래스 패시브 테스트 통과');
+console.log('--- 모든 센티넬 테스트 완료 ---');


### PR DESCRIPTION
## Summary
- add Sentinel passive skill `sentryDuty` and expose it via skill database
- integrate Sentinel class data, grades, proficiencies, specialization and GUARDIAN skill tag
- preload Sentinel assets and implement `sentryDutyDebuff` status effect with guardian icon

## Testing
- `node tests/sentinel_skill_integration_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6891e4126bc883279f4c00bd53716a23