### PR TITLE
feat: add frost status effect and iceball skill

### DIFF
--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -732,4 +732,98 @@ export const activeSkills = {
         }
     },
     // --- ▲ [신규] 파이어볼 스킬 추가 ▲ ---
+
+    // --- ▼ [신규] 아이스볼 스킬 추가 ▼ ---
+    iceball: {
+        yinYangValue: -4,
+        NORMAL: {
+            id: 'iceball',
+            name: '아이스볼',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.WATER, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '지정한 위치에 얼음 덩어리를 날려 십자(5칸) 범위의 적들에게 {{damage}}%의 마법 피해를 주고, 2턴간 [동상] 효과를 부여합니다.',
+            illustrationPath: 'assets/images/skills/ice-ball.png',
+            cooldown: 3,
+            range: 4,
+            aoe: {
+                shape: 'CROSS',
+                radius: 1
+            },
+            damageMultiplier: { min: 0.9, max: 1.1 },
+            effect: {
+                id: 'frost',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 2,
+            }
+        },
+        RARE: {
+            id: 'iceball',
+            name: '아이스볼 [R]',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.WATER, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '지정한 위치에 얼음 덩어리를 날려 십자(5칸) 범위의 적들에게 {{damage}}%의 마법 피해를 주고, 2턴간 [동상] 효과를 부여합니다. (쿨타임 1 감소)',
+            illustrationPath: 'assets/images/skills/ice-ball.png',
+            cooldown: 2,
+            range: 4,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 1.0, max: 1.2 },
+            effect: {
+                id: 'frost',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 2,
+            }
+        },
+        EPIC: {
+            id: 'iceball',
+            name: '아이스볼 [E]',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.WATER, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '지정한 위치에 얼음 덩어리를 날려 십자(5칸) 범위의 적들에게 {{damage}}%의 마법 피해를 주고, 3턴간 [동상] 효과를 부여합니다.',
+            illustrationPath: 'assets/images/skills/ice-ball.png',
+            cooldown: 2,
+            range: 5,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 1.1, max: 1.3 },
+            effect: {
+                id: 'frost',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 3,
+            }
+        },
+        LEGENDARY: {
+            id: 'iceball',
+            name: '아이스볼 [L]',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.WATER, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '지정한 위치에 얼음 덩어리를 날려 십자(5칸) 범위의 적들에게 {{damage}}%의 마법 피해를 주고, 3턴간 [동상] 효과를 부여하며, 중심부의 적을 1턴간 [속박]시킵니다.',
+            illustrationPath: 'assets/images/skills/ice-ball.png',
+            cooldown: 2,
+            range: 5,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 1.2, max: 1.4 },
+            effect: {
+                id: 'frost',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 3,
+            },
+            centerTargetEffect: {
+                id: 'bind', // 속박 효과
+                type: EFFECT_TYPES.STATUS_EFFECT,
+                duration: 1
+            }
+        }
+    },
+    // --- ▲ [신규] 아이스볼 스킬 추가 ▲ ---
 };

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -41,6 +41,14 @@ export const statusEffects = {
         iconPath: 'assets/images/status-effects/burn.png',
         // onApply, onRemove는 지금 당장 필요 없지만, 나중에 확장할 수 있습니다.
     },
