### PR TITLE
feat: add ISFJ medic archetype

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -20,6 +20,8 @@ import { createINFP_AI } from './behaviors/createINFP_AI.js';
 import { createENFP_AI } from './behaviors/createENFP_AI.js';
 // ✨ [신규] ISTJ AI import
 import { createISTJ_AI } from './behaviors/createISTJ_AI.js';
+// ✨ [신규] ISFJ AI import
+import { createISFJ_AI } from './behaviors/createISFJ_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -70,6 +72,8 @@ class AIManager {
                 case 'ENFP': return createENFP_AI(this.aiEngines);
                 // ✨ [신규] ISTJ 케이스 추가
                 case 'ISTJ': return createISTJ_AI(this.aiEngines);
+                // ✨ [신규] ISFJ 케이스 추가
+                case 'ISFJ': return createISFJ_AI(this.aiEngines);
                 // 다른 MBTI 유형은 여기서 추가 가능
             }
         }

--- a/src/ai/behaviors/createISFJ_AI.js
+++ b/src/ai/behaviors/createISFJ_AI.js
@@ -1,0 +1,63 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindSafeHealingPositionNode from '../nodes/FindSafeHealingPositionNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindLowestHealthAllyNode from '../nodes/FindLowestHealthAllyNode.js';
+import FindAllyToBuffNode from '../nodes/FindAllyToBuffNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+
+/**
+ * ISFJ: 용감한 수호자 아키타입 행동 트리 (메딕)
+ * 우선순위:
+ * 1. (최우선 치유) 체력이 100%가 아닌 아군 중 가장 체력 비율이 낮은 아군을 치유합니다.
+ * 2. (예방적 버프) 치유할 대상이 없으면, 아직 버프가 없는 아군에게 버프(의지 방패 등)를 겁니다.
+ * 3. (위치 선정) 할 행동이 없으면, 아군 근처의 안전한 위치로 이동합니다.
+ */
+function createISFJ_AI(engines = {}) {
+    // 스킬 하나를 실행하는 공통 로직 (이동 포함)
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeHealingPositionNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 아군 치유
+        new SequenceNode([
+            new FindLowestHealthAllyNode(engines), // 체력이 100%가 아닌 가장 위급한 아군 탐색
+            new FindBestSkillByScoreNode(engines), // SkillScoreEngine이 HEAL, AID 태그에 높은 점수 부여
+            executeSkillBranch
+        ]),
+
+        // 2순위: 예방적 버프/보호막
+        new SequenceNode([
+            new FindAllyToBuffNode(engines), // 버프가 없는 아군 탐색
+            new FindBestSkillByScoreNode(engines), // WILL_GUARD, BUFF 태그에 높은 점수 부여
+            executeSkillBranch
+        ]),
+
+        // 3순위: 안전한 위치로 재배치
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines),
+            new MoveToTargetNode(engines)
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createISFJ_AI };

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -106,7 +106,15 @@ export const mercenaryData = {
             attackRange: 2,
             movement: 2,
             weight: 18
+        },
+        // --- ▼ [신규] 클래스 패시브 정보 추가 ▼ ---
+        classPassive: {
+            id: 'firstAid',
+            name: '응급처치',
+            description: '체력이 25% 이하인 아군을 대상으로 사용하는 [치유] 태그 스킬의 효과가 25% 증가합니다.',
+            iconPath: 'assets/images/skills/first-aid.png'
         }
