### PR TITLE
feat: add poison and disarm effects with related skills

### DIFF
--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -1061,4 +1061,63 @@ export const activeSkills = {
         }
     },
     // --- ▲ [신규] 더블 스트라이크 스킬 추가 ▲ ---
+
+    // --- ▼ [신규] 암살 일격, 맹독 구름, 아드레날린 주사 스킬 추가 ▼ ---
+    assassinate: {
+        yinYangValue: -5,
+        NORMAL: {
+            id: 'assassinate',
+            name: '암살 일격',
+            type: 'ACTIVE',
+            requiredClass: ['clown', 'ghost'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.PHYSICAL, SKILL_TAGS.MELEE, SKILL_TAGS.EXECUTE, SKILL_TAGS.SPECIAL],
+            cost: 3,
+            targetType: 'enemy',
+            description: '적에게 100%의 물리 피해를 주고, 대상에게 걸린 해로운 효과 하나당 20%의 추가 피해를 입힙니다.',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 1,
+            damageMultiplier: { min: 0.9, max: 1.1 },
+            damagePerDebuff: 0.2 // 디버프당 20% 추가 데미지 (나중에 CombatCalculationEngine에서 이 값을 사용)
+        }
+    },
+
+    poisonCloud: {
+        yinYangValue: -3,
+        NORMAL: {
+            id: 'poisonCloud',
+            name: '맹독 구름',
+            type: 'ACTIVE',
+            requiredClass: ['plagueDoctor'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.POISON, SKILL_TAGS.DEBUFF, SKILL_TAGS.AURA],
+            cost: 0, // 자원만 소모
+            targetType: 'enemy',
+            description: '넓은(3x3) 범위에 독안개를 살포하여 3턴간 [중독] 효과를 부여합니다. (소모 자원: 독 2)',
+            illustrationPath: null,
+            cooldown: 4,
+            range: 3,
+            resourceCost: { type: 'POISON', amount: 2 },
+            aoe: { shape: 'SQUARE', radius: 1 },
+            effect: { id: 'poison', type: EFFECT_TYPES.DEBUFF, duration: 3 }
+        }
+    },
+
+    adrenalineShot: {
+        yinYangValue: +3,
+        NORMAL: {
+            id: 'adrenalineShot',
+            name: '아드레날린 주사',
+            type: 'AID', // 지원 스킬이지만 액티브로도 분류 가능
+            tags: [SKILL_TAGS.AID, SKILL_TAGS.BUFF],
+            cost: 3,
+            targetType: 'ally',
+            description: '아군 하나의 [둔화]와 [속박]을 즉시 해제하고, 2턴간 [아드레날린] 버프를 부여합니다.',
+            illustrationPath: null,
+            cooldown: 5,
+            range: 1,
+            cleanses: ['slow', 'bind'], // 해제할 상태이상 목록 (나중에 SkillEffectProcessor에서 처리)
+            effect: { id: 'adrenaline', type: EFFECT_TYPES.BUFF, duration: 2 }
+        }
+    },
+    // --- ▲ [신규] 암살 일격, 맹독 구름, 아드레날린 주사 스킬 추가 ▲ ---
 };

--- a/src/game/data/skills/aid.js
+++ b/src/game/data/skills/aid.js
@@ -223,6 +223,32 @@ export const aidSkills = {
                 stack: { type: 'DAMAGE_IMMUNITY', amount: 5 }
             }
         }
-    }
+    },
     // --- ▲ [신규] 마이티 쉴드 스킬 추가 ▲ ---
+
+    // --- ▼ [신규] 맹독 바르기 스킬 추가 ▼ ---
+    applyPoison: {
+        yinYangValue: +1,
+        NORMAL: {
+            id: 'applyPoison',
+            name: '맹독 바르기',
+            type: 'AID',
+            requiredClass: ['plagueDoctor'],
+            tags: [SKILL_TAGS.AID, SKILL_TAGS.BUFF, SKILL_TAGS.POISON, SKILL_TAGS.PRODUCTION],
+            cost: 1,
+            targetType: 'ally',
+            description: '아군 하나의 무기에 독을 발라, 2턴간 공격 시 50% 확률로 적을 [중독]시킵니다. [독] 자원을 1 생산합니다.',
+            illustrationPath: null,
+            cooldown: 2,
+            range: 2,
+            generatesResource: { type: 'POISON', amount: 1 },
+            effect: {
+                id: 'poisonWeapon',
+                type: EFFECT_TYPES.BUFF,
+                duration: 2,
+                poisonChance: 0.5 // 중독 확률 (나중에 CombatCalculationEngine에서 처리)
+            }
+        }
+    },
+    // --- ▲ [신규] 맹독 바르기 스킬 추가 ▲ ---
 };

