### PR TITLE
feat: introduce elemental debuffs and magic spheres

### DIFF
--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -827,6 +827,88 @@ export const activeSkills = {
     },
     // --- ▲ [신규] 아이스볼 스킬 추가 ▲ ---
 
+    // --- ▼ [신규] 4대 원소 마법 스킬 추가 (NORMAL 등급) ▼ ---
+    lightningStrike: {
+        yinYangValue: -4,
+        NORMAL: {
+            id: 'lightningStrike',
+            name: '라이트닝 스트라이크',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.WIND, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '번개 구체를 날려 십자(5칸) 범위의 적들에게 {{damage}}% 마법 피해를 주고, 2턴간 [감전] 효과를 부여합니다.',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 4,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 0.8, max: 1.1 },
+            effect: { id: 'shock', type: EFFECT_TYPES.DEBUFF, duration: 2 }
+        }
+    },
+
+    stoneBlast: {
+        yinYangValue: -4,
+        NORMAL: {
+            id: 'stoneBlast',
+            name: '스톤 블라스트',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.EARTH, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '바위 파편을 날려 십자(5칸) 범위의 적들에게 {{damage}}% 마법 피해를 주고, 2턴간 [약화] 효과를 부여합니다.',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 4,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 0.8, max: 1.1 },
+            effect: { id: 'weaken', type: EFFECT_TYPES.DEBUFF, duration: 2 }
+        }
+    },
+
+    holyLight: {
+        yinYangValue: -4,
+        NORMAL: {
+            id: 'holyLight',
+            name: '홀리 라이트',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.LIGHT, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '성스러운 빛으로 십자(5칸) 범위의 적들에게 {{damage}}% 마법 피해를 주고, 2턴간 [취약] 상태로 만듭니다.',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 4,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 0.8, max: 1.1 },
+            effect: { id: 'vulnerable', type: EFFECT_TYPES.DEBUFF, duration: 2 }
+        }
+    },
+
+    shadowBolt: {
+        yinYangValue: -4,
+        NORMAL: {
+            id: 'shadowBolt',
+            name: '섀도우 볼트',
+            type: 'ACTIVE',
+            requiredClass: ['nanomancer', 'esper'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.DARK, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '어둠의 구체를 날려 십자(5칸) 범위의 적들에게 {{damage}}% 마법 피해를 주고, 2턴간 [정기 흡수] 효과를 부여합니다.',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 4,
+            aoe: { shape: 'CROSS', radius: 1 },
+            damageMultiplier: { min: 0.8, max: 1.1 },
+            effect: { id: 'drain', type: EFFECT_TYPES.DEBUFF, duration: 2 }
+        }
+    },
+    // --- ▲ [신규] 4대 원소 마법 스킬 추가 (NORMAL 등급) ▲ ---
+
     // --- ▼ [신규] 관통 사격 스킬 추가 ▼ ---
     piercingShot: {
         yinYangValue: -3,

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -51,6 +51,45 @@ export const statusEffects = {
         modifiers: { stat: 'movement', type: 'flat', value: -1 } // 이동력 1 감소
     },
     // ▲▲▲ [신규] 추가 완료 ▲▲▲
+    // --- ▼ [신규] 4대 원소 상태이상 효과 추가 ▼ ---
+    shock: {
+        id: 'shock',
+        name: '감전',
+        type: EFFECT_TYPES.DEBUFF,
+        description: '턴 시작 시 50% 확률로 토큰 1개를 잃습니다.',
+        iconPath: null, // 추후 전용 아이콘 추가 예정
+    },
+    weaken: {
+        id: 'weaken',
+        name: '약화',
+        type: EFFECT_TYPES.DEBUFF,
+        description: '물리 및 마법 공격력이 15% 감소합니다.',
+        iconPath: null,
+        modifiers: [
+            { stat: 'physicalAttack', type: 'percentage', value: -0.15 },
+            { stat: 'magicAttack', type: 'percentage', value: -0.15 }
+        ]
+    },
+    vulnerable: {
+        id: 'vulnerable',
+        name: '취약',
+        type: EFFECT_TYPES.DEBUFF,
+        description: '받는 모든 피해가 15% 증가합니다.',
+        iconPath: null,
+        modifiers: { stat: 'damageIncrease', type: 'percentage', value: 0.15 }
+    },
+    drain: {
+        id: 'drain',
+        name: '정기 흡수',
+        type: EFFECT_TYPES.DEBUFF,
+        description: '지능과 지혜가 15% 감소합니다.',
+        iconPath: null,
+        modifiers: [
+            { stat: 'intelligence', type: 'percentage', value: -0.15 },
+            { stat: 'wisdom', type: 'percentage', value: -0.15 }
+        ]
+    },
+    // --- ▲ [신규] 추가 완료 ▲ ---
     // ✨ [신규] 이동력 감소(slow) 및 속박(bind) 효과 추가
     slow: {
         id: 'slow',

--- a/tests/esper_skill_integration_test.js
+++ b/tests/esper_skill_integration_test.js
@@ -64,6 +64,14 @@ const iceballBase = {
     }
 };
 
+// 신규 4대 원소 스킬 (NORMAL 등급만 존재)
+const elementalBases = [
+    { id: 'lightningStrike', cost: 3, cooldown: 3, range: 4, effect: { id: 'shock', duration: 2 } },
+    { id: 'stoneBlast', cost: 3, cooldown: 3, range: 4, effect: { id: 'weaken', duration: 2 } },
+    { id: 'holyLight', cost: 3, cooldown: 3, range: 4, effect: { id: 'vulnerable', duration: 2 } },
+    { id: 'shadowBolt', cost: 3, cooldown: 3, range: 4, effect: { id: 'drain', duration: 2 } }
+];
+
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 for (const grade of grades) {
@@ -109,6 +117,16 @@ for (const grade of grades) {
     } else {
         assert(!skill.centerTargetEffect, 'Center effect should only exist in Legendary');
     }
+}
+
+// 신규 4대 원소 스킬 검증
+for (const base of elementalBases) {
+    const skill = skillModifierEngine.getModifiedSkill(base, 'NORMAL');
+    assert.strictEqual(skill.cost, base.cost, `${base.id} cost failed`);
+    assert.strictEqual(skill.cooldown, base.cooldown, `${base.id} cooldown failed`);
+    assert.strictEqual(skill.range, base.range, `${base.id} range failed`);
+    assert.strictEqual(skill.effect.id, base.effect.id, `${base.id} effect id mismatch`);
+    assert.strictEqual(skill.effect.duration, base.effect.duration, `${base.id} duration failed`);
 }
 
 console.log('Esper skills integration test passed.');

--- a/tests/nanomancer_skill_integration_test.js
+++ b/tests/nanomancer_skill_integration_test.js
@@ -36,6 +36,14 @@ const iceballBase = {
     }
 };
 
+// 신규 4대 원소 스킬 (NORMAL 등급만 존재)
+const elementalBases = [
+    { id: 'lightningStrike', cost: 3, cooldown: 3, range: 4, effect: { id: 'shock', duration: 2 } },
+    { id: 'stoneBlast', cost: 3, cooldown: 3, range: 4, effect: { id: 'weaken', duration: 2 } },
+    { id: 'holyLight', cost: 3, cooldown: 3, range: 4, effect: { id: 'vulnerable', duration: 2 } },
+    { id: 'shadowBolt', cost: 3, cooldown: 3, range: 4, effect: { id: 'drain', duration: 2 } }
+];
+
 const expectedDamage = [1.3, 1.2, 1.1, 1.0];
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
@@ -84,6 +92,16 @@ for (const grade of grades) {
     } else {
         assert(!skill.centerTargetEffect, 'Center effect should only exist in Legendary');
     }
+}
+
+// 신규 4대 원소 스킬 검증
+for (const base of elementalBases) {
+    const skill = skillModifierEngine.getModifiedSkill(base, 'NORMAL');
+    assert.strictEqual(skill.cost, base.cost, `${base.id} cost failed`);
+    assert.strictEqual(skill.cooldown, base.cooldown, `${base.id} cooldown failed`);
+    assert.strictEqual(skill.range, base.range, `${base.id} range failed`);
+    assert.strictEqual(skill.effect.id, base.effect.id, `${base.id} effect id mismatch`);
+    assert.strictEqual(skill.effect.duration, base.effect.duration, `${base.id} duration failed`);
 }
 
 console.log('Nanomancer skills integration test passed.');


### PR DESCRIPTION
## Summary
- add Shock, Weaken, Vulnerable, and Drain status effects
- implement four elemental sphere spells for nanomancer/esper classes
- extend nanomancer and esper skill tests to cover new spells

## Testing
- `node tests/nanomancer_skill_integration_test.js`
- `node tests/esper_skill_integration_test.js`
- `node tests/status_effect_interaction_test.js`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6892f8d61ad8832791111a788344dc40