### PR TITLE
Add Hunt Sense status effect

### DIFF
--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -100,6 +100,18 @@ export const statusEffects = {
         name: '숯돌 갈기',
         iconPath: 'assets/images/skills/grindstone.png',
     },
+    huntSenseBuff: {
+        id: 'huntSenseBuff',
+        name: '사냥꾼의 감각',
+        description: '다음 3턴간 치명타 확률이 25% 증가합니다.',
+        iconPath: 'assets/images/icons/buffs/hunt-sense.png',
+        duration: 3,
+        type: EFFECT_TYPES.BUFF,
+        stats: {
+            critChance: 0.25,
+        },
+        tags: ['buff', 'crit'],
+    },
     // 치료 불가 디버프
     stigma: {
         id: 'stigma',


### PR DESCRIPTION
## Summary
- define Hunt Sense buff in status effect database

## Testing
- `for f in tests/*_test.js; do echo "Running $f"; node $f >/tmp/test.log && tail -n 5 /tmp/test.log; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68926496a4108327834b2c337ceeec16