### PR TITLE
Improve AI aggressiveness and fallback skills

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -14,6 +14,7 @@ import UseSkillNode from '../nodes/UseSkillNode.js';
 import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 import { NodeState } from '../nodes/Node.js';
 import MoveToUseSkillNode from '../nodes/MoveToUseSkillNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * MeleeAI: 근접 공격형 AI 행동 트리 (개선 버전)
@@ -77,8 +78,21 @@ function createMeleeAI(engines = {}) {
 
         // 4순위: 기본 공격 (가장 가까운 적)
         new SequenceNode([
-            new FindTargetNode(engines), // TargetManager의 기본 findNearestEnemy 사용
+            new FindTargetNode(engines),
             executeSkillBranch
+        ]),
+        // 5순위: 공격에 실패했다면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 6순위: 전진도 불가능하면 안전한 위치로 이동
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines),
+            new MoveToTargetNode(engines)
         ])
     ]);
 

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -12,6 +12,8 @@ import IsTargetTooCloseNode from '../nodes/IsTargetTooCloseNode.js';
 import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import MoveToUseSkillNode from '../nodes/MoveToUseSkillNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 function createRangedAI(engines = {}) {
     // --- 공통 사용 브랜치 ---
@@ -24,15 +26,19 @@ function createRangedAI(engines = {}) {
         ])
     ]);
     
-    // --- 기본 행동 (최후의 보루) ---
+    // --- 기본 행동 로직 ---
     const basicActionBranch = new SelectorNode([
-        // 1. 주 공격 로직
         new SequenceNode([
             new FindBestSkillByScoreNode(engines),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 2. 공격할 수 없으면 안전한 위치로 재배치
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/behaviors/createENFP_AI.js
+++ b/src/ai/behaviors/createENFP_AI.js
@@ -10,6 +10,8 @@ import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * ENFP: 활동가 아키타입 행동 트리 (거너)
@@ -51,10 +53,17 @@ function createENFP_AI(engines = {}) {
             executeSkillBranch
         ]),
 
-        // 3순위: 끊임없는 위치 변경 (재배치)
+        // 3순위: 공격에 실패했다면 적을 향해 전진
         new SequenceNode([
             new HasNotMovedNode(),
-            new FindSafeRepositionNode(engines), // 단순히 안전한 곳으로 계속 이동
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 4순위: 전진도 불가능하면 끊임없이 위치 변경 (재배치)
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
         ])
     ]);

--- a/src/ai/behaviors/createENTP_AI.js
+++ b/src/ai/behaviors/createENTP_AI.js
@@ -11,6 +11,8 @@ import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 // ✨ ENTP 전용으로 만든 신규 노드들을 import 합니다.
 import FindHighValueTargetNode from '../nodes/FindHighValueTargetNode.js';
 import FindPullPositionNode from '../nodes/FindPullPositionNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * ENTP: 변론가 아키타입 행동 트리
@@ -56,7 +58,14 @@ function createENTP_AI(engines = {}) {
             executeSkillBranch
         ]),
 
-        // 4순위: 모든 행동이 불가능할 때의 안전한 재배치
+        // 4순위: 모든 행동이 불가능했다면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 5순위: 전진도 실패했다면 안전한 재배치
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/behaviors/createESTJ_AI.js
+++ b/src/ai/behaviors/createESTJ_AI.js
@@ -13,6 +13,8 @@ import FindLowestHealthEnemyNode from '../nodes/FindLowestHealthEnemyNode.js';
 import FindSkillByTagNode from '../nodes/FindSkillByTagNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * ESTJ: 엄격한 관리자 아키타입 행동 트리 (전사)
@@ -63,7 +65,14 @@ function createESTJ_AI(engines = {}) {
                 ])
             ])
         ]),
