### PR TITLE
feat(ai): add ISTJ sentinel behavior

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -18,6 +18,8 @@ import { createINFJ_AI } from './behaviors/createINFJ_AI.js';
 import { createINFP_AI } from './behaviors/createINFP_AI.js';
 // ✨ [신규] ENFP AI import
 import { createENFP_AI } from './behaviors/createENFP_AI.js';
+// ✨ [신규] ISTJ AI import
+import { createISTJ_AI } from './behaviors/createISTJ_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -66,6 +68,8 @@ class AIManager {
                 case 'INFP': return createINFP_AI(this.aiEngines);
                 // ✨ [신규] ENFP 케이스 추가
                 case 'ENFP': return createENFP_AI(this.aiEngines);
+                // ✨ [신규] ISTJ 케이스 추가
+                case 'ISTJ': return createISTJ_AI(this.aiEngines);
                 // 다른 MBTI 유형은 여기서 추가 가능
             }
         }

--- a/src/ai/behaviors/createISTJ_AI.js
+++ b/src/ai/behaviors/createISTJ_AI.js
@@ -1,0 +1,73 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+
+/**
+ * ISTJ: 청렴한 논리주의자 아키타입 행동 트리 (센티넬)
+ * 우선순위:
+ * 1. (자기 강화) 자신에게 사용할 수 있는 버프 스킬(방어력 증가 등)이 있다면 최우선으로 사용합니다.
+ * 2. (위치 고수 공격) 현재 위치에서 공격 가능한 적이 있다면 공격합니다. (이동 X)
+ * 3. (초기 위치 선정) 아직 이동하지 않았고, 공격할 대상이 없다면 안전한 위치로 이동합니다.
+ * 4. (일반 공격) 위 모든 행동이 불가능할 경우, 가장 가까운 적을 향해 이동 및 공격을 시도합니다.
+ */
+function createISTJ_AI(engines = {}) {
+    // 스킬 하나를 실행하는 공통 로직 (이동 포함)
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 자기 자신에게 버프 사용
+        new SequenceNode([
+            // SkillScoreEngine에서 BUFF, WILL_GUARD 태그에 높은 점수를 받도록 설정
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetBySkillTypeNode(engines), // BUFF, AID 타입은 자신 또는 아군을 찾음
+            // 자신에게 버프를 거는 경우는 이동이 필요 없으므로 executeSkillBranch 사용
+            executeSkillBranch
+        ]),
+
+        // 2순위: 이동 없이 현재 위치에서 공격
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetBySkillTypeNode(engines),
+            new IsSkillInRangeNode(engines), // 사거리 내에 있을 때만 SUCCESS
+            new UseSkillNode(engines)       // 이동 없이 즉시 사용
+        ]),
+
+        // 3순위: 초기 위치 선정 (아직 이동 안했을 경우)
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+
+        // 4순위: 일반적인 근접 공격 (최후의 수단)
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createISTJ_AI };

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -111,6 +111,13 @@ class SkillScoreEngine {
                 if (tags.includes(SKILL_TAGS.CHARGE)) mbtiScore += 20; // 돌진 스킬도 선호
                 if (tags.includes(SKILL_TAGS.KINETIC)) mbtiScore += 15; // 관성(넉백) 스킬 선호
             }
+            // ✨ [신규] ISTJ 성향 보너스
+            if (mbtiString === 'ISTJ') {
+                const tags = skillData.tags || [];
+                if (tags.includes(SKILL_TAGS.WILL_GUARD)) mbtiScore += 40; // 의지 방패 매우 선호
+                if (skillData.type === 'BUFF') mbtiScore += 30; // 버프 스킬 선호
+                if (tags.includes(SKILL_TAGS.AURA)) mbtiScore += 25; // 오라 스킬 선호
+            }
         }
 
         // ✨ 3. 음양 시스템 점수 계산 로직 추가


### PR DESCRIPTION
## Summary
- add ISTJ behavior tree with buff-first sentinel logic
- wire ISTJ units through AIManager
- teach SkillScoreEngine ISTJ tag preferences

## Testing
- `node tests/sentinel_skill_integration_test.js`
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6891e644f488832780801298f855e4e7