### PR TITLE
Add fireball skill with burn status effect

### DIFF
--- a/src/game/data/skills/SkillCardDatabase.js
+++ b/src/game/data/skills/SkillCardDatabase.js
@@ -9,7 +9,7 @@ import { strategySkills } from './strategy.js';
 
 // 모든 스킬을 하나의 객체로 통합하여 쉽게 조회할 수 있도록 함
 export const skillCardDatabase = {
-    ...activeSkills,
+    ...activeSkills, // includes fireball and other active skills
     ...buffSkills,
     ...debuffSkills,
     // ...passiveSkills, // passive skills are intentionally excluded from card generation

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -642,4 +642,94 @@ export const activeSkills = {
         }
     },
     // --- ▲ [신규] 끌어당기기 스킬 추가 ▲ ---
+    // --- ▼ [신규] 파이어볼 스킬 추가 ▼ ---
+    fireball: {
+        yinYangValue: -4,
+        NORMAL: {
+            id: 'fireball',
+            name: '파이어볼',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.FIRE, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '지정한 위치에 거대한 화염구를 날려 십자(5칸) 범위의 적들에게 {{damage}}%의 마법 피해를 주고, 2턴간 [화상] 효과를 부여합니다.',
+            illustrationPath: 'assets/images/skills/fire-ball.png',
+            cooldown: 3,
+            range: 4,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 1.0, max: 1.2 },
+            effect: {
+                id: 'burn',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 2,
+            }
+        },
+        RARE: {
+            id: 'fireball',
+            name: '파이어볼 [R]',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.FIRE, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '지정한 위치에 거대한 화염구를 날려 십자(5칸) 범위의 적들에게 {{damage}}%의 마법 피해를 주고, 2턴간 [화상] 효과를 부여합니다. (쿨타임 1 감소)',
+            illustrationPath: 'assets/images/skills/fire-ball.png',
+            cooldown: 2,
+            range: 4,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 1.1, max: 1.3 },
+            effect: {
+                id: 'burn',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 2,
+            }
+        },
+        EPIC: {
+            id: 'fireball',
+            name: '파이어볼 [E]',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.FIRE, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '지정한 위치에 거대한 화염구를 날려 십자(5칸) 범위의 적들에게 {{damage}}%의 마법 피해를 주고, 3턴간 [화상] 효과를 부여합니다.',
+            illustrationPath: 'assets/images/skills/fire-ball.png',
+            cooldown: 2,
+            range: 5,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 1.2, max: 1.4 },
+            effect: {
+                id: 'burn',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 3,
+            }
+        },
+        LEGENDARY: {
+            id: 'fireball',
+            name: '파이어볼 [L]',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.FIRE, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '지정한 위치에 거대한 화염구를 날려 십자(5칸) 범위의 적들에게 {{damage}}%의 마법 피해를 주고, 3턴간 [화상] 효과를 부여하며, 중심부의 적을 1턴간 기절시킵니다.',
+            illustrationPath: 'assets/images/skills/fire-ball.png',
+            cooldown: 2,
+            range: 5,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 1.3, max: 1.5 },
+            effect: {
+                id: 'burn',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 3,
+            },
+            centerTargetEffect: {
+                id: 'stun',
+                type: EFFECT_TYPES.STATUS_EFFECT,
+                duration: 1,
+            }
+        }
+    },
+    // --- ▲ [신규] 파이어볼 스킬 추가 ▲ ---
 };

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -33,6 +33,14 @@ export const statusEffects = {
             }
         },
     },
+    burn: {
+        id: 'burn',
+        name: '화상',
+        type: EFFECT_TYPES.DEBUFF,
+        description: '턴이 끝날 때마다 최대 체력의 5%만큼 화염 피해를 받습니다.',
+        iconPath: 'assets/images/status-effects/burn.png',
+        // onApply, onRemove는 지금 당장 필요 없지만, 나중에 확장할 수 있습니다.
+    },
     // ✨ [신규] 이동력 감소(slow) 및 속박(bind) 효과 추가
     slow: {
         id: 'slow',

--- a/tests/esper_skill_integration_test.js
+++ b/tests/esper_skill_integration_test.js
@@ -36,6 +36,20 @@ const confusionBase = {
     }
 };
 