-        // 2순위: 공격할 수 없다면 안전한 위치로 이동하여 턴을 낭비하지 않습니다.
+        // 2순위: 공격에 실패했다면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 3순위: 전진도 불가능할 때만 안전한 위치로 이동하여 턴을 낭비하지 않습니다.
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/behaviors/createESTP_AI.js
+++ b/src/ai/behaviors/createESTP_AI.js
@@ -12,6 +12,8 @@ import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import FindLowestHealthEnemyNode from '../nodes/FindLowestHealthEnemyNode.js';
 // 새로 만든 노드를 import 합니다.
 import IsHealthAboveThresholdNode from '../nodes/IsHealthAboveThresholdNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * ESTP: 모험을 즐기는 사업가 아키타입 행동 트리 (플라잉맨)
@@ -49,7 +51,14 @@ function createESTP_AI(engines = {}) {
             executeSkillBranch
         ]),
 
-        // 3순위: 최후의 수단으로 위치 재조정
+        // 3순위: 공격에 실패했다면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 4순위: 최후의 수단으로 위치 재조정
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -10,6 +10,8 @@ import UseSkillNode from '../nodes/UseSkillNode.js';
 import FindSafeHealingPositionNode from '../nodes/FindSafeHealingPositionNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 function createHealerAI(engines = {}) {
     // --- 공통 사용 브랜치 ---
@@ -29,13 +31,17 @@ function createHealerAI(engines = {}) {
     
     // --- 기본 행동 (최후의 보루) ---
     const basicActionBranch = new SelectorNode([
-        // 1. 아군 지원(힐/버프) 또는 적 공격(디버프/공격) 시도
         new SequenceNode([
             new FindBestSkillByScoreNode(engines),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
-        // 2. 할 수 있는 스킬이 없으면 안전한 위치로 재배치
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/behaviors/createINFJ_AI.js
+++ b/src/ai/behaviors/createINFJ_AI.js
@@ -11,6 +11,8 @@ import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import FindNearestAllyInDangerNode from '../nodes/FindNearestAllyInDangerNode.js';
 import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * INFJ: 옹호자 아키타입 행동 트리
@@ -61,7 +63,14 @@ function createINFJ_AI(engines = {}) {
             executeSkillBranch
         ]),
 
-        // 4순위: 안전한 위치로 재배치
+        // 4순위: 공격에 실패했다면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 5순위: 전진도 불가능하면 안전한 위치로 재배치
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/behaviors/createINFP_AI.js
+++ b/src/ai/behaviors/createINFP_AI.js
@@ -14,6 +14,8 @@ import FindEnemyMedicNode from '../nodes/FindEnemyMedicNode.js';
 import FindBuffedEnemyNode from '../nodes/FindBuffedEnemyNode.js';
 import FindNearestAllyInDangerNode from '../nodes/FindNearestAllyInDangerNode.js';
 import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * INFP: 중재자 아키타입 행동 트리
@@ -73,17 +75,28 @@ function createINFP_AI(engines = {}) {
 
         // 4순위: 안전한 기본 공격 (카이팅)
         new SequenceNode([
-            new FindTargetBySkillTypeNode(engines), // 일반적인 타겟 선정
+            new FindTargetBySkillTypeNode(engines),
             new SelectorNode([
-                 // 이미 안전하면 바로 공격
                 executeSkillBranch,
-                // 안전하지 않으면 카이팅 위치로 이동
                 new SequenceNode([
                     new HasNotMovedNode(),
                     new FindKitingPositionNode(engines),
                     new MoveToTargetNode(engines)
                 ])
             ])
+        ]),
+        // 5순위: 공격도 카이팅도 불가능하면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 6순위: 전진마저 불가능하면 안전한 위치로 후퇴
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines),
+            new MoveToTargetNode(engines)
         ])
     ]);
 

--- a/src/ai/behaviors/createINTJ_AI.js
+++ b/src/ai/behaviors/createINTJ_AI.js
@@ -13,6 +13,8 @@ import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import FindYinYangTargetNode from '../nodes/FindYinYangTargetNode.js';
 import FindUniqueDebuffTargetNode from '../nodes/FindUniqueDebuffTargetNode.js';
 import FindAllyMagicClusterNode from '../nodes/FindAllyMagicClusterNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * INTJ: 전략가 아키타입 행동 트리
