### PR TITLE
feat: improve AI attack flow and pathfinding

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -9,11 +9,11 @@ import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import IsHealthBelowThresholdNode from '../nodes/IsHealthBelowThresholdNode.js';
 import FindTargetNode from '../nodes/FindTargetNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
-import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
 import UseSkillNode from '../nodes/UseSkillNode.js';
 import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 import { NodeState } from '../nodes/Node.js';
+import MoveToUseSkillNode from '../nodes/MoveToUseSkillNode.js';
 
 /**
  * MeleeAI: 근접 공격형 AI 행동 트리 (개선 버전)
@@ -48,9 +48,7 @@ function createMeleeAI(engines = {}) {
             ]),
             new SequenceNode([
                 new HasNotMovedNode(),
-                new FindPathToSkillRangeNode(engines),
-                new MoveToTargetNode(engines),
-                new IsSkillInRangeNode(engines),
+                new MoveToUseSkillNode(engines),
                 new UseSkillNode(engines)
             ])
         ])

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -7,11 +7,11 @@ import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 import FindTargetBySkillTypeNode from '../nodes/FindTargetBySkillTypeNode.js';
 import IsSkillInRangeNode from '../nodes/IsSkillInRangeNode.js';
 import UseSkillNode from '../nodes/UseSkillNode.js';
-import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import IsTargetTooCloseNode from '../nodes/IsTargetTooCloseNode.js';
 import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import MoveToUseSkillNode from '../nodes/MoveToUseSkillNode.js';
 
 function createRangedAI(engines = {}) {
     // --- 공통 사용 브랜치 ---
@@ -19,9 +19,7 @@ function createRangedAI(engines = {}) {
         new SequenceNode([new IsSkillInRangeNode(engines), new UseSkillNode(engines)]),
         new SequenceNode([
             new HasNotMovedNode(),
-            new FindPathToSkillRangeNode(engines),
-            new MoveToTargetNode(engines),
-            new IsSkillInRangeNode(engines),
+            new MoveToUseSkillNode(engines),
             new UseSkillNode(engines)
         ])
     ]);

--- a/src/ai/nodes/MoveToUseSkillNode.js
+++ b/src/ai/nodes/MoveToUseSkillNode.js
@@ -1,13 +1,11 @@
 import Node, { NodeState } from './Node.js';
 import { debugAIManager } from '../../game/debug/DebugAIManager.js';
-import { getReachableTiles } from '../../game/utils/GridEngine.js';
 import MoveToTargetNode from './MoveToTargetNode.js';
 
 class MoveToUseSkillNode extends Node {
     constructor(engines = {}) {
         super();
         this.pathfinderEngine = engines.pathfinderEngine;
-        this.formationEngine = engines.formationEngine;
         this.moveNode = new MoveToTargetNode(engines);
     }
 
@@ -20,44 +18,17 @@ class MoveToUseSkillNode extends Node {
             return NodeState.FAILURE;
         }
 
-        const skillRange = skill.range ?? 1;
-        const moveRange = unit.finalStats.movement || 0;
-        const start = { col: unit.gridX, row: unit.gridY };
-        const targetPos = { col: target.gridX, row: target.gridY };
-
-        const reachableTiles = getReachableTiles(start, moveRange, this.formationEngine.grid);
-
-        const potentialDestinations = [];
-        for (const tile of reachableTiles) {
-            const distance = Math.abs(tile.col - targetPos.col) + Math.abs(tile.row - targetPos.row);
-            if (distance <= skillRange) {
-                const pathLength = Math.abs(tile.col - start.col) + Math.abs(tile.row - start.row);
-                potentialDestinations.push({ tile, distance, pathLength });
-            }
-        }
-
-        if (potentialDestinations.length === 0) {
+        const path = this.pathfinderEngine.findBestPathToAttack(unit, skill, target);
+        if (!path) {
             debugAIManager.logNodeResult(NodeState.FAILURE, `스킬 [${skill.name}] 사용 위치 없음`);
             return NodeState.FAILURE;
         }
 
-        potentialDestinations.sort((a, b) => {
-            if (a.pathLength !== b.pathLength) {
-                return a.pathLength - b.pathLength;
-            }
-            return a.distance - b.distance;
-        });
-
-        const best = potentialDestinations[0].tile;
-        const path = this.pathfinderEngine.findPath(unit, start, { col: best.col, row: best.row });
-
-        if (path) {
-            blackboard.set('movementPath', path);
-            const result = await this.moveNode.evaluate(unit, blackboard);
-            if (result === NodeState.SUCCESS) {
-                debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skill.name}] 사용 위치로 이동`);
-                return NodeState.SUCCESS;
-            }
+        blackboard.set('movementPath', path);
+        const result = await this.moveNode.evaluate(unit, blackboard);
+        if (result === NodeState.SUCCESS) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skill.name}] 사용 위치로 이동`);
+            return NodeState.SUCCESS;
         }
 
         debugAIManager.logNodeResult(NodeState.FAILURE, '경로 탐색 실패');

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -52,6 +52,20 @@ class SkillScoreEngine {
             });
         }
 
+        // 공격 스킬 기본 가중치 및 마무리 보너스
+        if (skillData.type === 'ACTIVE') {
+            baseScore *= 1.5;
+            if (target && target.currentHp < target.finalStats.hp * 0.4) {
+                situationScore += 20;
+                situationLogs.push('마무리:+20');
+            }
+        }
+
+        // 체력이 충분할 때 방어/지원 스킬 점수 감소
+        if ((skillData.type === 'BUFF' || skillData.type === 'AID') && unit.currentHp > unit.finalStats.hp * 0.8) {
+            baseScore *= 0.5;
+        }
+
         const lowHealthAllies = allies.filter(a => a.currentHp / a.finalStats.hp <= 0.5).length;
         if (lowHealthAllies > 0 && (skillData.tags.includes(SKILL_TAGS.HEAL) || skillData.tags.includes(SKILL_TAGS.AID))) {
             const bonus = lowHealthAllies * 15;


### PR DESCRIPTION
## Summary
- ensure melee and ranged AIs move then attack in one sequence
- add PathfinderEngine helper to choose best attack tile
- boost attack skills in SkillScoreEngine

## Testing
- `node tests/pathfinder_flyingmen_bug_test.js`
- `for f in tests/*_test.js; do node $f; done`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`
- `node tests/warrior_skill_integration_test.js | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68933268a0e08327a5a0980520e25343