### PR TITLE
feat: add magic impact particle effect

### DIFF
--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -177,6 +177,10 @@ export class Preloader extends Scene
         redParticle.generateTexture('red-particle', 4, 4);
         redParticle.destroy();
 
+        // ▼▼▼ [추가] 마법 효과용 플레이스홀더 이미지 로드 ▼▼▼
+        this.load.image('placeholder', 'images/placeholder.png');
+        // ▲▲▲ [추가] 마법 효과용 플레이스홀더 이미지 로드 ▲▲▲
+
         // 상태 효과 아이콘 로드
         Object.values(statusEffects).forEach(e => {
             const path = e.iconPath.replace(/^assets\//, '');

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -197,7 +197,20 @@ class SkillEffectProcessor {
 
     async _processOffensiveSkill(unit, target, skill, instanceId, grade) {
         spriteEngine.changeSpriteForDuration(unit, 'attack', 600);
-        await this.animationEngine.attack(unit.sprite, target.sprite);
+
+        // ▼▼▼ [수정] 마법 스킬일 경우 공격 애니메이션을 다르게 처리합니다. ▼▼▼
+        if (skill.tags?.includes(SKILL_TAGS.MAGIC)) {
+            // 마법사는 제자리에서 시전하는 느낌을 주기 위해 이동 애니메이션을 생략하고,
+            // 대신 타겟 위치에 바로 파티클 효과를 생성합니다.
+            this.vfxManager.createMagicImpact(target.sprite.x, target.sprite.y, 'placeholder');
+            // 약간의 딜레이를 주어 효과가 보일 시간을 확보합니다.
+            await this.battleSimulator.delayEngine.hold(300);
+        } else {
+            // 기존의 물리 공격 애니메이션
+            await this.animationEngine.attack(unit.sprite, target.sprite);
+        }
+        // ▲▲▲ [수정] ▲▲▲
+
         spriteEngine.changeSpriteForDuration(target, 'hitted', 300);
 
         if (skill.type !== 'ACTIVE') return;

--- a/src/game/utils/VFXManager.js
+++ b/src/game/utils/VFXManager.js
@@ -27,6 +27,32 @@ export class VFXManager {
         debugLogEngine.log('VFXManager', 'VFX 매니저가 초기화되었습니다.');
     }
 
+    // ▼▼▼ [신규] 마법 공격 파티클 효과 메서드 추가 ▼▼▼
+    /**
+     * 마법 공격의 임팩트 효과를 파티클로 생성합니다.
+     * @param {number} x - 효과가 나타날 x 좌표
+     * @param {number} y - 효과가 나타날 y 좌표
+     * @param {string} textureKey - 사용할 파티클 텍스처 키 (예: 'placeholder')
+     */
+    createMagicImpact(x, y, textureKey = 'placeholder') {
+        const particles = this.scene.add.particles(x, y, textureKey, {
+            speed: 0, // 파티클이 날아가지 않고 제자리에서 효과를 냅니다.
+            scale: { start: 0, end: 0.5, ease: 'Quad.easeOut' }, // 0에서 시작해 0.5배 크기로 커집니다.
+            alpha: { start: 1, end: 0, ease: 'Quad.easeIn' },   // 100% 불투명도에서 시작해 투명해집니다.
+            lifespan: 600, // 0.6초 동안 지속됩니다.
+            blendMode: 'ADD', // 빛나는 효과를 위해 ADD 블렌드 모드를 사용합니다.
+            emitting: false
+        });
+        particles.explode(1); // 파티클 1개를 즉시 터뜨립니다.
+        this.vfxLayer.add(particles);
+
+        // 파티클 객체가 자동으로 소멸되도록 타이머를 설정합니다.
+        this.scene.time.delayedCall(1000, () => {
+            particles.destroy();
+        });
+    }
+    // ▲▲▲ [신규] 마법 공격 파티클 효과 메서드 추가 ▲▲▲
+
     // ✨ createBloodSplatter 함수 추가
     createBloodSplatter(x, y) {
         const particles = this.scene.add.particles(x, y, 'red-particle', {


### PR DESCRIPTION
## Summary
- add particle-based magic impact effect to VFXManager
- load placeholder particle texture during preload
- trigger magic impact for [MAGIC] tagged offensive skills

## Testing
- `for f in tests/*_test.js; do echo "Running $f"; node $f > /tmp/out && tail -n 1 /tmp/out; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6892d6dbfd7c83278b65fb905517a289