### PR TITLE
Refine ranged kiting and healer fallback behaviors

### DIFF
--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -49,7 +49,8 @@ function createRangedAI(engines = {}) {
     // --- MBTI 기반 특수 행동들 ---
     const kitingBehavior = new SequenceNode([
         new HasNotMovedNode(),
-        new IsTargetTooCloseNode({ ...engines, dangerZone: 2 }),
+        // 적이 바로 인접했을 때만 "위협"으로 간주하도록 조건을 완화합니다.
+        new IsTargetTooCloseNode({ ...engines, dangerZone: 1 }),
         new FindKitingPositionNode(engines),
         new MoveToTargetNode(engines)
     ]);

--- a/src/ai/behaviors/createHealerAI.js
+++ b/src/ai/behaviors/createHealerAI.js
@@ -10,6 +10,7 @@ import UseSkillNode from '../nodes/UseSkillNode.js';
 import FindSafeHealingPositionNode from '../nodes/FindSafeHealingPositionNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
+// 적이 없을 때는 가장 가까운 적을 찾아 공격하기 위해 사용됩니다.
 import FindTargetNode from '../nodes/FindTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
 
@@ -29,19 +30,22 @@ function createHealerAI(engines = {}) {
         ])
     ]);
     
-    // --- 기본 행동 (최후의 보루) ---
+    // --- 기본 행동 로직 ---
     const basicActionBranch = new SelectorNode([
+        // 1순위: 지원할 아군을 찾고, 힐/버프/디버프 등 스킬을 사용합니다.
         new SequenceNode([
             new FindBestSkillByScoreNode(engines),
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
+        // 2순위: 지원할 대상이 없다면, 가장 가까운 적을 공격하기 위해 이동합니다.
         new SequenceNode([
             new HasNotMovedNode(),
             new FindTargetNode(engines),
             new FindPathToTargetNode(engines),
             new MoveToTargetNode(engines)
         ]),
+        // 3순위: 공격할 적도 없다면 안전한 위치로 재배치합니다.
         new SequenceNode([
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),

--- a/src/ai/nodes/FindSafeHealingPositionNode.js
+++ b/src/ai/nodes/FindSafeHealingPositionNode.js
@@ -47,7 +47,8 @@ class FindSafeHealingPositionNode extends Node {
             }
 
             const travelDist = Math.abs(cell.col - unit.gridX) + Math.abs(cell.row - unit.gridY);
-            const score = minEnemyDist - travelDist * 0.5;
+            // 아군과 지나치게 멀어지는 위치에는 페널티를 주어, 적당히 가까운 곳을 선호합니다.
+            const score = minEnemyDist - (travelDist * 0.5) - (distToAlly * 0.2);
             if (score > maxScore) {
                 maxScore = score;
                 bestCell = cell;


### PR DESCRIPTION
## Summary
- Relax ranged AI kiting trigger to only retreat when enemies are adjacent
- Allow healer AI to chase the nearest enemy when no ally needs support
- Penalize healer movement options that stray too far from the ally being healed

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 -m http.server 8000 &`; `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68934b3a0498832781df2e6551f449ea