### PR TITLE
feat: add paladin class with aura passive

### DIFF
--- a/src/game/data/classGrades.js
+++ b/src/game/data/classGrades.js
@@ -115,6 +115,17 @@ export const classGrades = {
     },
     // --- ▲ [신규] 역병 의사 등급 추가 ▲ ---
 
+    // --- ▼ [신규] 팔라딘 등급 추가 ▼ ---
+    paladin: {
+        meleeAttack: 3,
+        rangedAttack: 1,
+        magicAttack: 2,
+        meleeDefense: 3,
+        rangedDefense: 2,
+        magicDefense: 3,
+    },
+    // --- ▲ [신규] 팔라딘 등급 추가 ▲ ---
+
     // --- ▼ [신규] 센티넬 등급 추가 ▼ ---
     sentinel: {
         meleeAttack: 2,

--- a/src/game/data/classProficiencies.js
+++ b/src/game/data/classProficiencies.js
@@ -83,6 +83,16 @@ export const classProficiencies = {
     ],
     // --- ▲ [신규] 역병 의사 숙련도 태그 추가 ▲ ---
 
+    // --- ▼ [신규] 팔라딘 숙련도 태그 추가 ▼ ---
+    paladin: [
+        SKILL_TAGS.MELEE,
+        SKILL_TAGS.PHYSICAL,
+        SKILL_TAGS.WILL,
+        SKILL_TAGS.AID,
+        SKILL_TAGS.AURA,
+    ],
+    // --- ▲ [신규] 팔라딘 숙련도 태그 추가 ▲ ---
+
     // --- ▼ [신규] 센티넬 숙련도 태그 추가 ▼ ---
     sentinel: [
         SKILL_TAGS.MELEE,

--- a/src/game/data/classSpecializations.js
+++ b/src/game/data/classSpecializations.js
@@ -152,6 +152,24 @@ export const classSpecializations = {
     ],
     // --- ▲ [신규] 역병 의사 특화 태그 추가 ▲ ---
 
+    // --- ▼ [신규] 팔라딘 특화 태그 추가 ▼ ---
+    paladin: [
+        {
+            tag: SKILL_TAGS.AURA,
+            description: "'오라' 태그 스킬 사용 시, 2턴간 자신의 모든 방어력이 10% 증가합니다.",
+            effect: {
+                id: 'paladinAuraBonus',
+                type: EFFECT_TYPES.BUFF,
+                duration: 2,
+                modifiers: [
+                    { stat: 'physicalDefense', type: 'percentage', value: 0.10 },
+                    { stat: 'magicDefense', type: 'percentage', value: 0.10 }
+                ]
+            }
+        }
+    ],
+    // --- ▲ [신규] 팔라딘 특화 태그 추가 ▲ ---
+
     // --- ▼ [신규] 센티넬 특화 태그 추가 ▼ ---
     sentinel: [
         {

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -323,6 +323,37 @@ export const mercenaryData = {
     },
     // --- ▲ [신규] 역병 의사 클래스 데이터 추가 ▲ ---
 
+    // --- ▼ [신규] 팔라딘 클래스 데이터 추가 ▼ ---
+    paladin: {
+        id: 'paladin',
+        name: '팔라딘',
+        ai_archetype: 'melee', // 기본 AI는 근접 타입, 아군 중심으로 이동하는 AI와 잘 맞습니다.
+        uiImage: 'assets/images/unit/paladin-ui.png',
+        battleSprite: 'paladin',
+        sprites: {
+            idle: 'paladin',
+            attack: 'paladin',
+            hitted: 'paladin',
+            cast: 'paladin',
+            'status-effects': 'paladin',
+        },
+        description: '"신념의 빛으로 아군을 보호하리라."',
+        baseStats: {
+            hp: 125, valor: 10, strength: 13, endurance: 13,
+            agility: 7, intelligence: 8, wisdom: 11, luck: 8,
+            attackRange: 2,
+            movement: 3,
+            weight: 19
+        },
+        classPassive: {
+            id: 'sanctuaryAura',
+            name: '성역의 오라',
+            description: '자신 주위 2타일 내의 모든 아군은 받는 피해량이 10% 감소합니다.',
+            iconPath: 'assets/images/skills/magic-shield.png' // 임시 아이콘
+        }
+    },
+    // --- ▲ [신규] 팔라딘 클래스 데이터 추가 ▲ ---
+
     // --- ▼ [신규] 센티넬 클래스 데이터 추가 ▼ ---
     sentinel: {
         id: 'sentinel',

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -73,6 +73,8 @@ export class Preloader extends Scene
         this.load.image('plague-doctor', 'images/unit/plague-doctor.png');
         // ✨ [추가] 센티넬 스프라이트 로드
         this.load.image('sentinel', 'images/unit/sentinel.png');
+        // ✨ [추가] 팔라딘 스프라이트 로드
+        this.load.image('paladin', 'images/unit/paladin.png');
 
         // UI용 이미지 로드
         this.load.image('warrior-ui', 'images/territory/warrior-ui.png');
@@ -89,6 +91,8 @@ export class Preloader extends Scene
         this.load.image('plague-doctor-ui', 'images/unit/plague-doctor-ui.png');
         // ✨ [추가] 센티넬 UI 이미지 로드
         this.load.image('sentinel-ui', 'images/unit/sentinel-ui.png');
+        // ✨ [추가] 팔라딘 UI 이미지 로드
+        this.load.image('paladin-ui', 'images/unit/paladin-ui.png');
 
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -224,8 +224,27 @@ class CombatCalculationEngine {
         const damageAfterGrade = initialDamage * combatMultiplier;
 
         // ✨ 방어자의 받는 데미지 증가/감소 효과 적용
-        const damageReductionPercent = statusEffectManager.getModifierValue(defender, 'damageReduction');
+        let damageReductionPercent = statusEffectManager.getModifierValue(defender, 'damageReduction');
         const damageIncreasePercent = statusEffectManager.getModifierValue(defender, 'damageIncrease');
+
+        // --- ▼ [신규] 팔라딘 '성역의 오라' 패시브 로직 추가 ▼ ---
+        if (this.battleSimulator) {
+            const allies = this.battleSimulator.turnQueue.filter(u => u.team === defender.team && u.currentHp > 0);
+            const paladinsNearby = allies.filter(ally =>
+                ally.classPassive?.id === 'sanctuaryAura' &&
+                Math.abs(ally.gridX - defender.gridX) + Math.abs(ally.gridY - defender.gridY) <= 2
+            );
+            if (paladinsNearby.length > 0) {
+                const auraReduction = 0.10 * paladinsNearby.length;
+                damageReductionPercent += auraReduction;
+                debugLogEngine.log(
+                    'CombatCalculationEngine',
+                    `[성역의 오라] 효과! ${paladinsNearby.length}명의 팔라딘에 의해 피해량 ${auraReduction * 100}% 감소.`
+                );
+            }
+        }
+        // --- ▲ [신규] 팔라딘 '성역의 오라' 패시브 로직 추가 ▲ ---
+
         // ✨ 아이언 윌 패시브 효과 계산
         const ironWillReduction = this.calculateIronWillReduction(defender);
 

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -49,4 +49,5 @@ export const SKILL_TAGS = {
     SACRIFICE: '희생', // ✨ 안드로이드를 위한 '희생' 태그
     SUMMON: '소환',     // ✨ 소환수를 다루는 태그
     GUARDIAN: '가디언', // ✨ 센티넬을 위한 '가디언' 태그
+    AURA: '오라',       // ✨ 팔라딘을 위한 '오라' 태그
 };

--- a/tests/paladin_passive_integration_test.js
+++ b/tests/paladin_passive_integration_test.js
@@ -1,0 +1,57 @@
+import assert from 'assert';
+import { combatCalculationEngine } from '../src/game/utils/CombatCalculationEngine.js';
+import { mercenaryData } from '../src/game/data/mercenaries.js';
+
+console.log('--- 팔라딘 패시브 통합 테스트 시작 ---');
+
+// Mock 객체 설정
+const mockAttacker = {
+    uniqueId: 1,
+    finalStats: { physicalAttack: 20 },
+};
+const mockDefender = {
+    uniqueId: 2,
+    team: 'ally',
+    gridX: 5,
+    gridY: 5,
+    finalStats: { physicalDefense: 0 },
+    currentHp: 100,
+};
+const mockPaladin = {
+    uniqueId: 3,
+    team: 'ally',
+    gridX: 8,
+    gridY: 8, // 초기에는 멀리 떨어져 있어 오라가 적용되지 않습니다.
+    classPassive: mercenaryData.paladin.classPassive,
+    currentHp: 100,
+};
+
+// 가짜 BattleSimulator 참조 설정
+combatCalculationEngine.battleSimulator = {
+    turnQueue: [mockAttacker, mockDefender, mockPaladin]
+};
+
+// 1. 팔라딘이 멀리 있을 때의 기본 데미지 계산
+let result = combatCalculationEngine.calculateDamage(mockAttacker, mockDefender, { damageMultiplier: 1.0 });
+assert.strictEqual(result.damage, 20, '테스트 1 실패: 팔라딘이 멀리 있을 때 기본 데미지가 20이어야 합니다.');
+console.log('✅ 테스트 1 통과: 팔라딘이 멀리 있을 때 정상 데미지 적용');
+
+// 2. 팔라딘이 주변에 있을 때 데미지 감소 확인
+mockPaladin.gridX = 5;
+mockPaladin.gridY = 6; // 1칸 거리
+result = combatCalculationEngine.calculateDamage(mockAttacker, mockDefender, { damageMultiplier: 1.0 });
+// 예상 데미지: 20 * (1 - 0.10) = 18
+assert.strictEqual(result.damage, 18, '테스트 2 실패: 팔라딘 오라의 피해량 감소(10%)가 적용되지 않았습니다.');
+console.log('✅ 테스트 2 통과: 팔라딘 오라로 피해량 10% 감소');
+
+// 3. 팔라딘이 너무 멀리 있을 때 효과 미적용 확인
+mockPaladin.gridX = 8;
+mockPaladin.gridY = 5; // 3칸 거리
+result = combatCalculationEngine.calculateDamage(mockAttacker, mockDefender, { damageMultiplier: 1.0 });
+assert.strictEqual(result.damage, 20, '테스트 3 실패: 팔라딘이 멀리 있을 때 오라가 적용되었습니다.');
+console.log('✅ 테스트 3 통과: 거리가 멀 때 오라 미적용');
+
+// 참조 초기화
+combatCalculationEngine.battleSimulator = null;
+
+console.log('--- 모든 팔라딘 패시브 테스트 완료 ---');


### PR DESCRIPTION
## Summary
- add Paladin mercenary with Sanctuary Aura passive and associated grade, proficiency, and specialization data
- introduce AURA skill tag and integrate passive damage reduction in combat calculations
- load paladin assets and add integration test for aura passive

## Testing
- `for f in tests/*_test.js; do node --import ./tests/setup-indexeddb.js $f; done | tail -n 20`
- `node --import ./tests/setup-indexeddb.js tests/paladin_passive_integration_test.js | tail -n 30`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6891ef0739088327a4341a0c1178a0ac