+const fireballBase = {
+    NORMAL: { id: 'fireball', cost: 3, cooldown: 3, range: 4, effect: { id: 'burn', duration: 2 } },
+    RARE: { id: 'fireball', cost: 3, cooldown: 2, range: 4, effect: { id: 'burn', duration: 2 } },
+    EPIC: { id: 'fireball', cost: 3, cooldown: 2, range: 5, effect: { id: 'burn', duration: 3 } },
+    LEGENDARY: {
+        id: 'fireball',
+        cost: 3,
+        cooldown: 2,
+        range: 5,
+        effect: { id: 'burn', duration: 3 },
+        centerTargetEffect: { id: 'stun', duration: 1 }
+    }
+};
+
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 for (const grade of grades) {
@@ -50,6 +64,21 @@ for (const grade of grades) {
     if (grade === 'LEGENDARY') {
         const mod = skill.effect.modifiers;
         assert(mod && mod.stat === 'physicalAttack' && Math.abs(mod.value + 0.15) < 1e-6, 'Legendary attack reduction missing');
+    }
+}
+
+for (const grade of grades) {
+    const skill = skillModifierEngine.getModifiedSkill(fireballBase[grade], grade);
+    const expected = fireballBase[grade];
+    assert.strictEqual(skill.cost, expected.cost, `Fireball cost failed for ${grade}`);
+    assert.strictEqual(skill.cooldown, expected.cooldown, `Fireball cooldown failed for ${grade}`);
+    assert.strictEqual(skill.range, expected.range, `Fireball range failed for ${grade}`);
+    assert.strictEqual(skill.effect.id, 'burn', 'Fireball effect id mismatch');
+    assert.strictEqual(skill.effect.duration, expected.effect.duration, `Fireball duration failed for ${grade}`);
+    if (grade === 'LEGENDARY') {
+        assert(skill.centerTargetEffect && skill.centerTargetEffect.id === 'stun', 'Legendary center stun missing');
+    } else {
+        assert(!skill.centerTargetEffect, 'Center effect should only exist in Legendary');
     }
 }
 

--- a/tests/nanomancer_skill_integration_test.js
+++ b/tests/nanomancer_skill_integration_test.js
@@ -8,6 +8,20 @@ const nanobeamBase = {
     LEGENDARY: { id: 'nanobeam', cost: 0, cooldown: 0, damageMultiplier: { min: 0.9, max: 1.1 }, generatesToken: { chance: 1.0, amount: 1 } }
 };
 
+const fireballBase = {
+    NORMAL: { id: 'fireball', cost: 3, cooldown: 3, range: 4, effect: { id: 'burn', duration: 2 } },
+    RARE: { id: 'fireball', cost: 3, cooldown: 2, range: 4, effect: { id: 'burn', duration: 2 } },
+    EPIC: { id: 'fireball', cost: 3, cooldown: 2, range: 5, effect: { id: 'burn', duration: 3 } },
+    LEGENDARY: {
+        id: 'fireball',
+        cost: 3,
+        cooldown: 2,
+        range: 5,
+        effect: { id: 'burn', duration: 3 },
+        centerTargetEffect: { id: 'stun', duration: 1 }
+    }
+};
+
 const expectedDamage = [1.3, 1.2, 1.1, 1.0];
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
@@ -25,6 +39,21 @@ for (const grade of grades) {
         assert(skill.generatesToken && skill.generatesToken.chance === 1.0);
     } else {
         assert(!skill.generatesToken);
+    }
+}
+
+for (const grade of grades) {
+    const skill = skillModifierEngine.getModifiedSkill(fireballBase[grade], grade);
+    const expected = fireballBase[grade];
+    assert.strictEqual(skill.cost, expected.cost, `Fireball cost failed for ${grade}`);
+    assert.strictEqual(skill.cooldown, expected.cooldown, `Fireball cooldown failed for ${grade}`);
+    assert.strictEqual(skill.range, expected.range, `Fireball range failed for ${grade}`);
+    assert.strictEqual(skill.effect.id, 'burn', 'Fireball effect id mismatch');
+    assert.strictEqual(skill.effect.duration, expected.effect.duration, `Fireball duration failed for ${grade}`);
+    if (grade === 'LEGENDARY') {
+        assert(skill.centerTargetEffect && skill.centerTargetEffect.id === 'stun', 'Legendary center stun missing');
+    } else {
+        assert(!skill.centerTargetEffect, 'Center effect should only exist in Legendary');
     }
 }
 


### PR DESCRIPTION
## Summary
- add burn status effect
- add fireball active skill for nanomancer and esper
- register fireball in skill card database and add integration tests

## Testing
- `for f in tests/*_test.js tests/*integration_test.js; do node "$f"; done`
- `node tests/nanomancer_skill_integration_test.js`
- `node tests/esper_skill_integration_test.js`
- `python3 -m http.server 8000 &`; `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6892d52c8ad88327bcdd8ba21994622a