### PR TITLE
refactor: standardize sentinel debuff modifiers

### DIFF
--- a/src/game/data/skills/sentinel.js
+++ b/src/game/data/skills/sentinel.js
@@ -14,11 +14,13 @@ export const sentinelSkills = {
             type: EFFECT_TYPES.DEBUFF,
             duration: 99, // 전투 내내 지속
             maxStacks: 3,
-            modifiers: {
-                stat: 'damageToSentinel', // 센티넬에게 가하는 데미지
-                type: 'percentage',
-                value: -0.05
-            }
+            modifiers: [
+                {
+                    stat: 'damageToSentinel', // 센티넬에게 가하는 데미지
+                    type: 'percentage',
+                    value: -0.05
+                }
+            ]
         }
     }
 };

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -154,9 +154,19 @@ class CombatCalculationEngine {
             .filter(e => e.id === 'sentryDutyDebuff' && e.attackerId === defender.uniqueId);
 
         if (sentryDutyEffects.length > 0) {
-            const reduction = sentryDutyEffects[0].modifiers.value * sentryDutyEffects[0].stack;
-            initialDamage *= (1 + reduction); // value가 음수이므로 덧셈
-            debugLogEngine.log('CombatCalculationEngine', `[전방 주시] 효과로 ${defender.instanceName}에게 가하는 피해 ${reduction * 100}% 감소`);
+            const sentryEffect = sentryDutyEffects[0];
+            const modifier = Array.isArray(sentryEffect.modifiers)
+                ? sentryEffect.modifiers.find(m => m.stat === 'damageToSentinel')
+                : sentryEffect.modifiers;
+
+            if (modifier && modifier.value && sentryEffect.stack) {
+                const reduction = modifier.value * sentryEffect.stack;
+                initialDamage *= (1 + reduction); // value가 음수이므로 덧셈
+                debugLogEngine.log(
+                    'CombatCalculationEngine',
+                    `[전방 주시] 효과로 ${(defender.instanceName || defender.name)}에게 가하는 피해 ${(reduction * 100).toFixed(0)}% 감소`
+                );
+            }
         }
         // --- 로직 추가 끝 ---
 


### PR DESCRIPTION
## Summary
- wrap sentinel debuff modifiers in an array for consistent handling
- safeguard CombatCalculationEngine to read modifier arrays and improve logging

## Testing
- `node tests/sentinel_skill_integration_test.js`
- `node tests/combat_calculation_test.js`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68924df864508327ab6c8db4e0427a12