### PR TITLE
feat(ai): improve skill pathing and scoring

### DIFF
--- a/src/ai/nodes/FindBestSkillByScoreNode.js
+++ b/src/ai/nodes/FindBestSkillByScoreNode.js
@@ -25,7 +25,7 @@ class FindBestSkillByScoreNode extends Node {
         const enemies = blackboard.get('enemyUnits') || [];
 
         let bestSkill = null;
-        let maxScore = -1;
+        let maxScore = -Infinity;
 
         for (const instanceId of equippedSkillInstances) {
             if (!instanceId || usedSkills.has(instanceId)) continue;
@@ -35,6 +35,9 @@ class FindBestSkillByScoreNode extends Node {
 
             if (this.skillEngine.canUseSkill(unit, skillData)) {
                 const currentScore = await this.skillScoreEngine.calculateScore(unit, skillData, target, allies, enemies);
+                if (currentScore <= 0) {
+                    continue;
+                }
                 if (currentScore > maxScore) {
                     maxScore = currentScore;
                     bestSkill = { skillData, instanceId };

--- a/src/ai/nodes/MoveToUseSkillNode.js
+++ b/src/ai/nodes/MoveToUseSkillNode.js
@@ -1,0 +1,68 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { getReachableTiles } from '../../game/utils/GridEngine.js';
+import MoveToTargetNode from './MoveToTargetNode.js';
+
+class MoveToUseSkillNode extends Node {
+    constructor(engines = {}) {
+        super();
+        this.pathfinderEngine = engines.pathfinderEngine;
+        this.formationEngine = engines.formationEngine;
+        this.moveNode = new MoveToTargetNode(engines);
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+        const skill = blackboard.get('currentSkillData');
+        const target = blackboard.get('skillTarget');
+        if (!skill || !target) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '스킬 또는 타겟 없음');
+            return NodeState.FAILURE;
+        }
+
+        const skillRange = skill.range ?? 1;
+        const moveRange = unit.finalStats.movement || 0;
+        const start = { col: unit.gridX, row: unit.gridY };
+        const targetPos = { col: target.gridX, row: target.gridY };
+
+        const reachableTiles = getReachableTiles(start, moveRange, this.formationEngine.grid);
+
+        const potentialDestinations = [];
+        for (const tile of reachableTiles) {
+            const distance = Math.abs(tile.col - targetPos.col) + Math.abs(tile.row - targetPos.row);
+            if (distance <= skillRange) {
+                const pathLength = Math.abs(tile.col - start.col) + Math.abs(tile.row - start.row);
+                potentialDestinations.push({ tile, distance, pathLength });
+            }
+        }
+
+        if (potentialDestinations.length === 0) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, `스킬 [${skill.name}] 사용 위치 없음`);
+            return NodeState.FAILURE;
+        }
+
+        potentialDestinations.sort((a, b) => {
+            if (a.pathLength !== b.pathLength) {
+                return a.pathLength - b.pathLength;
+            }
+            return a.distance - b.distance;
+        });
+
+        const best = potentialDestinations[0].tile;
+        const path = this.pathfinderEngine.findPath(unit, start, { col: best.col, row: best.row });
+
+        if (path) {
+            blackboard.set('movementPath', path);
+            const result = await this.moveNode.evaluate(unit, blackboard);
+            if (result === NodeState.SUCCESS) {
+                debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skill.name}] 사용 위치로 이동`);
+                return NodeState.SUCCESS;
+            }
+        }
+
+        debugAIManager.logNodeResult(NodeState.FAILURE, '경로 탐색 실패');
+        return NodeState.FAILURE;
+    }
+}
+
+export default MoveToUseSkillNode;

--- a/src/game/utils/GridEngine.js
+++ b/src/game/utils/GridEngine.js
@@ -61,3 +61,46 @@ export class GridEngine {
         return this.gridCells.find(cell => cell.col === col && cell.row === row);
     }
 }
+
+/**
+ * 시작 위치에서 이동력 범위 내에 도달 가능한 모든 타일을 반환합니다.
+ * @param {{col:number,row:number}} start 시작 타일 좌표
+ * @param {number} moveRange 이동력(칸 수)
+ * @param {object} grid 탐색할 그리드 객체
+ * @returns {Array<{col:number,row:number}>}
+ */
+export function getReachableTiles(start, moveRange, grid) {
+    if (!grid) return [];
+
+    const visited = new Set();
+    const queue = [{ col: start.col, row: start.row, dist: 0 }];
+    const tiles = [];
+
+    visited.add(`${start.col},${start.row}`);
+
+    while (queue.length > 0) {
+        const { col, row, dist } = queue.shift();
+        tiles.push({ col, row });
+        if (dist >= moveRange) continue;
+
+        const directions = [
+            { x: 0, y: 1 },
+            { x: 0, y: -1 },
+            { x: 1, y: 0 },
+            { x: -1, y: 0 }
+        ];
+
+        for (const dir of directions) {
+            const nc = col + dir.x;
+            const nr = row + dir.y;
+            const key = `${nc},${nr}`;
+            if (visited.has(key)) continue;
+            const cell = grid.getCell(nc, nr);
+            if (!cell || cell.isOccupied) continue;
+            visited.add(key);
+            queue.push({ col: nc, row: nr, dist: dist + 1 });
+        }
+    }
+
+    return tiles;
+}

--- a/src/game/utils/ItemFactory.js
+++ b/src/game/utils/ItemFactory.js
@@ -55,7 +55,7 @@ class ItemFactory {
             { type: 'prefix', data: diceEngine.getRandomElement(itemAffixes.prefixes) },
             { type: 'suffix', data: diceEngine.getRandomElement(itemAffixes.suffixes) },
             { type: 'mbti', data: this._getRandomMbtiEffect() },
-            { type: 'sockets', data: { count: diceEngine.rollWithAdvantage(0, 3, 1) } }
+            { type: 'sockets', data: { count: Math.max(1, diceEngine.rollWithAdvantage(0, 3, 1)) } }
         ];
 
         // 3. 옵션 풀을 무작위로 섞고 등급에 맞는 수만큼 선택


### PR DESCRIPTION
## Summary
- add `MoveToUseSkillNode` that finds optimal tile to cast skills and moves unit there
- skip skills with non-positive score during evaluation
- expose `getReachableTiles` helper and ensure socket option always yields at least one slot

## Testing
- `for f in tests/*_test.js tests/*integration_test.js; do echo "Running $f"; node $f >/tmp/testlog && tail -n 1 /tmp/testlog; done`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68931007bb8c8327867176997553a184