### PR TITLE
feat(ai): add ISTP counter behavior

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -26,6 +26,8 @@ import { createISFJ_AI } from './behaviors/createISFJ_AI.js';
 import { createESTJ_AI } from './behaviors/createESTJ_AI.js';
 // ✨ [신규] ESFJ AI import
 import { createESFJ_AI } from './behaviors/createESFJ_AI.js';
+// ✨ ISTP AI import 추가
+import { createISTP_AI } from './behaviors/createISTP_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -82,6 +84,8 @@ class AIManager {
                 case 'ESTJ': return createESTJ_AI(this.aiEngines);
                 // ✨ [신규] ESFJ 케이스 추가
                 case 'ESFJ': return createESFJ_AI(this.aiEngines);
+                // ✨ [신규] ISTP 케이스 추가
+                case 'ISTP': return createISTP_AI(this.aiEngines);
                 // 다른 MBTI 유형은 여기서 추가 가능
             }
         }
@@ -152,6 +156,9 @@ class AIManager {
     async executeTurn(unit, allUnits, enemyUnits) {
         const data = this.unitData.get(unit.uniqueId);
         if (!data) return;
+
+        // --- \u25BC [핵심 추가] 턴 시작 시 피격 기록 초기화 \u25BC ---
+        unit.wasAttackedBy = null;
 
         // ✨ [신규] 턴 시작 시, 전략적 상황을 계산하여 블랙보드에 업데이트
         const blackboard = data.behaviorTree.blackboard;

--- a/src/ai/behaviors/createISTP_AI.js
+++ b/src/ai/behaviors/createISTP_AI.js
@@ -1,0 +1,65 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import FindSkillByTagNode from '../nodes/FindSkillByTagNode.js';
+import FindLowestHealthEnemyNode from '../nodes/FindLowestHealthEnemyNode.js';
+import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
+import WasAttackedRecentlyNode from '../nodes/WasAttackedRecentlyNode.js';
+import FindAttackerNode from '../nodes/FindAttackerNode.js';
+
+/**
+ * ISTP: 만능 재주꾼 아키타입 행동 트리
+ * 우선순위:
+ * 1. (반격) 최근 자신을 공격한 적에게 [COUNTER] 스킬로 즉시 응수합니다.
+ * 2. (기회 포착) 반격할 상황이 아니면, [FIXED]나 [KINETIC] 태그를 가진 유틸리티 스킬을 사용합니다.
+ * 3. (소극적 대기) 사용할 스킬이 없으면, 안전한 위치로 이동하며 다음 기회를 기다립니다.
+ */
+function createISTP_AI(engines = {}) {
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([ new IsSkillInRangeNode(engines), new UseSkillNode(engines) ]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 반격 로직
+        new SequenceNode([
+            new WasAttackedRecentlyNode(),
+            new FindAttackerNode(engines),
+            new FindSkillByTagNode(SKILL_TAGS.COUNTER, engines),
+            executeSkillBranch
+        ]),
+
+        // 2순위: 기회 포착 (유틸리티 스킬 사용)
+        new SequenceNode([
+            new SelectorNode([
+                new FindSkillByTagNode(SKILL_TAGS.FIXED, engines),
+                new FindSkillByTagNode(SKILL_TAGS.KINETIC, engines)
+            ]),
+            new FindLowestHealthEnemyNode(engines),
+            executeSkillBranch
+        ]),
+
+        // 3순위: 소극적인 위치 재선정
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines),
+            new MoveToTargetNode(engines)
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createISTP_AI };

--- a/src/ai/nodes/FindAttackerNode.js
+++ b/src/ai/nodes/FindAttackerNode.js
@@ -1,0 +1,28 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 블랙보드에 기록된 'lastAttackerId'를 사용해 공격자를 찾아 타겟으로 설정합니다.
+ */
+class FindAttackerNode extends Node {
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const attackerId = blackboard.get('lastAttackerId');
+        const allUnits = blackboard.get('allUnits');
+
+        if (attackerId && allUnits) {
+            const attacker = allUnits.find(u => u.uniqueId === attackerId && u.currentHp > 0);
+            if (attacker) {
+                blackboard.set('skillTarget', attacker);
+                blackboard.set('currentTargetUnit', attacker);
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `반격 대상 [${attacker.instanceName}] 설정`);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '반격 대상을 찾을 수 없음 (사망 등)');
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindAttackerNode;

--- a/src/ai/nodes/WasAttackedRecentlyNode.js
+++ b/src/ai/nodes/WasAttackedRecentlyNode.js
@@ -1,0 +1,24 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 이 유닛이 마지막 턴 이후 공격을 받았는지 확인하는 노드
+ */
+class WasAttackedRecentlyNode extends Node {
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+
+        // CombatCalculationEngine에서 설정한 플래그를 확인합니다.
+        if (unit.wasAttackedBy) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `최근 공격 받음 (공격자 ID: ${unit.wasAttackedBy})`);
+            // 다른 노드가 사용할 수 있도록 공격자 ID를 블랙보드에 저장합니다.
+            blackboard.set('lastAttackerId', unit.wasAttackedBy);
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '최근 공격받은 기록 없음');
+        return NodeState.FAILURE;
+    }
+}
+
+export default WasAttackedRecentlyNode;

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -280,6 +280,9 @@ class CombatCalculationEngine {
             finalDamage,
             finalDefense
         );
+        // --- \u25BC [핵심 추가] 피격 사실을 방어자에게 기록 \u25BC ---
+        defender.wasAttackedBy = attacker.uniqueId;
+
         return { damage: Math.round(finalDamage), hitType: hitType, comboCount };
     }
 

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -50,4 +50,5 @@ export const SKILL_TAGS = {
     SUMMON: '소환',     // ✨ 소환수를 다루는 태그
     GUARDIAN: '가디언', // ✨ 센티넬을 위한 '가디언' 태그
     AURA: '오라',       // ✨ 팔라딘을 위한 '오라' 태그
+    COUNTER: '반격',    // ✨ ISTP를 위한 '반격' 태그
 };


### PR DESCRIPTION
## Summary
- add COUNTER skill tag
- track last attacker and reset each turn
- introduce ISTP AI that retaliates against recent attackers

## Testing
- `node tests/combat_calculation_test.js`
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68921579b6f48327837b8989915ffd70