--- a/src/game/data/skills/debuff.js
+++ b/src/game/data/skills/debuff.js
@@ -180,4 +180,24 @@ export const debuffSkills = {
         }
     },
     // --- ▲ [신규] 컨퓨전 스킬 추가 ▲ ---
+
+    // --- ▼ [신규] 시스템 해킹 스킬 추가 ▼ ---
+    systemHack: {
+        yinYangValue: +3,
+        NORMAL: {
+            id: 'systemHack',
+            name: '시스템 해킹',
+            type: 'DEBUFF',
+            requiredClass: ['hacker'],
+            tags: [SKILL_TAGS.DEBUFF, SKILL_TAGS.RANGED, SKILL_TAGS.MAGIC, SKILL_TAGS.PROHIBITION, SKILL_TAGS.MIND, SKILL_TAGS.SPECIAL],
+            cost: 2,
+            targetType: 'enemy',
+            description: '적의 시스템을 교란하여 1턴간 [무장 해제] 상태로 만듭니다. (공격/스킬 사용 불가)',
+            illustrationPath: null,
+            cooldown: 4,
+            range: 3,
+            effect: { id: 'disarm', type: EFFECT_TYPES.DEBUFF, duration: 1 }
+        }
+    },
+    // --- ▲ [신규] 시스템 해킹 스킬 추가 ▲ ---
 };

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -336,4 +336,47 @@ export const statusEffects = {
         iconPath: 'assets/images/skills/curse-of-darkness.png',
     },
     // --- ▲ [신규] 다크나이트 패시브 및 특화 효과 추가 ▲ ---
+
+    // --- ▼ [신규] 5가지 신규 상태이상 및 버프 효과 추가 ▼ ---
+    disarm: {
+        id: 'disarm',
+        name: '무장 해제',
+        type: EFFECT_TYPES.DEBUFF,
+        description: '공격 및 스킬 사용이 불가능합니다.',
+        iconPath: null, // 시스템 해킹
+        onApply: (unit) => { unit.isDisarmed = true; },
+        onRemove: (unit) => { unit.isDisarmed = false; }
+    },
+
+    poisonWeapon: {
+        id: 'poisonWeapon',
+        name: '맹독 부여',
+        type: EFFECT_TYPES.BUFF,
+        description: '다음 공격 시 50% 확률로 적을 [중독]시킵니다.',
+        iconPath: null, // 맹독 바르기
+    },
+
+    poison: {
+        id: 'poison',
+        name: '중독',
+        type: EFFECT_TYPES.DEBUFF,
+        description: '턴 종료 시 최대 체력의 8%만큼 지속 피해를 입고, 받는 치유량이 25% 감소합니다.',
+        iconPath: null, // 맹독 구름
+        modifiers: { stat: 'healingReceived', type: 'percentage', value: -0.25 }
+        // 지속 피해 로직은 나중에 StatusEffectManager.js에서 별도 처리가 필요합니다.
+    },
+
+    adrenaline: {
+        id: 'adrenaline',
+        name: '아드레날린',
+        type: EFFECT_TYPES.BUFF,
+        description: '공격력이 25% 증가하고, 행동 순서가 더 빨리 돌아옵니다.',
+        iconPath: null, // 아드레날린 주사
+        modifiers: [
+            { stat: 'physicalAttack', type: 'percentage', value: 0.25 },
+            { stat: 'magicAttack', type: 'percentage', value: 0.25 },
+            { stat: 'turnValue', type: 'percentage', value: -0.30 } // 턴 순서 값 30% 감소 (빨라짐)
+        ]
+    },
+    // --- ▲ [신규] 추가 완료 ▲ ---
 };


### PR DESCRIPTION
## Summary
- introduce disarm, poison, poison weapon, and adrenaline status effects
- add assassinate, poison cloud, adrenaline shot, and apply poison skills
- enable hacker's system hack skill to inflict disarm

## Testing
- `node tests/clown_skill_integration_test.js`
- `node tests/status_effect_interaction_test.js`
- `node tests/mighty_shield_skill_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6892fd6aec388327bae317903db7948d