### PR TITLE
fix: remove class passives from skill card pool

### DIFF
--- a/src/game/data/skills/SkillCardDatabase.js
+++ b/src/game/data/skills/SkillCardDatabase.js
@@ -5,8 +5,7 @@ import { passiveSkills } from './passive.js';
 import { aidSkills } from './aid.js';
 import { summonSkills } from './summon.js';
 import { strategySkills } from './strategy.js';
-import { sentinelSkills } from './sentinel.js';
-import { darkKnightSkills } from './darkKnight.js';
+// sentinelSkills와 darkKnightSkills import를 제거합니다.
 
 // 모든 스킬을 하나의 객체로 통합하여 쉽게 조회할 수 있도록 함
 export const skillCardDatabase = {
@@ -17,6 +16,5 @@ export const skillCardDatabase = {
     ...aidSkills,
     ...summonSkills,
     ...strategySkills,
-    ...sentinelSkills,
-    ...darkKnightSkills,
+    // sentinelSkills와 darkKnightSkills를 여기서 제거합니다.
 };

--- a/src/game/data/skills/darkKnight.js
+++ b/src/game/data/skills/darkKnight.js
@@ -9,6 +9,7 @@ export const darkKnightSkills = {
         tags: [SKILL_TAGS.PASSIVE, SKILL_TAGS.AURA, SKILL_TAGS.DEBUFF, SKILL_TAGS.DARK],
         description: '다크나이트의 주위 3타일 내에 있는 모든 적의 공격력과 방어력을 5% 감소시킵니다.',
         illustrationPath: 'assets/images/skills/curse-of-darkness.png',
+        iconPath: 'assets/images/skills/curse-of-darkness.png', // 패시브 상세 정보창 아이콘
         effect: {
             id: 'despairAuraDebuff',
             type: EFFECT_TYPES.DEBUFF,

--- a/src/game/data/skills/sentinel.js
+++ b/src/game/data/skills/sentinel.js
@@ -9,6 +9,7 @@ export const sentinelSkills = {
         tags: [SKILL_TAGS.PASSIVE, SKILL_TAGS.GUARDIAN],
         description: '센티넬에게 공격받은 적은 전투가 끝날 때까지 [전방 주시] 디버프를 받습니다. 이 디버프는 센티넬에게 가하는 피해량을 5% 감소시키며, 최대 3번까지 중첩됩니다.',
         illustrationPath: 'assets/images/skills/eye-of-guard.png',
+        iconPath: 'assets/images/skills/eye-of-guard.png', // 패시브 상세 정보창 아이콘
         effect: {
             id: 'sentryDutyDebuff',
             type: EFFECT_TYPES.DEBUFF,


### PR DESCRIPTION
## Summary
- remove sentinel/darkKnight passives from card generation
- add explicit icon paths for sentinel and dark knight passive skills

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68924febb0ac8327b140493278ddfde0