### PR TITLE
feat: add focus fire debuff and skill

### DIFF
--- a/src/game/data/skills/debuff.js
+++ b/src/game/data/skills/debuff.js
@@ -101,6 +101,93 @@ export const debuffSkills = {
             }
         }
     },
+    // --- ▼ [신규] 집중 포화 스킬 추가 ▼ ---
+    focusFire: {
+        yinYangValue: +3,
+        NORMAL: {
+            id: 'focusFire',
+            name: '집중 포화',
+            type: 'DEBUFF',
+            requiredClass: ['gunner', 'commander'],
+            tags: [SKILL_TAGS.DEBUFF, SKILL_TAGS.RANGED, SKILL_TAGS.STRATEGY, SKILL_TAGS.SPECIAL],
+            cost: 0, // 자원만 소모
+            targetType: 'enemy',
+            description: '대상의 약점을 아군에게 공유합니다. 3턴간 대상이 받는 모든 피해가 15% 증가합니다. (소모 자원: 철 2)',
+            illustrationPath: null,
+            cooldown: 4,
+            range: 5,
+            resourceCost: { type: 'IRON', amount: 2 },
+            effect: { id: 'focusFireMark', type: EFFECT_TYPES.DEBUFF, duration: 3 }
+        },
+        RARE: {
+            id: 'focusFire',
+            name: '집중 포화 [R]',
+            type: 'DEBUFF',
+            requiredClass: ['gunner', 'commander'],
+            tags: [SKILL_TAGS.DEBUFF, SKILL_TAGS.RANGED, SKILL_TAGS.STRATEGY, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'enemy',
+            description: '대상의 약점을 아군에게 공유합니다. 3턴간 대상이 받는 모든 피해가 20% 증가합니다. (소모 자원: 철 2)',
+            illustrationPath: null,
+            cooldown: 4,
+            range: 5,
+            resourceCost: { type: 'IRON', amount: 2 },
+            effect: {
+                id: 'focusFireMark',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 3,
+                modifiers: { stat: 'damageIncrease', type: 'percentage', value: 0.20 } // 피해량 증가
+            }
+        },
+        EPIC: {
+            id: 'focusFire',
+            name: '집중 포화 [E]',
+            type: 'DEBUFF',
+            requiredClass: ['gunner', 'commander'],
+            tags: [SKILL_TAGS.DEBUFF, SKILL_TAGS.RANGED, SKILL_TAGS.STRATEGY, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'enemy',
+            description: '대상의 약점을 아군에게 공유합니다. 3턴간 대상이 받는 모든 피해가 25% 증가하고, 물리 방어력이 10% 감소합니다. (소모 자원: 철 2)',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 6,
+            resourceCost: { type: 'IRON', amount: 2 },
+            effect: {
+                id: 'focusFireMark',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 3,
+                modifiers: [ // 두 가지 효과
+                    { stat: 'damageIncrease', type: 'percentage', value: 0.25 },
+                    { stat: 'physicalDefense', type: 'percentage', value: -0.10 }
+                ]
+            }
+        },
+        LEGENDARY: {
+            id: 'focusFire',
+            name: '집중 포화 [L]',
+            type: 'DEBUFF',
+            requiredClass: ['gunner', 'commander'],
+            tags: [SKILL_TAGS.DEBUFF, SKILL_TAGS.RANGED, SKILL_TAGS.STRATEGY, SKILL_TAGS.SPECIAL],
+            cost: 0,
+            targetType: 'enemy',
+            description: '대상의 약점을 아군에게 공유합니다. 4턴간 대상이 받는 모든 피해가 30% 증가하고, 모든 방어력이 15% 감소합니다. (소모 자원: 철 1)',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 6,
+            resourceCost: { type: 'IRON', amount: 1 }, // 비용 감소
+            effect: {
+                id: 'focusFireMark',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 4, // 지속시간 증가
+                modifiers: [
+                    { stat: 'damageIncrease', type: 'percentage', value: 0.30 },
+                    { stat: 'physicalDefense', type: 'percentage', value: -0.15 },
+                    { stat: 'magicDefense', type: 'percentage', value: -0.15 }
+                ]
+            }
+        }
+    },
+    // --- ▲ [신규] 집중 포화 스킬 추가 ▲ ---
     // --- ▼ [신규] 컨퓨전 스킬 추가 ▼ ---
     confusion: {
         yinYangValue: +4, // 전장을 뒤흔드는 강력한 양(Yang)의 기술로 +4의 높은 점수를 부여했습니다.

--- a/src/game/data/status-effects.js
+++ b/src/game/data/status-effects.js
@@ -407,6 +407,16 @@ export const statusEffects = {
         iconPath: null, // 무효화
         onApply: (unit) => { unit.isBuffImmune = true; },
         onRemove: (unit) => { unit.isBuffImmune = false; }
+    },
+    // --- ▼ [신규] '약점 노출' 디버프 효과 추가 ▼ ---
+    focusFireMark: {
+        id: 'focusFireMark',
+        name: '약점 노출',
+        type: EFFECT_TYPES.DEBUFF,
+        description: '이 유닛은 모든 공격으로부터 추가 피해를 받습니다.',
+        iconPath: null, // 나중에 전용 아이콘 추가
+        // 'damageIncrease' modifier를 사용하여 CombatCalculationEngine에서 자동으로 처리되도록 합니다.
+        modifiers: { stat: 'damageIncrease', type: 'percentage', value: 0.15 } // 기본 15% 추가 피해
     }
     // --- ▲ [신규] 추가 완료 ▲ ---
 };

--- a/tests/gunner_skill_integration_test.js
+++ b/tests/gunner_skill_integration_test.js
@@ -87,6 +87,58 @@ const piercingShotBase = {
 };
 // --- ▲ [신규] 관통 사격 테스트 데이터 추가 ▲ ---
 
+// --- ▼ [신규] 집중 포화 테스트 데이터 추가 ▼ ---
+const focusFireBase = {
+    NORMAL: {
+        id: 'focusFire',
+        cost: 0,
+        cooldown: 4,
+        range: 5,
+        resourceCost: { type: 'IRON', amount: 2 },
+        effect: { id: 'focusFireMark', duration: 3 }
+    },
+    RARE: {
+        id: 'focusFire',
+        cost: 0,
+        cooldown: 4,
+        range: 5,
+        resourceCost: { type: 'IRON', amount: 2 },
+        effect: { id: 'focusFireMark', duration: 3, modifiers: { stat: 'damageIncrease', type: 'percentage', value: 0.20 } }
+    },
+    EPIC: {
+        id: 'focusFire',
+        cost: 0,
+        cooldown: 3,
+        range: 6,
+        resourceCost: { type: 'IRON', amount: 2 },
+        effect: {
+            id: 'focusFireMark',
+            duration: 3,
+            modifiers: [
+                { stat: 'damageIncrease', type: 'percentage', value: 0.25 },
+                { stat: 'physicalDefense', type: 'percentage', value: -0.10 }
+            ]
+        }
+    },
+    LEGENDARY: {
+        id: 'focusFire',
+        cost: 0,
+        cooldown: 3,
+        range: 6,
+        resourceCost: { type: 'IRON', amount: 1 },
+        effect: {
+            id: 'focusFireMark',
+            duration: 4,
+            modifiers: [
+                { stat: 'damageIncrease', type: 'percentage', value: 0.30 },
+                { stat: 'physicalDefense', type: 'percentage', value: -0.15 },
+                { stat: 'magicDefense', type: 'percentage', value: -0.15 }
+            ]
+        }
+    }
+};
+// --- ▲ [신규] 집중 포화 테스트 데이터 추가 ▲ ---
+
 const grades = ['NORMAL', 'RARE', 'EPIC', 'LEGENDARY'];
 
 // 1. 데미지 계수 테스트
@@ -164,5 +216,34 @@ for (const grade of grades) {
     }
 }
 // --- ▲ [신규] 관통 사격 테스트 로직 추가 ▲ ---
+
+// --- ▼ [신규] 집중 포화 테스트 로직 추가 ▼ ---
+for (const grade of grades) {
+    const skill = skillModifierEngine.getModifiedSkill(focusFireBase[grade], grade);
+
+    const expectedAmount = grade === 'LEGENDARY' ? 1 : 2;
+    const expectedDuration = grade === 'LEGENDARY' ? 4 : 3;
+
+    assert.strictEqual(skill.resourceCost.amount, expectedAmount, `Focus Fire resource cost failed for grade ${grade}`);
+    assert.strictEqual(skill.effect.duration, expectedDuration, `Focus Fire duration failed for grade ${grade}`);
+
+    if (grade !== 'NORMAL') {
+        const mods = Array.isArray(skill.effect.modifiers) ? skill.effect.modifiers : [skill.effect.modifiers];
+        const dmgMod = mods.find(m => m.stat === 'damageIncrease');
+        const expectedDmg = grade === 'RARE' ? 0.20 : grade === 'EPIC' ? 0.25 : 0.30;
+        assert(dmgMod && Math.abs(dmgMod.value - expectedDmg) < 1e-6, `Focus Fire damage modifier failed for grade ${grade}`);
+
+        if (grade === 'EPIC' || grade === 'LEGENDARY') {
+            const defMod = mods.find(m => m.stat === 'physicalDefense');
+            const expectedDef = grade === 'EPIC' ? -0.10 : -0.15;
+            assert(defMod && Math.abs(defMod.value - expectedDef) < 1e-6, `Focus Fire physical defense mod failed for grade ${grade}`);
+        }
+        if (grade === 'LEGENDARY') {
+            const mdefMod = mods.find(m => m.stat === 'magicDefense');
+            assert(mdefMod && Math.abs(mdefMod.value + 0.15) < 1e-6, 'Focus Fire magic defense mod failed for LEGENDARY');
+        }
+    }
+}
+// --- ▲ [신규] 집중 포화 테스트 로직 추가 ▲ ---
 
 console.log('Gunner skills integration test passed.');


### PR DESCRIPTION
## Summary
- add `focusFireMark` debuff for exposing enemy weakness
- introduce `focusFire` skill with scaling damage boost and defense reduction
- cover gunner integration tests for the new skill

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `node tests/gunner_skill_integration_test.js`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68930b0ef64c8327b7f7f1f84e35f10a