### PR TITLE
feat: add battle speed controls

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1289,6 +1289,33 @@ body {
     line-height: 1;
 }
 
+.combat-right-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+#battle-speed-button {
+    background-color: #2a2a2a;
+    border: 1px solid #888;
+    color: #f0e68c;
+    font-family: 'Cinzel', serif;
+    font-size: 16px;
+    font-weight: bold;
+    width: 60px;
+    padding: 4px;
+    border-radius: 5px;
+    cursor: pointer;
+    pointer-events: auto;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+#battle-speed-button:hover {
+    background-color: #f0e68c;
+    color: #2a2a2a;
+}
+
 .combat-portrait-panel {
     width: 100px;
     height: 100px;
@@ -1296,8 +1323,7 @@ body {
     background-position: center;
     border: 2px solid #888;
     border-radius: 5px;
-    background-size: 200%; 
-    margin-left: 20px; /* 좌측 패널과의 간격 */
+    background-size: 200%;
 }
 
 

--- a/src/game/dom/CombatUIManager.js
+++ b/src/game/dom/CombatUIManager.js
@@ -12,7 +12,7 @@ import { cooldownManager } from '../utils/CooldownManager.js';
  * 재사용하여 최소한의 조작만 수행합니다.
  */
 export class CombatUIManager {
-    constructor() {
+    constructor(battleSpeedManager) {
         this.container = document.getElementById('combat-ui-container');
         if (!this.container) {
             this.container = document.createElement('div');
@@ -20,6 +20,7 @@ export class CombatUIManager {
             document.getElementById('ui-container').appendChild(this.container);
         }
         
+        this.battleSpeedManager = battleSpeedManager;
         this.currentUnitId = null; // 현재 표시 중인 유닛 ID
         this.skillIcons = [];      // 스킬 아이콘 요소들을 저장할 배열
 
@@ -82,12 +83,25 @@ export class CombatUIManager {
         infoPanel.appendChild(topRow);
         infoPanel.appendChild(bottomRow);
 
-        // 2. 오른쪽 초상화 패널
+        // 2. 오른쪽 패널 (초상화 + 속도 버튼)
         this.portraitPanel = document.createElement('div');
         this.portraitPanel.className = 'combat-portrait-panel';
 
+        this.speedButton = document.createElement('button');
+        this.speedButton.id = 'battle-speed-button';
+        this.speedButton.innerText = '1x';
+        this.speedButton.onclick = () => {
+            const newSpeed = this.battleSpeedManager.cycleSpeed();
+            this.speedButton.innerText = `${newSpeed}x`;
+        };
+
+        const rightPanel = document.createElement('div');
+        rightPanel.className = 'combat-right-panel';
+        rightPanel.appendChild(this.portraitPanel);
+        rightPanel.appendChild(this.speedButton);
+
         this.container.appendChild(infoPanel);
-        this.container.appendChild(this.portraitPanel);
+        this.container.appendChild(rightPanel);
     }
 
     /**

--- a/src/game/utils/AnimationEngine.js
+++ b/src/game/utils/AnimationEngine.js
@@ -1,5 +1,5 @@
 import { debugLogEngine } from './DebugLogEngine.js';
-import { delayEngine } from './DelayEngine.js';
+import { battleSpeedManager } from './BattleSpeedManager.js';
 
 /**
  * Phaser의 tween을 사용하여 게임 오브젝트에 부드러운 애니메이션 효과를 적용하는 엔진
@@ -51,11 +51,12 @@ export class AnimationEngine {
      */
     moveTo(target, x, y, duration = 500, onUpdateCallback = null) {
         return new Promise(resolve => {
+            const finalDuration = duration / battleSpeedManager.getMultiplier();
             const tweenConfig = {
                 targets: target,
                 x: x,
                 y: y,
-                duration: duration,
+                duration: finalDuration,
                 ease: 'Sine.easeInOut',
                 onComplete: () => {
                     resolve();

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -32,6 +32,7 @@ import { aspirationEngine } from './AspirationEngine.js'; // ✨ AspirationEngin
 import { statEngine } from './StatEngine.js';
 import { createMeleeAI } from '../../ai/behaviors/MeleeAI.js';
 import { EFFECT_TYPES } from './EffectTypes.js';
+import { BattleSpeedManager } from './BattleSpeedManager.js';
 
 // 그림자 생성을 담당하는 매니저
 import { ShadowManager } from './ShadowManager.js';
@@ -54,8 +55,10 @@ export class BattleSimulatorEngine {
         this.summoningEngine = new SummoningEngine(scene, this);
         // 소환 엔진을 참조하는 종료 매니저를 초기화합니다.
         this.terminationManager = new TerminationManager(scene, this.summoningEngine, this);
+        // 전투 속도 매니저
+        this.battleSpeedManager = new BattleSpeedManager();
         // 전투 중 유닛 정보를 표시할 UI 매니저
-        this.combatUI = new CombatUIManager();
+        this.combatUI = new CombatUIManager(this.battleSpeedManager);
         // 턴 순서 UI 매니저
         this.turnOrderUI = new TurnOrderUIManager();
         this.sharedResourceUI = new SharedResourceUIManager();
@@ -121,6 +124,8 @@ export class BattleSimulatorEngine {
         this.isRunning = true;
 
         aiManager.clear();
+
+        this.battleSpeedManager.reset();
         cooldownManager.reset();
         this.summoningEngine.reset();
         // ✨ [수정] 각 팀의 자원을 개별적으로 초기화

--- a/src/game/utils/BattleSpeedManager.js
+++ b/src/game/utils/BattleSpeedManager.js
@@ -1,0 +1,48 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 전투 속도를 관리하는 중앙 매니저 (싱글턴)
+ */
+class BattleSpeedManager {
+    constructor() {
+        if (BattleSpeedManager.instance) {
+            return BattleSpeedManager.instance;
+        }
+        this.name = 'BattleSpeedManager';
+        this.speeds = [1, 2, 3];
+        this.currentIndex = 0;
+        this.currentMultiplier = this.speeds[this.currentIndex];
+        debugLogEngine.log(this.name, '전투 속도 매니저가 초기화되었습니다.');
+        BattleSpeedManager.instance = this;
+    }
+
+    /**
+     * 사용 가능한 속도 배율을 순환합니다.
+     * @returns {number} 변경된 속도 배율
+     */
+    cycleSpeed() {
+        this.currentIndex = (this.currentIndex + 1) % this.speeds.length;
+        this.currentMultiplier = this.speeds[this.currentIndex];
+        debugLogEngine.log(this.name, `전투 속도가 ${this.currentMultiplier}x로 변경되었습니다.`);
+        return this.currentMultiplier;
+    }
+
+    /**
+     * 현재 속도 배율을 반환합니다.
+     * @returns {number}
+     */
+    getMultiplier() {
+        return this.currentMultiplier;
+    }
+
+    /**
+     * 속도를 초기값으로 되돌립니다.
+     */
+    reset() {
+        this.currentIndex = 0;
+        this.currentMultiplier = this.speeds[this.currentIndex];
+    }
+}
+
+export { BattleSpeedManager };
+export const battleSpeedManager = new BattleSpeedManager();

--- a/src/game/utils/DelayEngine.js
+++ b/src/game/utils/DelayEngine.js
@@ -1,4 +1,5 @@
 import { debugLogEngine } from './DebugLogEngine.js';
+import { battleSpeedManager } from './BattleSpeedManager.js'; // 전투 속도 적용
 
 /**
  * 지정된 시간만큼 코드 실행을 '홀딩'하는 기능을 제공하는 엔진
@@ -14,8 +15,9 @@ class DelayEngine {
      * @returns {Promise<void>}
      */
     hold(duration) {
+        const finalDuration = duration / battleSpeedManager.getMultiplier();
         return new Promise(resolve => {
-            setTimeout(resolve, duration);
+            setTimeout(resolve, finalDuration);
         });
     }
 }


### PR DESCRIPTION
## Summary
- centralize battle speed with a new BattleSpeedManager
- scale delays and animations by current speed multiplier
- add combat UI button to cycle through speed settings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68924c58dbcc832793e75fb1c07b75f2