### PR TITLE
fix: guard paladins guide and harmonize icon keys

### DIFF
--- a/src/game/utils/IconManager.js
+++ b/src/game/utils/IconManager.js
@@ -108,18 +108,21 @@ export class IconManager {
         buffs.forEach((effect, index) => {
             const effectDef = statusEffects[effect.id] || skillCardDatabase[effect.id];
 
-            // ▼▼▼ [수정] 아이콘 경로 확인 및 리포팅 로직 ▼▼▼
+            // ▼▼▼ [수정] 아이콘 경로 및 키 결정 로직 ▼▼▼
             let iconKey = effect.id;
-            let iconPath = effectDef?.iconPath || effect.illustrationPath;
+            let iconPath =
+                effectDef?.iconPath ||
+                effect.illustrationPath ||
+                effectDef?.illustrationPath;
 
-            // PlaceholderManager를 통해 최종 경로를 얻고, 없으면 리포트합니다.
             const expectedPath = `assets/images/status-effects/${effect.id}.png`;
             iconPath = placeholderManager.getPath(iconPath, expectedPath);
 
-            // illustrationPath가 있을 경우 key를 경로에서 추출
-            if (iconPath && iconPath !== 'assets/images/placeholder.png') {
+            if (iconPath && iconPath.includes('/')) {
                 iconKey = iconPath.split('/').pop().split('.')[0];
-            } else if (!this.scene.textures.exists(iconKey)) {
+            }
+
+            if (!this.scene.textures.exists(iconKey)) {
                 iconKey = 'placeholder';
             }
             // ▲▲▲ [수정] 완료 ▲▲▲
@@ -165,16 +168,18 @@ export class IconManager {
         debuffs.forEach((effect, index) => {
             const effectDef = statusEffects[effect.id] || skillCardDatabase[effect.id];
 
-            // ▼▼▼ [수정] 아이콘 경로 확인 및 리포팅 로직 (디버프에도 동일하게 적용) ▼▼▼
+            // ▼▼▼ [수정] 디버프 아이콘에도 동일한 키 결정 로직 적용 ▼▼▼
             let iconKey = effect.id;
             let iconPath = effectDef?.iconPath;
 
             const expectedPath = `assets/images/status-effects/${effect.id}.png`;
             iconPath = placeholderManager.getPath(iconPath, expectedPath);
 
-            if (iconPath && iconPath !== 'assets/images/placeholder.png') {
+            if (iconPath && iconPath.includes('/')) {
                 iconKey = iconPath.split('/').pop().split('.')[0];
-            } else if (!this.scene.textures.exists(iconKey)) {
+            }
+
+            if (!this.scene.textures.exists(iconKey)) {
                 iconKey = 'placeholder';
             }
             // ▲▲▲ [수정] 완료 ▲▲▲

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -577,7 +577,12 @@ class SkillEffectProcessor {
     
         // --- ▼ [신규] '팔라딘의 인도' 패시브 로직 추가 ▼ ---
         let finalEffect = skill.effect;
-        if (unit.classPassive?.id === 'paladinsGuide' && skill.tags?.includes(SKILL_TAGS.AURA) && finalEffect?.modifiers) {
+        if (
+            unit.classPassive?.id === 'paladinsGuide' &&
+            skill.tags?.includes(SKILL_TAGS.AURA) &&
+            finalEffect &&
+            finalEffect.modifiers
+        ) {
             // 원본 effect 객체를 변경하지 않기 위해 깊은 복사를 수행합니다.
             finalEffect = JSON.parse(JSON.stringify(skill.effect));
 


### PR DESCRIPTION
## Summary
- ensure Paladin's Guide passive only buffs skills with valid modifiers
- unify buff/debuff icon key resolution using file names

## Testing
- `for f in tests/*_test.js; do echo "Running $f"; node "$f" | tail -n 1; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68934ef7f30883278429e313b47ca9d4