@@ -58,12 +60,18 @@ function createINTJ_AI(engines = {}) {
             new MoveToTargetNode(engines)
         ]),
         
-        // 4순위: 기본 원거리 공격 또는 안전한 위치로 재배치
+        // 4순위: 기본 원거리 공격 → 전진 → 재배치
         new SelectorNode([
             new SequenceNode([
                 new FindBestSkillByScoreNode(engines),
                 new FindYinYangTargetNode(engines),
                 executeSkillBranch
+            ]),
+            new SequenceNode([
+                new HasNotMovedNode(),
+                new FindTargetNode(engines),
+                new FindPathToTargetNode(engines),
+                new MoveToTargetNode(engines)
             ]),
             new SequenceNode([
                 new HasNotMovedNode(),

--- a/src/ai/behaviors/createINTP_AI.js
+++ b/src/ai/behaviors/createINTP_AI.js
@@ -10,6 +10,8 @@ import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import FindComboSkillNode from '../nodes/FindComboSkillNode.js'; // ✨ 새로 추가될 노드
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * INTP: 논리술사 아키타입 행동 트리
@@ -46,7 +48,14 @@ function createINTP_AI(engines = {}) {
             executeSkillBranch
         ]),
 
-        // 3순위: 이동만 하기
+        // 3순위: 공격에 실패했다면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 4순위: 전진도 불가능하면 안전한 위치로 이동
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/behaviors/createISFJ_AI.js
+++ b/src/ai/behaviors/createISFJ_AI.js
@@ -10,6 +10,8 @@ import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import FindLowestHealthAllyNode from '../nodes/FindLowestHealthAllyNode.js';
 import FindAllyToBuffNode from '../nodes/FindAllyToBuffNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * ISFJ: 용감한 수호자 아키타입 행동 트리 (메딕)
@@ -49,7 +51,14 @@ function createISFJ_AI(engines = {}) {
             executeSkillBranch
         ]),
 
-        // 3순위: 안전한 위치로 재배치
+        // 3순위: 행동이 없다면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 4순위: 전진도 불가능하면 안전한 위치로 재배치
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/behaviors/createISFP_AI.js
+++ b/src/ai/behaviors/createISFP_AI.js
@@ -16,6 +16,8 @@ import FindKitingPositionNode from '../nodes/FindKitingPositionNode.js';
 import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
 // 새로 만든 노드를 import 합니다.
 import IsTargetHealthBelowThresholdNode from '../nodes/IsTargetHealthBelowThresholdNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * ISFP: 호기심 많은 예술가 아키타입 행동 트리 (고스트)
@@ -70,7 +72,14 @@ function createISFP_AI(engines = {}) {
             ])
         ]),
 
-        // 4순위: 소극적인 위치 재선정
+        // 4순위: 공격에 실패했다면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 5순위: 전진이 불가능하면 소극적인 위치 재선정
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/behaviors/createISTJ_AI.js
+++ b/src/ai/behaviors/createISTJ_AI.js
@@ -9,6 +9,8 @@ import UseSkillNode from '../nodes/UseSkillNode.js';
 import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * ISTJ: 청렴한 논리주의자 아키타입 행동 트리 (센티넬)
@@ -48,22 +50,30 @@ function createISTJ_AI(engines = {}) {
         new SequenceNode([
             new FindBestSkillByScoreNode(engines),
             new FindTargetBySkillTypeNode(engines),
-            new IsSkillInRangeNode(engines), // 사거리 내에 있을 때만 SUCCESS
-            new UseSkillNode(engines)       // 이동 없이 즉시 사용
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
         ]),
 
-        // 3순위: 초기 위치 선정 (아직 이동 안했을 경우)
-        new SequenceNode([
-            new HasNotMovedNode(),
-            new FindSafeRepositionNode(engines),
-            new MoveToTargetNode(engines)
-        ]),
-
-        // 4순위: 일반적인 근접 공격 (최후의 수단)
+        // 3순위: 일반적인 근접 공격 (이동 포함)
         new SequenceNode([
             new FindBestSkillByScoreNode(engines),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
+        ]),
+
+        // 4순위: 공격에 실패했다면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+
+        // 5순위: 전진도 불가능하면 안전한 위치로 이동
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindSafeRepositionNode(engines),
+            new MoveToTargetNode(engines)
         ]),
     ]);
 