+    frost: {
+        id: 'frost',
+        name: '동상',
+        type: EFFECT_TYPES.DEBUFF,
+        description: '이동력이 1 감소하고, 턴이 끝날 때마다 최대 체력의 3%만큼 냉기 피해를 받습니다.',
+        iconPath: 'assets/images/status-effects/frost.png',
+        modifiers: { stat: 'movement', type: 'flat', value: -1 } // 이동력 1 감소
+    },
     // ✨ [신규] 이동력 감소(slow) 및 속박(bind) 효과 추가
     slow: {
         id: 'slow',

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -181,6 +181,11 @@ export class Preloader extends Scene
         this.load.image('placeholder', 'images/placeholder.png');
         // ▲▲▲ [추가] 마법 효과용 플레이스홀더 이미지 로드 ▲▲▲
 
+        // ▼▼▼ [추가] 아이스볼 및 동상 아이콘 로드 ▼▼▼
+        this.load.image('ice-ball', 'images/skills/ice-ball.png');
+        this.load.image('frost', 'images/status-effects/frost.png');
+        // ▲▲▲ [추가] 아이스볼 및 동상 아이콘 로드 ▲▲▲
+
         // 상태 효과 아이콘 로드
         Object.values(statusEffects).forEach(e => {
             const path = e.iconPath.replace(/^assets\//, '');

--- a/tests/esper_skill_integration_test.js
+++ b/tests/esper_skill_integration_test.js
@@ -50,6 +50,20 @@ const fireballBase = {
     }
 };
 
+const iceballBase = {
+    NORMAL: { id: 'iceball', cost: 3, cooldown: 3, range: 4, effect: { id: 'frost', duration: 2 } },
+    RARE: { id: 'iceball', cost: 3, cooldown: 2, range: 4, effect: { id: 'frost', duration: 2 } },
+    EPIC: { id: 'iceball', cost: 3, cooldown: 2, range: 5, effect: { id: 'frost', duration: 3 } },
+    LEGENDARY: {
+        id: 'iceball',
+        cost: 3,
+        cooldown: 2,
+        range: 5,
+        effect: { id: 'frost', duration: 3 },
+        centerTargetEffect: { id: 'bind', duration: 1 }
+    }
+};
+
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 for (const grade of grades) {
@@ -77,6 +91,21 @@ for (const grade of grades) {
     assert.strictEqual(skill.effect.duration, expected.effect.duration, `Fireball duration failed for ${grade}`);
     if (grade === 'LEGENDARY') {
         assert(skill.centerTargetEffect && skill.centerTargetEffect.id === 'stun', 'Legendary center stun missing');
+    } else {
+        assert(!skill.centerTargetEffect, 'Center effect should only exist in Legendary');
+    }
+}
+
+for (const grade of grades) {
+    const skill = skillModifierEngine.getModifiedSkill(iceballBase[grade], grade);
+    const expected = iceballBase[grade];
+    assert.strictEqual(skill.cost, expected.cost, `Iceball cost failed for ${grade}`);
+    assert.strictEqual(skill.cooldown, expected.cooldown, `Iceball cooldown failed for ${grade}`);
+    assert.strictEqual(skill.range, expected.range, `Iceball range failed for ${grade}`);
+    assert.strictEqual(skill.effect.id, 'frost', 'Iceball effect id mismatch');
+    assert.strictEqual(skill.effect.duration, expected.effect.duration, `Iceball duration failed for ${grade}`);
+    if (grade === 'LEGENDARY') {
+        assert(skill.centerTargetEffect && skill.centerTargetEffect.id === 'bind', 'Legendary center bind missing');
     } else {
         assert(!skill.centerTargetEffect, 'Center effect should only exist in Legendary');
     }

--- a/tests/nanomancer_skill_integration_test.js
+++ b/tests/nanomancer_skill_integration_test.js
@@ -22,6 +22,20 @@ const fireballBase = {
     }
 };
 
+const iceballBase = {
+    NORMAL: { id: 'iceball', cost: 3, cooldown: 3, range: 4, effect: { id: 'frost', duration: 2 } },
+    RARE: { id: 'iceball', cost: 3, cooldown: 2, range: 4, effect: { id: 'frost', duration: 2 } },
+    EPIC: { id: 'iceball', cost: 3, cooldown: 2, range: 5, effect: { id: 'frost', duration: 3 } },
+    LEGENDARY: {
+        id: 'iceball',
+        cost: 3,
+        cooldown: 2,
+        range: 5,
+        effect: { id: 'frost', duration: 3 },
+        centerTargetEffect: { id: 'bind', duration: 1 }
+    }
+};
+
 const expectedDamage = [1.3, 1.2, 1.1, 1.0];
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
@@ -52,6 +66,21 @@ for (const grade of grades) {
     assert.strictEqual(skill.effect.duration, expected.effect.duration, `Fireball duration failed for ${grade}`);
     if (grade === 'LEGENDARY') {
         assert(skill.centerTargetEffect && skill.centerTargetEffect.id === 'stun', 'Legendary center stun missing');
+    } else {
+        assert(!skill.centerTargetEffect, 'Center effect should only exist in Legendary');
+    }
+}
+
+for (const grade of grades) {
+    const skill = skillModifierEngine.getModifiedSkill(iceballBase[grade], grade);
+    const expected = iceballBase[grade];
+    assert.strictEqual(skill.cost, expected.cost, `Iceball cost failed for ${grade}`);
+    assert.strictEqual(skill.cooldown, expected.cooldown, `Iceball cooldown failed for ${grade}`);
+    assert.strictEqual(skill.range, expected.range, `Iceball range failed for ${grade}`);
+    assert.strictEqual(skill.effect.id, 'frost', 'Iceball effect id mismatch');
+    assert.strictEqual(skill.effect.duration, expected.effect.duration, `Iceball duration failed for ${grade}`);
+    if (grade === 'LEGENDARY') {
+        assert(skill.centerTargetEffect && skill.centerTargetEffect.id === 'bind', 'Legendary center bind missing');
     } else {
         assert(!skill.centerTargetEffect, 'Center effect should only exist in Legendary');
     }


### PR DESCRIPTION
## Summary
- add Frost debuff with movement penalty
- introduce Iceball skill for nanomancer and esper with Frost effect
- preload Iceball and Frost icons
- cover Iceball in nanomancer and esper skill tests

## Testing
- `node tests/nanomancer_skill_integration_test.js`
- `node tests/esper_skill_integration_test.js`
- `node tests/status_effect_interaction_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6892d8cc60a083278861ecab3c3b2167