### PR TITLE
Add gem database and socket generation for items

### DIFF
--- a/src/game/data/items.js
+++ b/src/game/data/items.js
@@ -118,6 +118,15 @@ export const gemData = {
             [EQUIPMENT_SLOTS.ARMOR]: { stat: 'frostResistance', value: { min: 5, max: 8 } }
         },
         illustrationPath: 'assets/images/placeholder.png'
+    },
+    massiveFireGem: {
+        id: 'massiveFireGem',
+        name: '거대한 불의 보석',
+        effects: {
+            [EQUIPMENT_SLOTS.WEAPON]: { stat: 'fireDamage', value: { min: 20, max: 25 } },
+            [EQUIPMENT_SLOTS.ARMOR]: { stat: 'fireResistance', value: { min: 10, max: 15 } }
+        },
+        illustrationPath: 'assets/images/placeholder.png'
     }
     // ... 다른 보석들 추가 ...
 };

--- a/src/game/utils/ItemFactory.js
+++ b/src/game/utils/ItemFactory.js
@@ -55,7 +55,7 @@ class ItemFactory {
             { type: 'prefix', data: diceEngine.getRandomElement(itemAffixes.prefixes) },
             { type: 'suffix', data: diceEngine.getRandomElement(itemAffixes.suffixes) },
             { type: 'mbti', data: this._getRandomMbtiEffect() },
-            { type: 'sockets', data: { count: diceEngine.rollWithAdvantage(1, 3, 1) } }
+            { type: 'sockets', data: { count: diceEngine.rollWithAdvantage(0, 3, 1) } }
         ];
 
         // 3. 옵션 풀을 무작위로 섞고 등급에 맞는 수만큼 선택
@@ -78,11 +78,11 @@ class ItemFactory {
                 case 'mbti':
                     newItem.mbtiEffects.push(option.data);
                     break;
-                case 'sockets':
-                    for (let i = 0; i < option.data.count; i++) {
-                        newItem.sockets.push(null);
-                    }
+                case 'sockets': {
+                    const socketCount = Math.floor(Math.max(0, Math.min(3, option.data.count)));
+                    newItem.sockets.push(...Array(socketCount).fill(null));
                     break;
+                }
             }
         });
 


### PR DESCRIPTION
## Summary
- Introduce gem database with entries like the massive fire gem for future socketing
- Let ItemFactory roll 0–3 sockets and safely populate the socket array

## Testing
- `node tests/item_factory_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6892d59a10a88327a30d5d3567832bd1