### PR TITLE
feat: add ESFJ AI archetype

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -24,6 +24,8 @@ import { createISTJ_AI } from './behaviors/createISTJ_AI.js';
 import { createISFJ_AI } from './behaviors/createISFJ_AI.js';
 // ✨ [신규] ESTJ AI import
 import { createESTJ_AI } from './behaviors/createESTJ_AI.js';
+// ✨ [신규] ESFJ AI import
+import { createESFJ_AI } from './behaviors/createESFJ_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -78,6 +80,8 @@ class AIManager {
                 case 'ISFJ': return createISFJ_AI(this.aiEngines);
                 // ✨ [신규] ESTJ 케이스 추가
                 case 'ESTJ': return createESTJ_AI(this.aiEngines);
+                // ✨ [신규] ESFJ 케이스 추가
+                case 'ESFJ': return createESFJ_AI(this.aiEngines);
                 // 다른 MBTI 유형은 여기서 추가 가능
             }
         }

--- a/src/ai/behaviors/createESFJ_AI.js
+++ b/src/ai/behaviors/createESFJ_AI.js
@@ -1,0 +1,62 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindAllyClusterCenterNode from '../nodes/FindAllyClusterCenterNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+
+/**
+ * ESFJ: 사교적인 외교관 아키타입 행동 트리 (팔라딘)
+ * 우선순위:
+ * 1. (위치 선정) 아군이 가장 많이 뭉쳐있는 곳의 중심으로 이동합니다.
+ * 2. (광역 지원) 아군 전체에 영향을 주는 버프, 오라, 지원 스킬을 우선적으로 사용합니다.
+ * 3. (일반 행동) 위 행동이 불가능할 경우, 일반적인 최적 스킬을 사용합니다.
+ */
+function createESFJ_AI(engines = {}) {
+    // 스킬 하나를 실행하는 공통 로직 (이동 불포함, 현재 위치에서만)
+    const useSkillImmediately = new SequenceNode([
+        new IsSkillInRangeNode(engines),
+        new UseSkillNode(engines)
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 아군 클러스터 중심으로 이동
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindAllyClusterCenterNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+
+        // 2순위: 아군 지원 스킬 사용 (이동 없이 현재 위치에서)
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines), // SkillScoreEngine이 AURA, BUFF, AID에 높은 점수 부여
+            new FindTargetBySkillTypeNode(engines),
+            useSkillImmediately
+        ]),
+
+        // 3순위: 일반 공격 (최후의 수단, 이동 포함)
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetBySkillTypeNode(engines),
+            new SelectorNode([
+                useSkillImmediately, // 바로 공격 가능하면 공격
+                new SequenceNode([ // 아니면 이동 후 공격
+                    new HasNotMovedNode(),
+                    new FindPathToSkillRangeNode(engines),
+                    new MoveToTargetNode(engines),
+                    new IsSkillInRangeNode(engines),
+                    new UseSkillNode(engines)
+                ])
+            ])
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createESFJ_AI };

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -132,6 +132,13 @@ class SkillScoreEngine {
                 if (tags.includes(SKILL_TAGS.CHARGE)) mbtiScore += 30; // 돌진 선호
                 if (tags.includes(SKILL_TAGS.MELEE)) mbtiScore += 15;
             }
+            // ✨ [신규] ESFJ 성향 보너스
+            if (mbtiString === 'ESFJ') {
+                const tags = skillData.tags || [];
+                if (tags.includes(SKILL_TAGS.AURA)) mbtiScore += 50; // 오라 스킬 최우선
+                if (skillData.type === 'BUFF') mbtiScore += 40; // 버프 스킬 선호
+                if (skillData.type === 'AID') mbtiScore += 30; // 지원 스킬 선호
+            }
         }
 
         // ✨ 3. 음양 시스템 점수 계산 로직 추가


### PR DESCRIPTION
## Summary
- add ESFJ behavior tree prioritizing ally clustering and support
- wire ESFJ MBTI to AIManager
- score AURA, BUFF and AID skills higher for ESFJ units

## Testing
- `for f in tests/*test.js; do echo "Running $f"; node --import=./tests/setup-indexeddb.js $f | tail -n 1; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6891f11314648327927bacd2adce9a0c