### PR TITLE
feat: add ESFP AI behavior

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -32,6 +32,8 @@ import { createISTP_AI } from './behaviors/createISTP_AI.js';
 import { createISFP_AI } from './behaviors/createISFP_AI.js';
 // ✨ ESTP AI import 추가
 import { createESTP_AI } from './behaviors/createESTP_AI.js';
+// ✨ ESFP AI import 추가
+import { createESFP_AI } from './behaviors/createESFP_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -94,6 +96,8 @@ class AIManager {
                 case 'ISFP': return createISFP_AI(this.aiEngines);
                 // ✨ [신규] ESTP 케이스 추가
                 case 'ESTP': return createESTP_AI(this.aiEngines);
+                // ✨ [신규] ESFP 케이스 추가
+                case 'ESFP': return createESFP_AI(this.aiEngines);
                 // 다른 MBTI 유형은 여기서 추가 가능
             }
         }

--- a/src/ai/behaviors/createESFP_AI.js
+++ b/src/ai/behaviors/createESFP_AI.js
@@ -1,0 +1,62 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import FindEnemyClusterCenterNode from '../nodes/FindEnemyClusterCenterNode.js';
+
+/**
+ * ESFP: 자유로운 영혼의 연예인 아키타입 행동 트리 (다크나이트)
+ * 우선순위:
+ * 1. (위치 선정) 적 진영의 한가운데로 이동합니다.
+ * 2. (광역 교란) 자신을 중심으로 발동하는 오라, 디버프 스킬을 우선적으로 사용합니다.
+ * 3. (일반 공격) 위 행동이 불가능할 경우, 일반적인 최적 스킬을 사용합니다.
+ */
+function createESFP_AI(engines = {}) {
+    // 스킬 하나를 실행하는 공통 로직 (현재 위치에서만)
+    const useSkillImmediately = new SequenceNode([
+        new IsSkillInRangeNode(engines),
+        new UseSkillNode(engines)
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 적 클러스터 중심으로 이동
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindEnemyClusterCenterNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+
+        // 2순위: 자신 중심의 광역 스킬 사용 (이동 없이 현재 위치에서)
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines), // SkillScoreEngine이 AURA, DEBUFF(광역)에 높은 점수 부여
+            new FindTargetBySkillTypeNode(engines),
+            useSkillImmediately
+        ]),
+
+        // 3순위: 일반 공격 (최후의 수단, 이동 포함)
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetBySkillTypeNode(engines),
+            new SelectorNode([
+                useSkillImmediately, // 바로 공격 가능하면 공격
+                new SequenceNode([ // 아니면 이동 후 공격
+                    new HasNotMovedNode(),
+                    new FindPathToSkillRangeNode(engines),
+                    new MoveToTargetNode(engines),
+                    new IsSkillInRangeNode(engines),
+                    new UseSkillNode(engines)
+                ])
+            ])
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createESFP_AI };

--- a/src/ai/nodes/FindEnemyClusterCenterNode.js
+++ b/src/ai/nodes/FindEnemyClusterCenterNode.js
@@ -1,0 +1,70 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+
+/**
+ * 모든 적 유닛들의 평균 위치(중심점) 근처의 가장 가까운 빈 셀로 이동 경로를 설정하는 노드.
+ * ESFP AI가 적진으로 돌격할 위치를 찾는 데 사용됩니다.
+ */
+class FindEnemyClusterCenterNode extends Node {
+    constructor({ pathfinderEngine, formationEngine } = {}) {
+        super();
+        this.pathfinderEngine = pathfinderEngine;
+        this.formationEngine = formationEngine;
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const enemies = blackboard.get('enemyUnits');
+
+        if (!enemies || enemies.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '중심점을 계산할 적이 없음');
+            return NodeState.FAILURE;
+        }
+
+        const totalPos = enemies.reduce((acc, enemy) => {
+            acc.col += enemy.gridX;
+            acc.row += enemy.gridY;
+            return acc;
+        }, { col: 0, row: 0 });
+
+        const centerPos = {
+            col: Math.round(totalPos.col / enemies.length),
+            row: Math.round(totalPos.row / enemies.length),
+        };
+
+        const availableCells = this.formationEngine.grid.gridCells.filter(
+            c => !c.isOccupied || (c.col === unit.gridX && c.row === unit.gridY)
+        );
+        if (availableCells.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '이동할 빈 셀이 없음');
+            return NodeState.FAILURE;
+        }
+
+        availableCells.sort((a, b) => {
+            const distA = Math.abs(a.col - centerPos.col) + Math.abs(a.row - centerPos.row);
+            const distB = Math.abs(b.col - centerPos.col) + Math.abs(b.row - centerPos.row);
+            return distA - distB;
+        });
+        const bestCell = availableCells[0];
+
+        const path = this.pathfinderEngine.findPath(
+            unit,
+            { col: unit.gridX, row: unit.gridY },
+            { col: bestCell.col, row: bestCell.row }
+        );
+        if (path && path.length > 0) {
+            blackboard.set('movementPath', path);
+            blackboard.set('movementTarget', bestCell);
+            debugAIManager.logNodeResult(
+                NodeState.SUCCESS,
+                `적 중심(${bestCell.col}, ${bestCell.row})으로 경로 설정`
+            );
+            return NodeState.SUCCESS;
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '적 중심점으로의 경로 탐색 실패');
+        return NodeState.FAILURE;
+    }
+}
+
+export default FindEnemyClusterCenterNode;

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -149,6 +149,16 @@ class SkillScoreEngine {
                 if (skillData.type === 'BUFF' && skillData.targetType === 'self') mbtiScore -= 20; // 자기 대상 버프 비선호
             }
             // --- ▲ [신규] ESTP 성향 보너스 ▲ ---
+
+            // --- ▼ [신규] ESFP 성향 보너스 ▼ ---
+            if (mbtiString === 'ESFP') {
+                const tags = skillData.tags || [];
+                if (tags.includes(SKILL_TAGS.AURA)) mbtiScore += 60; // 오라 스킬 최우선
+                if (skillData.type === 'DEBUFF') mbtiScore += 40; // 광역 디버프 선호
+                if (tags.includes(SKILL_TAGS.KINETIC)) mbtiScore += 20; // 관성(밀치기) 선호
+                if (tags.includes(SKILL_TAGS.CHARGE)) mbtiScore += 25; // 돌진 선호
+            }
+            // --- ▲ [신규] ESFP 성향 보너스 ▲ ---
         }
 
         // ✨ 3. 음양 시스템 점수 계산 로직 추가


### PR DESCRIPTION
## Summary
- enable ESFP units to find enemy cluster center and dive in
- prioritize aura and debuff skills for ESFP archetype

## Testing
- `node tests/combat_calculation_test.js`
- `node tests/item_factory_test.js`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68922b3206fc83279d95e230644c267a