### PR TITLE
feat: add sentry debuff stacking and ENFJ AI

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -34,6 +34,8 @@ import { createISFP_AI } from './behaviors/createISFP_AI.js';
 import { createESTP_AI } from './behaviors/createESTP_AI.js';
 // ✨ ESFP AI import 추가
 import { createESFP_AI } from './behaviors/createESFP_AI.js';
+// ✨ [신규] ENFJ AI import
+import { createENFJ_AI } from './behaviors/createENFJ_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
@@ -82,6 +84,7 @@ class AIManager {
                 case 'INFP': return createINFP_AI(this.aiEngines);
                 // ✨ [신규] ENFP 케이스 추가
                 case 'ENFP': return createENFP_AI(this.aiEngines);
+                case 'ENFJ': return createENFJ_AI(this.aiEngines);
                 // ✨ [신규] ISTJ 케이스 추가
                 case 'ISTJ': return createISTJ_AI(this.aiEngines);
                 // ✨ [신규] ISFJ 케이스 추가
@@ -115,6 +118,8 @@ class AIManager {
                 // ✨ [신규] 거너가 ENFP AI를 사용하도록 연결
                 case 'gunner':
                     return createENFP_AI(this.aiEngines);
+                case 'enfj':
+                    return createENFJ_AI(this.aiEngines);
                 case 'melee':
                 default:
                     return createMeleeAI(this.aiEngines);

--- a/src/ai/behaviors/createENFJ_AI.js
+++ b/src/ai/behaviors/createENFJ_AI.js
@@ -1,0 +1,63 @@
+import BehaviorTree from '../BehaviorTree.js';
+import SelectorNode from '../nodes/SelectorNode.js';
+import SequenceNode from '../nodes/SequenceNode.js';
+import MoveToTargetNode from '../nodes/MoveToTargetNode.js';
+import FindAllyClusterNode from '../nodes/FindAllyClusterNode.js';
+import FindSkillByTagNode from '../nodes/FindSkillByTagNode.js';
+import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
+import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
+import UseSkillNode from '../nodes/UseSkillNode.js';
+import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
+import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
+import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
+
+/**
+ * ENFJ: 선도자 아키타입 행동 트리 (메카닉)
+ * 우선순위:
+ * 1. (버프) 아군이 뭉쳐있으면 AURA 스킬 사용
+ * 2. (돌격) 버프 후 가장 위협적인 적에게 CHARGE 스킬 사용
+ * 3. (일반 공격) 위 조건이 안되면 기본 근접 공격
+ */
+function createENFJ_AI(engines = {}) {
+    const executeSkillBranch = new SelectorNode([
+        new SequenceNode([
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ]),
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
+    ]);
+
+    const rootNode = new SelectorNode([
+        // 1순위: 아군 클러스터에 AURA 스킬 사용
+        new SequenceNode([
+            new FindAllyClusterNode(),
+            new FindSkillByTagNode(SKILL_TAGS.AURA, engines),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        // 2순위: 가장 위협적인 적에게 CHARGE 스킬 사용
+        new SequenceNode([
+            new FindPriorityTargetNode(engines),
+            new FindSkillByTagNode(SKILL_TAGS.CHARGE, engines),
+            executeSkillBranch
+        ]),
+        // 3순위: 일반 근접 공격
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ])
+    ]);
+
+    return new BehaviorTree(rootNode);
+}
+
+export { createENFJ_AI };

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -67,7 +67,7 @@ export const mercenaryData = {
     mechanic: {
         id: 'mechanic',
         name: '메카닉',
-        ai_archetype: 'ranged',
+        ai_archetype: 'enfj',
         uiImage: 'assets/images/unit/mechanic-ui.png',
         battleSprite: 'mechanic',
         sprites: {

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -147,7 +147,18 @@ class CombatCalculationEngine {
         // ✨ 2. 증폭된 공격력을 기반으로 스킬 데미지를 계산합니다.
         const skillDamage = amplifiedAttack * damageMultiplier;
 
-        const initialDamage = Math.max(1, skillDamage - finalDefense);
+        let initialDamage = Math.max(1, skillDamage - finalDefense);
+
+        // --- 센티넬 패시브 데미지 감소 로직 추가 ---
+        const sentryDutyEffects = (statusEffectManager.activeEffects.get(attacker.uniqueId) || [])
+            .filter(e => e.id === 'sentryDutyDebuff' && e.attackerId === defender.uniqueId);
+
+        if (sentryDutyEffects.length > 0) {
+            const reduction = sentryDutyEffects[0].modifiers.value * sentryDutyEffects[0].stack;
+            initialDamage *= (1 + reduction); // value가 음수이므로 덧셈
+            debugLogEngine.log('CombatCalculationEngine', `[전방 주시] 효과로 ${defender.instanceName}에게 가하는 피해 ${reduction * 100}% 감소`);
+        }
+        // --- 로직 추가 끝 ---
 
         // --- ✨ 전투 판정 로직 수정 ---
         let hitType = null;

--- a/src/game/utils/StatusEffectManager.js
+++ b/src/game/utils/StatusEffectManager.js
@@ -156,11 +156,18 @@ class StatusEffectManager {
         }
         const activeEffectsOnTarget = this.activeEffects.get(targetUnit.uniqueId);
 
-        // 기존에 동일한 ID의 효과가 있다면 제거합니다.
+        // 기존에 동일한 ID의 효과가 있다면 처리합니다.
         const existingEffectIndex = activeEffectsOnTarget.findIndex(e => e.id === effectId);
         if (existingEffectIndex !== -1) {
-            const removedEffect = activeEffectsOnTarget.splice(existingEffectIndex, 1)[0];
-            debugLogEngine.log('StatusEffectManager', `[${targetUnit.instanceName}]의 기존 [${removedEffect.sourceSkillName}] 효과를 제거하고 새 효과로 갱신합니다.`);
+            const existingEffect = activeEffectsOnTarget[existingEffectIndex];
+            if (effectId === 'sentryDutyDebuff') {
+                existingEffect.stack = Math.min((existingEffect.stack || 1) + 1, sourceSkill.effect.maxStacks || 1);
+                debugLogEngine.log('StatusEffectManager', `[${targetUnit.instanceName}]의 [${effectDefinition.name}] 스택이 ${existingEffect.stack}이 되었습니다.`);
+                return;
+            } else {
+                const removedEffect = activeEffectsOnTarget.splice(existingEffectIndex, 1)[0];
+                debugLogEngine.log('StatusEffectManager', `[${targetUnit.instanceName}]의 기존 [${removedEffect.sourceSkillName}] 효과를 제거하고 새 효과로 갱신합니다.`);
+            }
         }
 
         const newEffect = {
@@ -168,6 +175,7 @@ class StatusEffectManager {
             ...sourceSkill.effect,
             sourceSkillName: sourceSkill.name,
             attackerId: attackerUnit ? attackerUnit.uniqueId : null,
+            stack: sourceSkill.effect.maxStacks ? 1 : undefined,
         };
 
         activeEffectsOnTarget.push(newEffect);


### PR DESCRIPTION
## Summary
- stack Sentinel's Sentry Duty debuff and apply its damage reduction in combat
- wire up new ENFJ behavior tree and use it for the mechanic
- update tests for Sentry Duty stacking

## Testing
- `node tests/sentinel_skill_integration_test.js`
- `node tests/combat_calculation_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68922e547ab0832798cf03faada2ad40