### PR TITLE
feat: add archetype memory engine and two-step skill scoring

### DIFF
--- a/src/game/utils/ArchetypeMemoryEngine.js
+++ b/src/game/utils/ArchetypeMemoryEngine.js
@@ -1,0 +1,75 @@
+import { debugAIMemoryManager } from '../debug/DebugAIMemoryManager.js';
+
+/**
+ * IndexedDB를 사용하여 각 MBTI 아키타입의 집단 전투 경험을 저장하고 관리하는 엔진
+ */
+class ArchetypeMemoryEngine {
+    constructor() {
+        this.db = null;
+        this.dbName = 'ArchetypeMemoryDB'; // DB 이름 변경
+        this.storeName = 'archetypeCombatMemory'; // 스토어 이름 변경
+        this.initDB();
+    }
+
+    initDB() {
+        const request = indexedDB.open(this.dbName, 1);
+
+        request.onupgradeneeded = (event) => {
+            this.db = event.target.result;
+            if (!this.db.objectStoreNames.contains(this.storeName)) {
+                this.db.createObjectStore(this.storeName, { keyPath: 'id' }); // id는 mbtiString
+            }
+        };
+
+        request.onsuccess = (event) => {
+            this.db = event.target.result;
+            console.log('[ArchetypeMemoryEngine] IndexedDB가 성공적으로 초기화되었습니다.');
+        };
+
+        request.onerror = (event) => {
+            console.error('[ArchetypeMemoryEngine] IndexedDB 초기화 오류:', event.target.errorCode);
+        };
+    }
+
+    /**
+     * 특정 아키타입의 집단 기억(가중치)을 가져옵니다.
+     * @param {string} mbtiString - 'INTJ', 'ENFP' 등 MBTI 아키타입 문자열
+     * @returns {Promise<object>} - 대상 ID를 키로 갖는 가중치 객체
+     */
+    getMemory(mbtiString) {
+        return new Promise((resolve, reject) => {
+            if (!this.db) return resolve({});
+            const transaction = this.db.transaction([this.storeName], 'readonly');
+            const store = transaction.objectStore(this.storeName);
+            const request = store.get(mbtiString);
+
+            request.onsuccess = (event) => {
+                // 아키타입 로그는 별도로 관리하므로 디버그 로그는 생략
+                resolve(event.target.result?.memory || {});
+            };
+
+            request.onerror = (event) => {
+                console.error('[ArchetypeMemoryEngine] 메모리 읽기 오류:', event.target.error);
+                reject(event.target.error);
+            };
+        });
+    }
+
+    /**
+     * (중요) 외부에서 분석된 학습 데이터를 DB에 업데이트합니다.
+     * @param {string} mbtiString - 업데이트할 아키타입
+     * @param {object} learnedMemory - 분석을 통해 새로 생성된 기억 데이터
+     */
+    updateMemory(mbtiString, learnedMemory) {
+        return new Promise((resolve, reject) => {
+            if (!this.db) return reject('DB not initialized');
+            const transaction = this.db.transaction([this.storeName], 'readwrite');
+            const store = transaction.objectStore(this.storeName);
+            store.put({ id: mbtiString, memory: learnedMemory });
+            transaction.oncomplete = () => resolve();
+            transaction.onerror = (event) => reject(event.target.error);
+        });
+    }
+}
+
+export const archetypeMemoryEngine = new ArchetypeMemoryEngine();


### PR DESCRIPTION
## Summary
- add ArchetypeMemoryEngine for MBTI-based collective combat memory
- consult personal memory first and archetype memory fallback in SkillScoreEngine
- include helper to derive MBTI string from unit

## Testing
- `for f in tests/*test.js; do node $f >> test.log; done`
- `tail -n 20 test.log`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68925e15828c8327b434572e55fa79e9