--- a/src/ai/behaviors/createISTP_AI.js
+++ b/src/ai/behaviors/createISTP_AI.js
@@ -12,6 +12,8 @@ import FindLowestHealthEnemyNode from '../nodes/FindLowestHealthEnemyNode.js';
 import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
 import WasAttackedRecentlyNode from '../nodes/WasAttackedRecentlyNode.js';
 import FindAttackerNode from '../nodes/FindAttackerNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
+import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
 /**
  * ISTP: 만능 재주꾼 아키타입 행동 트리
@@ -51,7 +53,14 @@ function createISTP_AI(engines = {}) {
             executeSkillBranch
         ]),
 
-        // 3순위: 소극적인 위치 재선정
+        // 3순위: 공격 기회가 없다면 적을 향해 전진
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindTargetNode(engines),
+            new FindPathToTargetNode(engines),
+            new MoveToTargetNode(engines)
+        ]),
+        // 4순위: 전진도 어렵다면 소극적인 위치 재선정
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/nodes/FindBestSkillByScoreNode.js
+++ b/src/ai/nodes/FindBestSkillByScoreNode.js
@@ -4,6 +4,8 @@ import { ownedSkillsManager } from '../../game/utils/OwnedSkillsManager.js';
 import { skillInventoryManager } from '../../game/utils/SkillInventoryManager.js';
 import { skillEngine } from '../../game/utils/SkillEngine.js';
 import { skillScoreEngine } from '../../game/utils/SkillScoreEngine.js';
+import { activeSkills } from '../../game/data/skills/active.js';
+import { debugLogEngine } from '../../game/utils/DebugLogEngine.js';
 
 /**
  * 사용 가능한 스킬 중 SkillScoreEngine으로 계산된 점수가 가장 높은 스킬을 찾는 노드
@@ -41,6 +43,18 @@ class FindBestSkillByScoreNode extends Node {
                 if (currentScore > maxScore) {
                     maxScore = currentScore;
                     bestSkill = { skillData, instanceId };
+                }
+            }
+        }
+
+        if (maxScore <= 0) {
+            const attackSkillData = activeSkills.attack?.NORMAL || skillInventoryManager.getSkillData('attack', 'NORMAL');
+            if (attackSkillData && this.skillEngine.canUseSkill(unit, attackSkillData)) {
+                const attackInstance = skillInventoryManager.getInventory().find(inst => inst.skillId === 'attack');
+                if (attackInstance) {
+                    bestSkill = { skillData: attackSkillData, instanceId: attackInstance.instanceId };
+                    maxScore = 1;
+                    debugLogEngine.log(this.name, `[${unit.instanceName}]이(가) 다른 스킬 대신 기본 '공격'을 선택합니다.`);
                 }
             }
         }

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -61,11 +61,6 @@ class SkillScoreEngine {
             }
         }
 
-        // 체력이 충분할 때 방어/지원 스킬 점수 감소
-        if ((skillData.type === 'BUFF' || skillData.type === 'AID') && unit.currentHp > unit.finalStats.hp * 0.8) {
-            baseScore *= 0.5;
-        }
-
         const lowHealthAllies = allies.filter(a => a.currentHp / a.finalStats.hp <= 0.5).length;
         if (lowHealthAllies > 0 && (skillData.tags.includes(SKILL_TAGS.HEAL) || skillData.tags.includes(SKILL_TAGS.AID))) {
             const bonus = lowHealthAllies * 15;


### PR DESCRIPTION
## Summary
- Remove early HP penalty so AI values buffs regardless of health
- Add default attack fallback when no other skill scores positively
- Advance toward enemies before repositioning across AIs to encourage aggression

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689347cc2a308327a8413f2271661537