### PR TITLE
refactor memory engine initialization

### DIFF
--- a/src/game/utils/ArchetypeMemoryEngine.js
+++ b/src/game/utils/ArchetypeMemoryEngine.js
@@ -8,27 +8,33 @@ class ArchetypeMemoryEngine {
         this.db = null;
         this.dbName = 'ArchetypeMemoryDB'; // DB 이름 변경
         this.storeName = 'archetypeCombatMemory'; // 스토어 이름 변경
-        this.initDB();
+        // [수정] 생성자에서 초기화 Promise를 생성하고 저장합니다.
+        this.initPromise = this._initializeDB();
     }
 
-    initDB() {
-        const request = indexedDB.open(this.dbName, 1);
+    // [수정] initDB를 Promise를 반환하는 내부 메서드로 변경
+    _initializeDB() {
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(this.dbName, 1);
 
-        request.onupgradeneeded = (event) => {
-            this.db = event.target.result;
-            if (!this.db.objectStoreNames.contains(this.storeName)) {
-                this.db.createObjectStore(this.storeName, { keyPath: 'id' }); // id는 mbtiString
-            }
-        };
+            request.onupgradeneeded = (event) => {
+                this.db = event.target.result;
+                if (!this.db.objectStoreNames.contains(this.storeName)) {
+                    this.db.createObjectStore(this.storeName, { keyPath: 'id' }); // id는 mbtiString
+                }
+            };
 
-        request.onsuccess = (event) => {
-            this.db = event.target.result;
-            console.log('[ArchetypeMemoryEngine] IndexedDB가 성공적으로 초기화되었습니다.');
-        };
+            request.onsuccess = (event) => {
+                this.db = event.target.result;
+                console.log('[ArchetypeMemoryEngine] IndexedDB가 성공적으로 초기화되었습니다.');
+                resolve(this.db); // 성공 시 Promise를 resolve 합니다.
+            };
 
-        request.onerror = (event) => {
-            console.error('[ArchetypeMemoryEngine] IndexedDB 초기화 오류:', event.target.errorCode);
-        };
+            request.onerror = (event) => {
+                console.error('[ArchetypeMemoryEngine] IndexedDB 초기화 오류:', event.target.errorCode);
+                reject(event.target.error); // 실패 시 Promise를 reject 합니다.
+            };
+        });
     }
 
     /**
@@ -36,7 +42,10 @@ class ArchetypeMemoryEngine {
      * @param {string} mbtiString - 'INTJ', 'ENFP' 등 MBTI 아키타입 문자열
      * @returns {Promise<object>} - 대상 ID를 키로 갖는 가중치 객체
      */
-    getMemory(mbtiString) {
+    async getMemory(mbtiString) {
+        // [신규] DB가 준비될 때까지 기다립니다.
+        await this.initPromise;
+
         return new Promise((resolve, reject) => {
             if (!this.db) return resolve({});
             const transaction = this.db.transaction([this.storeName], 'readonly');
@@ -60,7 +69,10 @@ class ArchetypeMemoryEngine {
      * @param {string} mbtiString - 업데이트할 아키타입
      * @param {object} learnedMemory - 분석을 통해 새로 생성된 기억 데이터
      */
-    updateMemory(mbtiString, learnedMemory) {
+    async updateMemory(mbtiString, learnedMemory) {
+        // [신규] DB가 준비될 때까지 기다립니다.
+        await this.initPromise;
+
         return new Promise((resolve, reject) => {
             if (!this.db) return reject('DB not initialized');
             const transaction = this.db.transaction([this.storeName], 'readwrite');


### PR DESCRIPTION
## Summary
- wrap AI and archetype memory IndexedDB initialization with Promises and await readiness before access

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 -m http.server 8000`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6892de6cd2808327bfccb46b771a8928