### PR TITLE
feat: add narration UI manager

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1902,3 +1902,28 @@ body {
     filter: grayscale(80%);
     cursor: not-allowed;
 }
+
+/* --- 나레이션 패널 스타일 --- */
+#narration-container {
+    position: absolute;
+    bottom: 130px; /* 전투 UI 바로 위에 위치 */
+    left: 50%;
+    transform: translateX(-50%);
+    width: 700px;
+    background-color: rgba(0, 0, 0, 0.6);
+    border-top: 2px solid #666;
+    border-radius: 8px 8px 0 0;
+    padding: 10px 15px;
+    z-index: 199; /* 전투 UI(200) 바로 아래 */
+    pointer-events: none;
+    transition: opacity 0.5s ease-in-out;
+    text-align: center;
+}
+
+.narration-text {
+    margin: 0;
+    color: #f0e68c; /* 밝은 노란색 */
+    font-size: 16px;
+    font-style: italic;
+    text-shadow: 1px 1px 2px #000;
+}

--- a/src/ai/nodes/FindKitingPositionNode.js
+++ b/src/ai/nodes/FindKitingPositionNode.js
@@ -4,11 +4,12 @@ import { debugAIManager } from '../../game/debug/DebugAIManager.js';
 // 최적의 카이팅(거리두기) 위치를 찾는 노드
 class FindKitingPositionNode extends Node {
     // visionManager를 의존성으로 추가합니다.
-    constructor({ formationEngine, pathfinderEngine, visionManager }) {
+    constructor({ formationEngine, pathfinderEngine, visionManager, narrationEngine }) {
         super();
         this.formationEngine = formationEngine;
         this.pathfinderEngine = pathfinderEngine;
         this.visionManager = visionManager; // VisionManager 인스턴스 저장
+        this.narrationEngine = narrationEngine;
     }
 
     async evaluate(unit, blackboard) {
@@ -23,6 +24,10 @@ class FindKitingPositionNode extends Node {
         if (!target) {
             debugAIManager.logNodeResult(NodeState.FAILURE, "카이팅할 주 대상 없음");
             return NodeState.FAILURE;
+        }
+
+        if (this.narrationEngine) {
+            this.narrationEngine.show(`${unit.instanceName}이(가) [${target.instanceName}]와(과) 거리를 벌리기 위해 이동합니다.`);
         }
 
         const attackRange = unit.finalStats.attackRange || 3;

--- a/src/ai/nodes/FindLowestHealthEnemyNode.js
+++ b/src/ai/nodes/FindLowestHealthEnemyNode.js
@@ -3,9 +3,10 @@ import { debugAIManager } from '../../game/debug/DebugAIManager.js';
 
 // 체력이 가장 낮은 적을 찾는 노드
 class FindLowestHealthEnemyNode extends Node {
-    constructor({ targetManager }) {
+    constructor({ targetManager, narrationEngine }) {
         super();
         this.targetManager = targetManager;
+        this.narrationEngine = narrationEngine;
     }
 
     async evaluate(unit, blackboard) {
@@ -14,6 +15,9 @@ class FindLowestHealthEnemyNode extends Node {
         const target = this.targetManager.findLowestHealthEnemy(enemyUnits);
 
         if (target) {
+            if (this.narrationEngine) {
+                this.narrationEngine.show(`${unit.instanceName}이(가) 가장 약해진 적 [${target.instanceName}]을(를) 노립니다.`);
+            }
             blackboard.set('currentTargetUnit', target);
             debugAIManager.logNodeResult(NodeState.SUCCESS);
             return NodeState.SUCCESS;

--- a/src/ai/nodes/FindPriorityTargetNode.js
+++ b/src/ai/nodes/FindPriorityTargetNode.js
@@ -5,9 +5,10 @@ import { debugAIManager } from '../../game/debug/DebugAIManager.js';
  * 우선순위 클래스(메딕, 거너, 나노맨서)를 먼저 탐색하고, 없으면 가장 가까운 적을 찾는 노드
  */
 class FindPriorityTargetNode extends Node {
-    constructor({ targetManager }) {
+    constructor({ targetManager, narrationEngine }) {
         super();
         this.targetManager = targetManager;
+        this.narrationEngine = narrationEngine;
         this.priorityClasses = ['medic', 'gunner', 'nanomancer'];
     }
 
@@ -27,6 +28,9 @@ class FindPriorityTargetNode extends Node {
         if (priorityTargets.length > 0) {
             // 2. 우선순위 대상 중 가장 가까운 적 선택
             target = this.targetManager.findNearestEnemy(unit, priorityTargets);
+            if (this.narrationEngine && target) {
+                this.narrationEngine.show(`${unit.instanceName}이(가) 위협적인 적 [${target.name}]을(를) 먼저 제압하려 합니다.`);
+            }
             debugAIManager.logNodeResult(NodeState.SUCCESS, `우선순위 타겟 [${target.instanceName}] 설정`);
         } else {
             // 3. 우선순위 대상이 없으면, 모든 적 중 가장 가까운 적 선택

--- a/src/ai/nodes/FindSafeHealingPositionNode.js
+++ b/src/ai/nodes/FindSafeHealingPositionNode.js
@@ -5,10 +5,11 @@ import { debugAIManager } from '../../game/debug/DebugAIManager.js';
  * 아군을 치유하면서 적에게서 안전한 위치를 탐색합니다.
  */
 class FindSafeHealingPositionNode extends Node {
-    constructor({ formationEngine, pathfinderEngine }) {
+    constructor({ formationEngine, pathfinderEngine, narrationEngine }) {
         super();
         this.formationEngine = formationEngine;
         this.pathfinderEngine = pathfinderEngine;
+        this.narrationEngine = narrationEngine;
     }
 
     async evaluate(unit, blackboard) {
@@ -20,6 +21,10 @@ class FindSafeHealingPositionNode extends Node {
         if (!targetAlly) {
             debugAIManager.logNodeResult(NodeState.FAILURE, '치유 대상 아군 없음');
             return NodeState.FAILURE;
+        }
+
+        if (this.narrationEngine) {
+            this.narrationEngine.show(`${unit.instanceName}이(가) [${targetAlly.instanceName}]을(를) 치유하기 위해 안전한 위치를 찾습니다.`);
         }
 
         const cells = this.formationEngine.grid.gridCells.filter(

--- a/src/ai/nodes/FindSafeRepositionNode.js
+++ b/src/ai/nodes/FindSafeRepositionNode.js
@@ -5,15 +5,24 @@ import { debugAIManager } from '../../game/debug/DebugAIManager.js';
  * 전투가 잠잠할 때 유리한 위치로 이동하기 위한 위치를 탐색합니다.
  */
 class FindSafeRepositionNode extends Node {
-    constructor({ formationEngine, pathfinderEngine }) {
+    constructor({ formationEngine, pathfinderEngine, narrationEngine }) {
         super();
         this.formationEngine = formationEngine;
         this.pathfinderEngine = pathfinderEngine;
+        this.narrationEngine = narrationEngine;
     }
 
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
         const enemies = blackboard.get('enemyUnits');
+        if (this.narrationEngine) {
+            const isThreatened = blackboard.get('isThreatened');
+            if (isThreatened) {
+                this.narrationEngine.show(`${unit.instanceName}이(가) 위협을 피해 안전한 위치로 후퇴합니다.`);
+            } else {
+                this.narrationEngine.show(`${unit.instanceName}이(가) 다음 행동을 위해 유리한 위치로 이동합니다.`);
+            }
+        }
         const cells = this.formationEngine.grid.gridCells.filter(
             cell => !cell.isOccupied || (cell.col === unit.gridX && cell.row === unit.gridY)
         );

--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -15,6 +15,7 @@ class UseSkillNode extends Node {
         this.delayEngine = engines.delayEngine;
         this.skillEngine = engines.skillEngine || skillEngine;
         this.vfxManager = engines.vfxManager;
+        this.narrationEngine = engines.narrationEngine;
         // SkillEffectProcessor를 초기화합니다.
         this.skillEffectProcessor = new SkillEffectProcessor(engines);
     }
@@ -45,6 +46,10 @@ class UseSkillNode extends Node {
 
         // 최종 사용할 스킬 데이터를 준비합니다 (숙련도 보너스 적용)
         const finalSkill = this._applyProficiency(unit, modifiedSkill);
+
+        if (this.narrationEngine) {
+            this.narrationEngine.show(`${unit.instanceName}이(가) [${skillTarget.instanceName}]에게 [${finalSkill.name}]을(를) 사용합니다.`);
+        }
 
         // 스킬 사용 기록
         this.skillEngine.recordSkillUse(unit, finalSkill);

--- a/src/game/dom/NarrationUIManager.js
+++ b/src/game/dom/NarrationUIManager.js
@@ -1,0 +1,64 @@
+/**
+ * 전투 중 AI의 행동 의도를 설명하는 나레이션을 표시하는 UI 매니저
+ */
+export class NarrationUIManager {
+    constructor() {
+        this.container = document.getElementById('narration-container');
+        if (!this.container) {
+            this.container = document.createElement('div');
+            this.container.id = 'narration-container';
+            document.getElementById('ui-container').appendChild(this.container);
+        }
+        this.narrationText = document.createElement('p');
+        this.narrationText.className = 'narration-text';
+        this.container.appendChild(this.narrationText);
+
+        this.container.style.display = 'none';
+        this.timeoutId = null;
+    }
+
+    /**
+     * 나레이션 메시지를 표시합니다. 메시지는 일정 시간 후 자동으로 사라집니다.
+     * @param {string} message - 표시할 메시지
+     * @param {number} duration - 메시지 표시 시간 (ms)
+     */
+    show(message, duration = 2500) {
+        if (this.timeoutId) {
+            clearTimeout(this.timeoutId);
+        }
+
+        this.narrationText.textContent = message;
+        this.container.style.display = 'block';
+        this.container.style.opacity = 1;
+
+        this.timeoutId = setTimeout(() => {
+            this.container.style.opacity = 0;
+            // 트랜지션이 끝난 후 숨김
+            setTimeout(() => {
+                if (this.container) this.container.style.display = 'none';
+            }, 500);
+        }, duration);
+    }
+
+    /**
+     * UI를 즉시 숨깁니다.
+     */
+    hide() {
+        if (this.timeoutId) {
+            clearTimeout(this.timeoutId);
+        }
+        if (this.container) {
+            this.container.style.display = 'none';
+        }
+    }
+
+    /**
+     * UI 요소를 DOM에서 완전히 제거합니다.
+     */
+    destroy() {
+        if (this.container) {
+            this.container.remove();
+            this.container = null;
+        }
+    }
+}

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -33,6 +33,7 @@ import { statEngine } from './StatEngine.js';
 import { createMeleeAI } from '../../ai/behaviors/MeleeAI.js';
 import { EFFECT_TYPES } from './EffectTypes.js';
 import { BattleSpeedManager } from './BattleSpeedManager.js';
+import { NarrationUIManager } from '../dom/NarrationUIManager.js';
 
 // 그림자 생성을 담당하는 매니저
 import { ShadowManager } from './ShadowManager.js';
@@ -62,6 +63,7 @@ export class BattleSimulatorEngine {
         // 턴 순서 UI 매니저
         this.turnOrderUI = new TurnOrderUIManager();
         this.sharedResourceUI = new SharedResourceUIManager();
+        this.narrationUI = new NarrationUIManager();
         
         // AI 노드에 주입할 엔진 패키지
         this.aiEngines = {
@@ -78,6 +80,7 @@ export class BattleSimulatorEngine {
             // ✨ AI가 소환 엔진을 사용할 수 있도록 패키지에 포함합니다.
             summoningEngine: this.summoningEngine,
             battleSimulator: this,
+            narrationEngine: this.narrationUI,
         };
 
         // ✨ AspirationEngine에 battleSimulator 참조 설정
@@ -178,6 +181,7 @@ export class BattleSimulatorEngine {
         // 턴 순서 UI 초기화
         this.turnOrderUI.show(this.turnQueue);
         this.sharedResourceUI.show();
+        this.narrationUI.show('전투 시작!', 1500);
 
         // --- ✨ 첫 턴 시작 시 토큰 지급 ---
         tokenEngine.addTokensForNewTurn();
@@ -370,6 +374,9 @@ export class BattleSimulatorEngine {
         }
         if (this.sharedResourceUI) {
             this.sharedResourceUI.destroy();
+        }
+        if (this.narrationUI) {
+            this.narrationUI.destroy();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated narration UI manager and styles
- show battle narration via engine and AI nodes
- broadcast skill usage with narration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `python3 -m http.server 8000 &`
- `curl http://127.0.0.1:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689259cebc1c8327a037e3d9f85154d9