### PR TITLE
Unify shieldBreak modifiers and refine AI decision flows

### DIFF
--- a/src/ai/behaviors/createESTJ_AI.js
+++ b/src/ai/behaviors/createESTJ_AI.js
@@ -42,18 +42,15 @@ function createESTJ_AI(engines = {}) {
             new FindLowestHealthEnemyNode(engines),
             new FindPriorityTargetNode(engines)
         ]),
-        // 2. 결정된 타겟을 대상으로 행동 개시
+        // 2. 결정된 타겟을 대상으로 행동 개시 (Selector로 감싸 둘 중 하나만 실행되도록 수정)
         new SelectorNode([
-            // 2-1. 디버프 -> 공격 연계 시도
+            // 2-1. 디버프 스킬 사용 시도
             new SequenceNode([
                 new FindSkillByTagNode(SKILL_TAGS.DEBUFF, engines),
                 new FindTargetBySkillTypeNode(engines),
                 executeSkillBranch,
-                new FindBestSkillByScoreNode(engines),
-                new FindTargetBySkillTypeNode(engines),
-                executeSkillBranch
             ]),
-            // 2-2. 디버프가 없으면 바로 공격
+            // 2-2. 디버프가 없거나 실패하면 바로 공격
             new SequenceNode([
                 new FindBestSkillByScoreNode(engines),
                 new FindTargetBySkillTypeNode(engines),

--- a/src/ai/behaviors/createINFP_AI.js
+++ b/src/ai/behaviors/createINFP_AI.js
@@ -39,18 +39,6 @@ function createINFP_AI(engines = {}) {
         ])
     ]);
 
-    // 대상을 블랙보드의 특정 키('skillTarget')로 설정하는 헬퍼 노드
-    const setSkillTarget = (key) => ({
-        async evaluate(_unit, blackboard) {
-            const target = blackboard.get(key);
-            if (target) {
-                blackboard.set('skillTarget', target);
-                return 'SUCCESS';
-            }
-            return 'FAILURE';
-        }
-    });
-
     const rootNode = new SelectorNode([
         // 1순위: 생존 본능
         new SequenceNode([
@@ -65,14 +53,12 @@ function createINFP_AI(engines = {}) {
             // 2-1: 적 메딕에게 '낙인' 시도
             new SequenceNode([
                 new FindEnemyMedicNode(engines),
-                setSkillTarget('enemyMedic'),
                 new FindBestSkillByScoreNode(engines), // SkillScoreEngine이 PROHIBITION 태그에 높은 점수를 주도록 설정
                 executeSkillBranch
             ]),
             // 2-2: 위협적인 버프를 가진 적에게 디버프
             new SequenceNode([
                 new FindBuffedEnemyNode(engines), // 예: 전투의 함성 버프를 가진 적
-                setSkillTarget('buffedEnemy'),
                 new FindBestSkillByScoreNode(engines), // DEBUFF 스킬 선호
                 executeSkillBranch
             ]),
@@ -81,7 +67,6 @@ function createINFP_AI(engines = {}) {
         // 3순위: 아군 지원
         new SequenceNode([
             new FindNearestAllyInDangerNode(0.6), // 체력 60% 이하 아군 탐색
-            setSkillTarget('allyInDanger'),
             new FindBestSkillByScoreNode(engines), // HEAL, AID 스킬 선호
             executeSkillBranch
         ]),

--- a/src/game/data/skills/debuff.js
+++ b/src/game/data/skills/debuff.js
@@ -21,11 +21,13 @@ export const debuffSkills = {
                 id: 'shieldBreak',
                 type: EFFECT_TYPES.DEBUFF,
                 duration: 3,
-                modifiers: {
-                    stat: 'damageIncrease',
-                    type: 'percentage',
-                    value: 0.15 // 4순위 기준 기본값
-                }
+                modifiers: [ // 객체에서 배열로 수정
+                    {
+                        stat: 'damageIncrease',
+                        type: 'percentage',
+                        value: 0.15 // 4순위 기준 기본값
+                    }
+                ]
             }
         },
         // RARE 등급: 토큰 소모량 감소
@@ -44,11 +46,13 @@ export const debuffSkills = {
                 id: 'shieldBreak',
                 type: EFFECT_TYPES.DEBUFF,
                 duration: 3,
-                modifiers: {
-                    stat: 'damageIncrease',
-                    type: 'percentage',
-                    value: 0.15
-                }
+                modifiers: [ // 객체에서 배열로 수정
+                    {
+                        stat: 'damageIncrease',
+                        type: 'percentage',
+                        value: 0.15
+                    }
+                ]
             }
         },
         // EPIC 등급: 방어력 감소 효과 추가


### PR DESCRIPTION
## Summary
- standardize `shieldBreak` modifiers to an array across rarities
- streamline INFP archetype by removing temporary target node
- prevent ESTJ AI from double‑acting after debuffs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build-nolog`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6891f6bc52a083278d181c9931f29ad0