### PR TITLE
chore: skip iron will card

### DIFF
--- a/src/game/dom/SkillManagementDOMEngine.js
+++ b/src/game/dom/SkillManagementDOMEngine.js
@@ -296,6 +296,7 @@ export class SkillManagementDOMEngine {
 
         inventory.forEach(instance => {
             const data = skillInventoryManager.getSkillData(instance.skillId, instance.grade);
+            if (!data) return;
             const card = document.createElement('div');
             card.className = `skill-inventory-card ${data.type.toLowerCase()}-card grade-${instance.grade.toLowerCase()}`;
 

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -30,7 +30,6 @@ class SkillInventoryManager {
                 this.addSkillById('axeStrike', grade);
                 this.addSkillById('stoneSkin', grade);
                 this.addSkillById('shieldBreak', grade);
-                this.addSkillById('ironWill', grade);
                 this.addSkillById('heal', grade);
                 // ✨ 넉백샷 카드 추가
                 this.addSkillById('knockbackShot', grade);


### PR DESCRIPTION
## Summary
- stop generating `ironWill` during starter deck creation
- guard against missing skill data while rendering inventory

## Testing
- `node --test`
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6892550459b883279694976f680a8d90