### PR TITLE
feat: add ESTJ AI and bravery passive

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -22,6 +22,8 @@ import { createENFP_AI } from './behaviors/createENFP_AI.js';
 import { createISTJ_AI } from './behaviors/createISTJ_AI.js';
 // ✨ [신규] ISFJ AI import
 import { createISFJ_AI } from './behaviors/createISFJ_AI.js';
+// ✨ [신규] ESTJ AI import
+import { createESTJ_AI } from './behaviors/createESTJ_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -74,6 +76,8 @@ class AIManager {
                 case 'ISTJ': return createISTJ_AI(this.aiEngines);
                 // ✨ [신규] ISFJ 케이스 추가
                 case 'ISFJ': return createISFJ_AI(this.aiEngines);
+                // ✨ [신규] ESTJ 케이스 추가
+                case 'ESTJ': return createESTJ_AI(this.aiEngines);
                 // 다른 MBTI 유형은 여기서 추가 가능
             }
         }

--- a/src/ai/behaviors/createESTJ_AI.js
+++ b/src/ai/behaviors/createESTJ_AI.js
@@ -1,0 +1,68 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
+import FindLowestHealthEnemyNode from '../nodes/FindLowestHealthEnemyNode.js';
+import FindSkillByTagNode from '../nodes/FindSkillByTagNode.js';
+import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
+
+/**
+ * ESTJ: 엄격한 관리자 아키타입 행동 트리 (전사)
+ * 우선순위:
+ * 1. (점사 대상 선정) 위협적이거나 체력이 낮은 적을 이번 턴의 목표로 고정합니다.
+ * 2. (약화 후 공격) 목표에게 [DEBUFF] 스킬을 먼저 사용한 뒤, 다른 공격 스킬을 연계합니다.
+ * 3. (일반 공격) 사용할 디버프 스킬이 없다면, 바로 최적의 공격 스킬을 사용합니다.
+ * 4. (이동) 위 행동을 위해 필요하다면 이동합니다.
+ */
+function createESTJ_AI(engines = {}) {
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SequenceNode([
+        // 1. 점사할 타겟을 먼저 결정 (가장 체력 낮은 적 > 우선순위 적)
+        new SelectorNode([
+            new FindLowestHealthEnemyNode(engines),
+            new FindPriorityTargetNode(engines)
+        ]),
+        // 2. 결정된 타겟을 대상으로 행동 개시
+        new SelectorNode([
+            // 2-1. 디버프 -> 공격 연계 시도
+            new SequenceNode([
+                new FindSkillByTagNode(SKILL_TAGS.DEBUFF, engines),
+                new FindTargetBySkillTypeNode(engines),
+                executeSkillBranch,
+                new FindBestSkillByScoreNode(engines),
+                new FindTargetBySkillTypeNode(engines),
+                executeSkillBranch
+            ]),
+            // 2-2. 디버프가 없으면 바로 공격
+            new SequenceNode([
+                new FindBestSkillByScoreNode(engines),
+                new FindTargetBySkillTypeNode(engines),
+                executeSkillBranch
+            ])
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createESTJ_AI };

--- a/src/ai/nodes/FindSkillByTagNode.js
+++ b/src/ai/nodes/FindSkillByTagNode.js
@@ -1,0 +1,60 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { ownedSkillsManager } from '../../game/utils/OwnedSkillsManager.js';
+import { skillInventoryManager } from '../../game/utils/SkillInventoryManager.js';
+import { skillEngine } from '../../game/utils/SkillEngine.js';
+import { skillScoreEngine } from '../../game/utils/SkillScoreEngine.js';
+
+/**
+ * 사용 가능한 스킬 중 특정 태그를 가진 스킬을 점수 기반으로 찾는 노드
+ */
+class FindSkillByTagNode extends Node {
+    constructor(tag, engines = {}) {
+        super();
+        this.tag = tag;
+        this.skillEngine = engines.skillEngine || skillEngine;
+        this.skillScoreEngine = engines.skillScoreEngine || skillScoreEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+
+        const equippedSkillInstances = ownedSkillsManager.getEquippedSkills(unit.uniqueId);
+        const target = blackboard.get('currentTargetUnit');
+        const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
+        const allies = blackboard.get('allyUnits') || [];
+        const enemies = blackboard.get('enemyUnits') || [];
+
+        let bestSkill = null;
+        let maxScore = -1;
+
+        for (const instanceId of equippedSkillInstances) {
+            if (!instanceId || usedSkills.has(instanceId)) continue;
+
+            const instData = skillInventoryManager.getInstanceData(instanceId);
+            const skillData = skillInventoryManager.getSkillData(instData.skillId, instData.grade);
+
+            // 해당 태그를 가졌고, 사용 가능한 스킬만 대상으로 함
+            if (skillData.tags?.includes(this.tag) && this.skillEngine.canUseSkill(unit, skillData)) {
+                const currentScore = await this.skillScoreEngine.calculateScore(unit, skillData, target, allies, enemies);
+                if (currentScore > maxScore) {
+                    maxScore = currentScore;
+                    bestSkill = { skillData, instanceId };
+                }
+            }
+        }
+
+        if (bestSkill) {
+            blackboard.set('currentTargetSkill', bestSkill);
+            blackboard.set('currentSkillData', bestSkill.skillData);
+            blackboard.set('currentSkillInstanceId', bestSkill.instanceId);
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `[${this.tag}] 태그 스킬 [${bestSkill.skillData.name}] 찾음`);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, `사용 가능한 [${this.tag}] 태그 스킬 없음`);
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindSkillByTagNode;

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -21,7 +21,15 @@ export const mercenaryData = {
             agility: 8, intelligence: 5, wisdom: 5, luck: 7,
             movement: 3,
             weight: 10
+        },
+        // --- ▼ [신규] 클래스 패시브 정보 추가 ▼ ---
+        classPassive: {
+            id: 'bravery',
+            name: '대담함',
+            description: '주위 2타일 내의 적 유닛 수만큼 공격력과 방어력이 4%씩 증가합니다.',
+            iconPath: 'assets/images/skills/bravery.png'
         }
+        // --- ▲ [신규] 클래스 패시브 정보 추가 ▲ ---
     },
     gunner: {
         id: 'gunner',

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -122,6 +122,9 @@ export class Preloader extends Scene
         // --- ▼ [신규] 메딕 패시브 아이콘 추가 ▼ ---
         this.load.image('first-aid', 'images/skills/first-aid.png');
         // --- ▲ [신규] 메딕 패시브 아이콘 추가 ▲ ---
+        // --- ▼ [신규] 전사 패시브 아이콘 추가 ▼ ---
+        this.load.image('bravery', 'images/skills/bravery.png');
+        // --- ▲ [신규] 전사 패시브 아이콘 추가 ▲ ---
         // --- ✨ [추가] 센티넬 패시브 아이콘 로드 ---
         this.load.image('eye-of-guard', 'images/skills/eye-of-guard.png');
         this.load.image('suppress-shot', 'images/skills/suppress-shot.png');

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -125,6 +125,13 @@ class SkillScoreEngine {
                 if (tags.includes(SKILL_TAGS.AID)) mbtiScore += 40; // 지원 스킬도 매우 선호
                 if (tags.includes(SKILL_TAGS.WILL_GUARD)) mbtiScore += 30; // 보호막 스킬 선호
             }
+            // ✨ [신규] ESTJ 성향 보너스
+            if (mbtiString === 'ESTJ') {
+                const tags = skillData.tags || [];
+                if (skillData.type === 'DEBUFF') mbtiScore += 50; // 디버프가 최우선
+                if (tags.includes(SKILL_TAGS.CHARGE)) mbtiScore += 30; // 돌진 선호
+                if (tags.includes(SKILL_TAGS.MELEE)) mbtiScore += 15;
+            }
         }
 
         // ✨ 3. 음양 시스템 점수 계산 로직 추가

--- a/tests/bravery_passive_test.js
+++ b/tests/bravery_passive_test.js
@@ -1,0 +1,50 @@
+import assert from 'assert';
+import { combatCalculationEngine } from '../src/game/utils/CombatCalculationEngine.js';
+import { SKILL_TAGS } from '../src/game/utils/SkillTagManager.js';
+import { comboManager } from '../src/game/utils/ComboManager.js';
+
+const attacker = {
+    team: 'A',
+    classPassive: { id: 'bravery' },
+    gridX: 0,
+    gridY: 0,
+    finalStats: { physicalAttack: 100, physicalDefense: 0, hp: 100 },
+    currentHp: 100,
+    currentBarrier: 0,
+    maxBarrier: 0,
+    instanceName: 'Attacker',
+};
+
+const defender = {
+    team: 'B',
+    gridX: 1,
+    gridY: 0,
+    finalStats: { physicalDefense: 0, hp: 100 },
+    currentHp: 100,
+    currentBarrier: 0,
+    maxBarrier: 0,
+    instanceName: 'Defender',
+};
+
+const skill = {
+    type: 'ACTIVE',
+    tags: [SKILL_TAGS.PHYSICAL],
+    damageMultiplier: 1,
+    cost: 0,
+    cooldown: 0,
+};
+
+combatCalculationEngine.battleSimulator = { turnQueue: [attacker, defender] };
+comboManager.startTurn(attacker.uniqueId);
+const resultNear = combatCalculationEngine.calculateDamage(attacker, defender, skill);
+
+// 멀리 떨어졌을 때
+combatCalculationEngine.battleSimulator.turnQueue[1].gridX = 10;
+combatCalculationEngine.battleSimulator.turnQueue[1].gridY = 10;
+comboManager.startTurn(attacker.uniqueId);
+const resultFar = combatCalculationEngine.calculateDamage(attacker, defender, skill);
+
+assert(resultNear.damage > resultFar.damage);
+const ratio = resultNear.damage / resultFar.damage;
+assert(Math.abs(ratio - 1.04) < 0.01);
+console.log('Bravery passive test passed.');


### PR DESCRIPTION
## Summary
- add ESTJ archetype behavior tree that prioritizes debuffs before attacks
- implement bravery passive and scoring bonuses for ESTJ units
- load warrior passive icon and test bravery passive damage boost

## Testing
- `node --require ./tests/setup-indexeddb.js tests/bravery_passive_test.js`
- `node --require ./tests/setup-indexeddb.js tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6891eb8659988327a5ba2115f7b7eadc