### PR TITLE
Fix status effect immunity and implement poison damage

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -303,7 +303,8 @@ export class BattleSimulatorEngine {
                 this.currentTurnIndex = 0;
                 this.currentTurnNumber++; // 모든 유닛의 턴이 끝나면 전체 턴 수 증가
 
-                statusEffectManager.onTurnEnd();
+                // ✨ [수정] 턴 종료 시 지속 피해 효과 처리를 statusEffectManager로 위임
+                statusEffectManager.onTurnEnd(this.turnQueue);
                 // ✨ 턴 종료 시 음양 지수 자연 감소를 적용합니다.
                 yinYangEngine.applyTurnDecay();
                 tokenEngine.addTokensForNewTurn();

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -27,6 +27,7 @@ import { aspirationEngine } from './AspirationEngine.js';
 // ▼▼▼ [추가] 새로 만든 데미지 타입 매니저를 import 합니다. ▼▼▼
 import { damageTypeManager } from './DamageTypeManager.js';
 import { debugLogEngine } from './DebugLogEngine.js';
+import { statusEffects } from '../data/status-effects.js';
 
 /**
  * 실제 전투 데미지 계산을 담당하는 엔진
@@ -294,6 +295,14 @@ class CombatCalculationEngine {
         }
 
         // 디버그 로그에 강화된 스탯을 반영하도록 수정
+        // ✨ [추가] 맹독 부여(poisonWeapon) 버프 처리
+        const attackerEffects = statusEffectManager.activeEffects.get(attacker.uniqueId) || [];
+        const poisonWeaponBuff = attackerEffects.find(e => e.id === 'poisonWeapon');
+        if (poisonWeaponBuff && Math.random() < (poisonWeaponBuff.poisonChance || 0.5)) {
+            const poisonSkill = { name: '맹독 부여', effect: statusEffects.poison };
+            statusEffectManager.addEffect(defender, poisonSkill, attacker);
+        }
+
         debugCombatLogManager.logAttackCalculation(
             { ...attacker, finalStats: attackerStats },
             { ...defender, finalStats: defenderStats },

--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -48,8 +48,13 @@ class SkillEngine {
      * @param {object} unit - 스킬을 사용하려는 유닛
      * @param {object} skill - 사용하려는 스킬 데이터
      * @returns {boolean} - 스킬 사용 가능 여부
-     */
+    */
     canUseSkill(unit, skill) {
+        // ✨ [수정] 무장 해제 상태인지 가장 먼저 확인합니다.
+        if (unit.isDisarmed) {
+            return false;
+        }
+
         // 1. 토큰이 충분한가?
         const currentTokens = tokenEngine.getTokens(unit.uniqueId);
         if (currentTokens < skill.cost) {

--- a/src/game/utils/SkillInventoryManager.js
+++ b/src/game/utils/SkillInventoryManager.js
@@ -145,7 +145,8 @@ class SkillInventoryManager {
         
         const finalSkillData = { ...baseData, ...gradeData };
 
-        // [신규] 네이밍 규칙에 따라 이미지 경로를 확인하고, 없으면 리포트하도록 전달
+        // ✨ [수정] illustrationPath가 없을 경우, skillId를 기반으로 자동 경로를 생성합니다.
+        // placeholderManager는 경로가 실제로 없을 때만 경고를 출력합니다.
         if (!finalSkillData.illustrationPath) {
             const expectedPath = `assets/images/skills/${finalSkillData.id}.png`;
             finalSkillData.illustrationPath = placeholderManager.getPath(null, expectedPath);

--- a/tests/status_effect_interaction_test.js
+++ b/tests/status_effect_interaction_test.js
@@ -41,12 +41,12 @@ statusEffectManager.addEffect(mockUnit, stunSkill2);
 assert.strictEqual(mockUnit.isStunned, true, '테스트 1-1 실패: 기절 효과가 적용되지 않았습니다.');
 
 // 1턴 경과
-statusEffectManager.onTurnEnd();
+statusEffectManager.onTurnEnd([mockUnit]);
 assert.strictEqual(mockUnit.isStunned, true, '테스트 1-2 실패: 기절 중첩 시 조기에 효과가 해제되었습니다.');
 console.log('✅ 테스트 1 통과: 기절 효과가 올바르게 중첩됩니다.');
 
 // 2턴 경과 (모든 기절 해제)
-statusEffectManager.onTurnEnd();
+statusEffectManager.onTurnEnd([mockUnit]);
 assert.strictEqual(mockUnit.isStunned, false, '테스트 1-3 실패: 모든 기절 효과 만료 후에도 상태가 해제되지 않았습니다.');
 assert.strictEqual(mockUnit.justRecoveredFromStun, true, '테스트 1-4 실패: 기절에서 막 회복한 상태 플래그가 설정되지 않았습니다.');
 
@@ -56,7 +56,7 @@ const willGuardSkill = { name: 'Will Guard', effect: { id: 'willGuard' } }; // d
 statusEffectManager.addEffect(mockUnit, willGuardSkill);
 
 // 1턴 경과
-statusEffectManager.onTurnEnd();
+statusEffectManager.onTurnEnd([mockUnit]);
 const effects = statusEffectManager.activeEffects.get(mockUnit.uniqueId) || [];
 assert.strictEqual(effects.length, 1, '테스트 2-1 실패: 지속시간 없는 버프가 조기에 만료되었습니다.');
 assert.strictEqual(effects[0].id, 'willGuard', '테스트 2-2 실패: 남아있는 버프가 올바르지 않습니다.');


### PR DESCRIPTION
## Summary
- Prevent disarmed units from using skills
- Respect buff immunity and apply burn/poison damage each turn
- Allow poisonWeapon attacks to inflict poison; auto-fill missing skill images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node tests/status_effect_interaction_test.js`
- `node tests/combat_calculation_test.js`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689307309b4c8327a45ed02924bdf072