### PR TITLE
Add fallback mobility for ESTJ AI and guard skill effects

### DIFF
--- a/src/game/utils/IconManager.js
+++ b/src/game/utils/IconManager.js
@@ -90,6 +90,7 @@ export class IconManager {
         equipped.forEach(instId => {
             if (!instId) return;
             const inst = skillInventoryManager.getInstanceData(instId);
+            if (!inst) return; // 인스턴스 데이터가 없을 경우를 대비
             const skillData = skillInventoryManager.getSkillData(inst.skillId, inst.grade);
             if (skillData && skillData.type === 'PASSIVE') {
                 buffs.push({

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -356,6 +356,15 @@ class SkillEffectProcessor {
     }
     
     _applyStatusEffects(unit, target, skill, blackboard) {
+        // 이미 쓰러진 대상에게는 상태 효과를 적용하지 않습니다.
+        if (target.currentHp <= 0) {
+            debugLogEngine.log(
+                'SkillEffectProcessor',
+                `[${target.instanceName}]은(는) 이미 쓰러져서 상태 효과를 적용할 수 없습니다.`
+            );
+            return;
+        }
+
         const baseTargets = [target];
         // 다중 타겟 처리
         if (skill.numberOfTargets && skill.numberOfTargets > 1) {


### PR DESCRIPTION
## Summary
- prevent ESTJ AI from stalling by using a top-level selector with safe repositioning
- avoid applying status effects to dead targets
- guard passive icon lookup for missing skill data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689250c64c308327a1b24610be74c2f5