+        // --- ▲ [신규] 클래스 패시브 정보 추가 ▲ ---
     },
     nanomancer: {
         id: 'nanomancer',

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -119,6 +119,9 @@ export class Preloader extends Scene
         // --- ▼ [신규] 역병 의사 패시브 아이콘 추가 ▼ ---
         this.load.image('antidote', 'images/skills/antidote.png');
         // --- ▲ [신규] 역병 의사 패시브 아이콘 추가 ▲ ---
+        // --- ▼ [신규] 메딕 패시브 아이콘 추가 ▼ ---
+        this.load.image('first-aid', 'images/skills/first-aid.png');
+        // --- ▲ [신규] 메딕 패시브 아이콘 추가 ▲ ---
         // --- ✨ [추가] 센티넬 패시브 아이콘 로드 ---
         this.load.image('eye-of-guard', 'images/skills/eye-of-guard.png');
         this.load.image('suppress-shot', 'images/skills/suppress-shot.png');

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -228,7 +228,23 @@ class SkillEffectProcessor {
             return;
         }
 
-        const healAmount = Math.round(unit.finalStats.wisdom * (skill.healMultiplier || 0));
+        let healAmount = Math.round(unit.finalStats.wisdom * (skill.healMultiplier || 0));
+
+        // --- ▼ [신규] 메딕 '응급처치' 패시브 로직 추가 ▼ ---
+        if (unit.classPassive?.id === 'firstAid' &&
+            skill.tags?.includes(SKILL_TAGS.HEAL) &&
+            (target.currentHp / target.finalStats.hp) <= 0.25)
+        {
+            const bonusHeal = healAmount * 0.25;
+            healAmount += bonusHeal;
+            debugLogEngine.log(
+                this.constructor.name,
+                `[${unit.instanceName}]의 [응급처치] 패시브 발동! 치유량 +25% (${bonusHeal.toFixed(0)})`
+            );
+            this.vfxManager.showEffectName(unit.sprite, '응급처치!', '#22c55e');
+        }
+        // --- ▲ [신규] 메딕 '응급처치' 패시브 로직 추가 ▲ ---
+
         if (healAmount > 0) {
             target.currentHp = Math.min(target.finalStats.hp, target.currentHp + healAmount);
             this.vfxManager.createDamageNumber(target.sprite.x, target.sprite.y, `+${healAmount}`, '#22c55e');

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -118,6 +118,13 @@ class SkillScoreEngine {
                 if (skillData.type === 'BUFF') mbtiScore += 30; // 버프 스킬 선호
                 if (tags.includes(SKILL_TAGS.AURA)) mbtiScore += 25; // 오라 스킬 선호
             }
+            // ✨ [신규] ISFJ 성향 보너스
+            if (mbtiString === 'ISFJ') {
+                const tags = skillData.tags || [];
+                if (tags.includes(SKILL_TAGS.HEAL)) mbtiScore += 50; // 치유가 최우선
+                if (tags.includes(SKILL_TAGS.AID)) mbtiScore += 40; // 지원 스킬도 매우 선호
+                if (tags.includes(SKILL_TAGS.WILL_GUARD)) mbtiScore += 30; // 보호막 스킬 선호
+            }
         }
 
         // ✨ 3. 음양 시스템 점수 계산 로직 추가

--- a/tests/first_aid_passive_test.js
+++ b/tests/first_aid_passive_test.js
@@ -1,0 +1,42 @@
+import assert from 'assert';
+import SkillEffectProcessor from '../src/game/utils/SkillEffectProcessor.js';
+import { SKILL_TAGS } from '../src/game/utils/SkillTagManager.js';
+import { spriteEngine } from '../src/game/utils/SpriteEngine.js';
+
+// 스프라이트 엔진의 애니메이션 변경을 무시합니다.
+spriteEngine.changeSpriteForDuration = () => {};
+
+const engines = {
+    vfxManager: { createDamageNumber() {}, showEffectName() {} },
+    animationEngine: {},
+    terminationManager: {},
+    summoningEngine: {},
+    battleSimulator: {}
+};
+
+const processor = new SkillEffectProcessor(engines);
+
+const medic = {
+    instanceName: 'Medic',
+    classPassive: { id: 'firstAid' },
+    finalStats: { wisdom: 100 },
+    sprite: { scene: null, setTexture: () => {}, active: true },
+    sprites: {}
+};
+
+const target = {
+    instanceName: 'Ally',
+    currentHp: 30,
+    finalStats: { hp: 200 },
+    isHealingProhibited: false,
+    sprite: { x: 0, y: 0 }
+};
+
+const skill = {
+    tags: [SKILL_TAGS.HEAL],
+    healMultiplier: 1
+};
+
+await processor._processAidSkill(medic, target, skill);
+assert.strictEqual(target.currentHp, 155);
+console.log('First Aid passive test passed.');

--- a/tests/setup-indexeddb.js
+++ b/tests/setup-indexeddb.js
@@ -1,0 +1,3 @@
+globalThis.indexedDB = {
+  open() { return { onerror: null, onsuccess: null }; }
+};


### PR DESCRIPTION
## Summary
- add ISFJ healer behavior tree and hook into AI manager
- introduce Medic `firstAid` class passive with healing bonus and asset
- support ISFJ scoring and add tests for first aid passive

## Testing
- `for f in tests/*_test.js; do node --require ./tests/setup-indexeddb.js $f; done`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6891e963353c8327bc797562a0a15859