### PR TITLE
feat: track AI threat state for smarter repositioning

### DIFF
--- a/src/ai/Blackboard.js
+++ b/src/ai/Blackboard.js
@@ -21,6 +21,7 @@ class Blackboard {
         this.set('enemiesInAttackRange', []);
 
         // --- ⚔️ 전술적 상황 판단 정보 ---
+        // ✨ [추가] AI가 현재 위협받고 있는지 여부를 나타내는 플래그를 추가합니다.
         this.set('isThreatened', false);
         this.set('squadAdvantage', 0);
         this.set('enemyHealerUnit', null);

--- a/src/ai/nodes/FindSafeRepositionNode.js
+++ b/src/ai/nodes/FindSafeRepositionNode.js
@@ -16,8 +16,17 @@ class FindSafeRepositionNode extends Node {
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
         const enemies = blackboard.get('enemyUnits');
+
+        // ✨ [핵심 추가] 현재 위협받고 있는지(isThreatened) 확인하는 로직
+        const isThreatened = blackboard.get('isThreatened');
+
+        // 만약 적이 있는데 위협받는 상황이 아니라면, 굳이 후퇴하지 않고 전투를 지속합니다.
+        if (enemies && enemies.length > 0 && !isThreatened) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '전투 중 불필요한 재배치는 수행하지 않음');
+            return NodeState.FAILURE;
+        }
+
         if (this.narrationEngine) {
-            const isThreatened = blackboard.get('isThreatened');
             if (isThreatened) {
                 this.narrationEngine.show(`${unit.instanceName}이(가) 위협을 피해 안전한 위치로 후퇴합니다.`);
             } else {
@@ -49,8 +58,8 @@ class FindSafeRepositionNode extends Node {
             const distToNearestEnemy = nearestEnemy ?
                 Math.abs(cell.col - nearestEnemy.gridX) + Math.abs(cell.row - nearestEnemy.gridY) : 0;
 
-            // 안전 거리 확보, 이동 최소화, 교전 거리 유지 간의 균형을 맞춥니다.
-            const score = (minEnemyDist * 1.5) - (travelDist * 0.5) - (distToNearestEnemy * 0.8);
+            // 🔁 [수정] 점수 계산 로직을 수정하여 너무 멀리 도망가지 않도록 합니다.
+            const score = (minEnemyDist * 1.2) - (travelDist * 0.5) - (distToNearestEnemy * 1.2);
 
             if (score > maxScore) {
                 maxScore = score;

--- a/src/ai/nodes/IsTargetTooCloseNode.js
+++ b/src/ai/nodes/IsTargetTooCloseNode.js
@@ -17,6 +17,8 @@ class IsTargetTooCloseNode extends Node {
         const nearestEnemy = this.targetManager.findNearestEnemy(unit, enemyUnits);
 
         if (!nearestEnemy) {
+            // ✨ 주변에 적이 없으면 위협 상태가 아니므로 false로 설정합니다.
+            blackboard.set('isThreatened', false);
             debugAIManager.logNodeResult(NodeState.FAILURE, "주변에 위협적인 적 없음");
             return NodeState.FAILURE; // 주변에 적이 없으면 안전
         }
@@ -27,12 +29,19 @@ class IsTargetTooCloseNode extends Node {
             // ✨ [핵심 변경] 어떤 적이 위협적인지 블랙보드에 기록합니다.
             // FindKitingPositionNode가 이 정보를 사용하여 "누구로부터" 도망칠지 결정합니다.
             blackboard.set('threateningUnit', nearestEnemy);
-            debugAIManager.logNodeResult(NodeState.SUCCESS, `가장 가까운 적 '${nearestEnemy.instanceName}'이 위험거리(${this.dangerZone}) 내에 있음!`);
+            // ✨ [핵심 추가] 적이 너무 가까우므로 위협 상태임을 블랙보드에 기록합니다.
+            blackboard.set('isThreatened', true);
+            debugAIManager.logNodeResult(
+                NodeState.SUCCESS,
+                `가장 가까운 적 '${nearestEnemy.instanceName}'이 위험거리(${this.dangerZone}) 내에 있음!`
+            );
             return NodeState.SUCCESS; // 너무 가까움!
         }
 
         // 위협적인 적이 없으므로 정보를 초기화합니다.
         blackboard.set('threateningUnit', null);
+        // ✨ 적이 안전거리에 있으므로 위협 상태가 아님을 명시적으로 기록합니다.
+        blackboard.set('isThreatened', false);
         debugAIManager.logNodeResult(NodeState.FAILURE, `가장 가까운 적 '${nearestEnemy.instanceName}'과의 거리가 안전함`);
         return NodeState.FAILURE; // 안전함
     }


### PR DESCRIPTION
## Summary
- add `isThreatened` flag to AI blackboard
- mark threat status when enemies get too close
- avoid unnecessary repositioning unless under threat and tweak escape scoring

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689349b2161c8327be60c70a7c94464a