### PR TITLE
chore: exclude passive skills from skill card database

### DIFF
--- a/src/game/data/skills/SkillCardDatabase.js
+++ b/src/game/data/skills/SkillCardDatabase.js
@@ -1,7 +1,7 @@
 import { activeSkills } from './active.js';
 import { buffSkills } from './buff.js';
 import { debuffSkills } from './debuff.js';
-import { passiveSkills } from './passive.js';
+// import { passiveSkills } from './passive.js'; // passive skills are intentionally excluded
 import { aidSkills } from './aid.js';
 import { summonSkills } from './summon.js';
 import { strategySkills } from './strategy.js';
@@ -12,7 +12,7 @@ export const skillCardDatabase = {
     ...activeSkills,
     ...buffSkills,
     ...debuffSkills,
-    ...passiveSkills,
+    // ...passiveSkills, // passive skills are intentionally excluded from card generation
     ...aidSkills,
     ...summonSkills,
     ...strategySkills,


### PR DESCRIPTION
## Summary
- stop importing passive skills so no passive cards are generated

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689251de2078832795acab97d3e29826