### PR TITLE
feat: add confusion debuff skill

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -202,7 +202,20 @@ class AIManager {
             const prevSkillsUsedSize = (blackboard.get('usedSkillsThisTurn') || new Set()).size;
             const wasMoved = blackboard.get('hasMovedThisTurn');
 
-            await data.behaviorTree.execute(unit, allUnits, enemyUnits);
+            // --- ▼ [핵심 수정] 혼란 상태 체크 및 타겟 교체 ▼ ---
+            let currentAllies = allUnits.filter(u => u.team === unit.team && u.currentHp > 0);
+            let currentEnemies = allUnits.filter(u => u.team !== unit.team && u.currentHp > 0);
+
+            if (unit.isConfused) {
+                // 혼란 상태일 경우, 아군을 적으로, 적을 아군으로 인식하게 만듭니다.
+                [currentAllies, currentEnemies] = [currentEnemies, currentAllies];
+                if (this.aiEngines.vfxManager) {
+                    this.aiEngines.vfxManager.showEffectName(unit.sprite, '혼란!', '#f43f5e');
+                }
+            }
+            // --- ▲ [핵심 수정] 혼란 상태 체크 및 타겟 교체 ▲ ---
+
+            await data.behaviorTree.execute(unit, allUnits, currentEnemies);
 
             const currentTokens = tokenEngine.getTokens(unit.uniqueId);
             const currentSkillsUsedSize = (blackboard.get('usedSkillsThisTurn') || new Set()).size;

--- a/src/game/data/skills/debuff.js
+++ b/src/game/data/skills/debuff.js
@@ -101,4 +101,83 @@ export const debuffSkills = {
             }
         }
     },
+    // --- ▼ [신규] 컨퓨전 스킬 추가 ▼ ---
+    confusion: {
+        yinYangValue: +4, // 전장을 뒤흔드는 강력한 양(Yang)의 기술로 +4의 높은 점수를 부여했습니다.
+        NORMAL: {
+            id: 'confusion',
+            name: '컨퓨전',
+            type: 'DEBUFF',
+            requiredClass: ['esper'], // 에스퍼 전용 스킬로 설정
+            tags: [SKILL_TAGS.DEBUFF, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.MIND, SKILL_TAGS.PROHIBITION, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '적을 2턴간 [혼란] 상태로 만들어, 아군을 공격하게 만듭니다.',
+            illustrationPath: 'assets/images/skills/confusion.png',
+            cooldown: 3,
+            range: 3,
+            effect: {
+                id: 'confusion',
+                type: EFFECT_TYPES.STATUS_EFFECT,
+                duration: 2,
+            }
+        },
+        RARE: {
+            id: 'confusion',
+            name: '컨퓨전 [R]',
+            type: 'DEBUFF',
+            requiredClass: ['esper'],
+            tags: [SKILL_TAGS.DEBUFF, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.MIND, SKILL_TAGS.PROHIBITION, SKILL_TAGS.SPECIAL],
+            cost: 2, // 토큰 소모량 1 감소
+            targetType: 'enemy',
+            description: '적을 2턴간 [혼란] 상태로 만들어, 아군을 공격하게 만듭니다.',
+            illustrationPath: 'assets/images/skills/confusion.png',
+            cooldown: 3,
+            range: 3,
+            effect: {
+                id: 'confusion',
+                type: EFFECT_TYPES.STATUS_EFFECT,
+                duration: 2,
+            }
+        },
+        EPIC: {
+            id: 'confusion',
+            name: '컨퓨전 [E]',
+            type: 'DEBUFF',
+            requiredClass: ['esper'],
+            tags: [SKILL_TAGS.DEBUFF, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.MIND, SKILL_TAGS.PROHIBITION, SKILL_TAGS.SPECIAL],
+            cost: 2,
+            targetType: 'enemy',
+            description: '적을 2턴간 [혼란] 상태로 만들어, 아군을 공격하게 만듭니다.',
+            illustrationPath: 'assets/images/skills/confusion.png',
+            cooldown: 2, // 쿨타임 1 감소
+            range: 4, // 사거리 1 증가
+            effect: {
+                id: 'confusion',
+                type: EFFECT_TYPES.STATUS_EFFECT,
+                duration: 2,
+            }
+        },
+        LEGENDARY: {
+            id: 'confusion',
+            name: '컨퓨전 [L]',
+            type: 'DEBUFF',
+            requiredClass: ['esper'],
+            tags: [SKILL_TAGS.DEBUFF, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.MIND, SKILL_TAGS.PROHIBITION, SKILL_TAGS.SPECIAL],
+            cost: 2,
+            targetType: 'enemy',
+            description: '적을 2턴간 [혼란] 상태로 만들고, 대상의 공격력을 15% 감소시킵니다.',
+            illustrationPath: 'assets/images/skills/confusion.png',
+            cooldown: 2,
+            range: 4,
+            effect: {
+                id: 'confusion',
+                type: EFFECT_TYPES.STATUS_EFFECT,
+                duration: 2,
+                // 레전더리 등급에는 공격력 감소 디버프를 추가하여 더욱 강력하게 만들었습니다.
+                modifiers: { stat: 'physicalAttack', type: 'percentage', value: -0.15 }
+            }
+        }
+    },
+    // --- ▲ [신규] 컨퓨전 스킬 추가 ▲ ---
 };

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -115,6 +115,23 @@ export const statusEffects = {
             console.log(`${unit.instanceName}의 [치료 금지] 효과가 해제됩니다.`);
         },
     },
+    // --- ▼ [신규] 혼란 효과 추가 ▼ ---
+    confusion: {
+        id: 'confusion',
+        name: '혼란',
+        type: EFFECT_TYPES.STATUS_EFFECT,
+        description: '제어 불능 상태가 되어 아군을 공격합니다.',
+        iconPath: 'assets/images/skills/confusion.png', // 스킬 아이콘 재사용
+        onApply: (unit) => {
+            unit.isConfused = true;
+            console.log(`%c[상태이상] ${unit.instanceName}이(가) 혼란에 빠졌습니다!`, "color: #f43f5e;");
+        },
+        onRemove: (unit) => {
+            unit.isConfused = false;
+            console.log(`%c[상태이상] ${unit.instanceName}이(가) 혼란에서 벗어났습니다.`, "color: #a3e635;");
+        },
+    },
+    // --- ▲ [신규] 혼란 효과 추가 ▲ ---
     // --- ▼ [신규] 윌 가드 효과 추가 ▼ ---
     willGuard: {
         id: 'willGuard',

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -48,6 +48,8 @@ class SkillInventoryManager {
                 this.addSkillById('willGuard', grade);
                 // ✨ [신규] 마이티 쉴드 카드 지급
                 this.addSkillById('mightyShield', grade);
+                // ✨ 컨퓨전 스킬 카드 지급 추가
+                this.addSkillById('confusion', grade);
             }
         });
 

--- a/tests/esper_skill_integration_test.js
+++ b/tests/esper_skill_integration_test.js
@@ -1,0 +1,56 @@
+import assert from 'assert';
+import { skillModifierEngine } from '../src/game/utils/SkillModifierEngine.js';
+
+const confusionBase = {
+    NORMAL: {
+        id: 'confusion',
+        cost: 3,
+        cooldown: 3,
+        range: 3,
+        effect: { id: 'confusion', duration: 2 }
+    },
+    RARE: {
+        id: 'confusion',
+        cost: 2,
+        cooldown: 3,
+        range: 3,
+        effect: { id: 'confusion', duration: 2 }
+    },
+    EPIC: {
+        id: 'confusion',
+        cost: 2,
+        cooldown: 2,
+        range: 4,
+        effect: { id: 'confusion', duration: 2 }
+    },
+    LEGENDARY: {
+        id: 'confusion',
+        cost: 2,
+        cooldown: 2,
+        range: 4,
+        effect: {
+            id: 'confusion',
+            duration: 2,
+            modifiers: { stat: 'physicalAttack', type: 'percentage', value: -0.15 }
+        }
+    }
+};
+
+const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
+
+for (const grade of grades) {
+    const skill = skillModifierEngine.getModifiedSkill(confusionBase[grade], grade);
+    const expected = confusionBase[grade];
+
+    assert.strictEqual(skill.cost, expected.cost, `Confusion cost failed for ${grade}`);
+    assert.strictEqual(skill.cooldown, expected.cooldown, `Confusion cooldown failed for ${grade}`);
+    assert.strictEqual(skill.range, expected.range, `Confusion range failed for ${grade}`);
+    assert.strictEqual(skill.effect.duration, expected.effect.duration, `Confusion duration failed for ${grade}`);
+
+    if (grade === 'LEGENDARY') {
+        const mod = skill.effect.modifiers;
+        assert(mod && mod.stat === 'physicalAttack' && Math.abs(mod.value + 0.15) < 1e-6, 'Legendary attack reduction missing');
+    }
+}
+
+console.log('Esper skills integration test passed.');


### PR DESCRIPTION
## Summary
- add new confusion debuff skill with grade-specific balances
- handle confusion status in AI to flip ally/enemy targeting
- register confusion cards and status effects
- add esper skill integration tests

## Testing
- `node tests/esper_skill_integration_test.js`
- `node tests/mighty_shield_skill_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689249455b24832781c7b283f80c3a65