### PR TITLE
feat: add second-stage reinforcement learning data

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,28 +1,39 @@
 import StartGame from './game/main.js';
 import { archetypeMemoryEngine } from './game/utils/ArchetypeMemoryEngine.js';
 
-// [1차 강화학습 데이터] - 2025-08-05 로그 기반
-const learnedData_v1 = {
-    // ESTJ는 '메딕'과 '거너'를 상대로 근접 공격 선호도를 대폭 상향
+// [2차 강화학습 데이터] - 2025-08-06 로그 기반
+const learnedData_v2 = {
+    // ESTJ: 메딕/거너 선호도는 유지하되, 자신을 공격하는 전사/다크나이트에 대한 대응 가중치 소폭 상향
     'ESTJ': {
-        'target_medic': { 'melee_weight': 1.4 }, // 메딕 대상 근접 공격 가중치 +40%
-        'target_gunner': { 'melee_weight': 1.3 }, // 거너 대상 근접 공격 가중치 +30%
+        'target_medic': { 'melee_weight': 1.4 },
+        'target_gunner': { 'melee_weight': 1.3 },
+        'target_warrior': { 'melee_weight': 1.1 }, // 근접 위협 대응력 +10%
+        'target_darkKnight': { 'melee_weight': 1.1 }
     },
-    // ESFJ는 '전사'와 '센티넬'을 상대로 근접 공격을 약간 기피하고, 버프/힐을 선호하게 유도
+    // ESFJ: 탱커(센티넬, 전사) 공격 선호도를 낮추고, 지원가(메딕, 역병의사) 공격 선호도 상향
     'ESFJ': {
-        'target_warrior': { 'melee_weight': 0.85 }, // 전사 대상 근접 공격 가중치 -15%
-        'target_sentinel': { 'melee_weight': 0.8 }, // 센티넬 대상 근접 공격 가중치 -20%
+        'target_sentinel': { 'melee_weight': 0.7 }, // 탱커 공격 가중치 -30%
+        'target_warrior': { 'melee_weight': 0.75 },
+        'target_medic': { 'melee_weight': 1.2 }, // 지원가 공격 가중치 +20%
+        'target_plagueDoctor': { 'melee_weight': 1.2 }
     },
-    // INFP는 위협적인 '전사'를 상대로 디버프(마법) 사용 선호도 상향
+    // INFP: 적 메딕과 팔라딘을 상대로 마법(디버프, 특히 '치료 금지') 사용 선호도 대폭 상향
     'INFP': {
-        'target_warrior': { 'magic_weight': 1.25 }, // 전사 대상 마법(디버프) 가중치 +25%
+        'target_warrior': { 'magic_weight': 1.25 },
+        'target_medic': { 'magic_weight': 1.5 }, // 메딕 대상 마법(치료 금지) 가중치 +50%
+        'target_paladin': { 'magic_weight': 1.4 }  // 팔라딘 대상 마법 가중치 +40%
+    },
+    // ENFP(거너): 원거리에서 이미 멀리 있는 적에 대한 공격 선호도를 낮춰, 불필요한 KINETIC 스킬 낭비 방지
+    'ENFP': {
+        'target_nanomancer': { 'ranged_weight': 0.8 }, // 원거리 딜러 대상 원거리 공격 가중치 -20%
+        'target_esper': { 'ranged_weight': 0.8 }
     }
 };
 
-// 학습 데이터 적용
+// 학습 데이터 적용 함수 (기존과 동일)
 async function applyLearnedData() {
-    console.log('AI 강화학습 v1 데이터를 적용합니다...');
-    for (const [mbti, memory] of Object.entries(learnedData_v1)) {
+    console.log('AI 강화학습 v2 데이터를 적용합니다...');
+    for (const [mbti, memory] of Object.entries(learnedData_v2)) {
         await archetypeMemoryEngine.updateMemory(mbti, memory);
     }
     console.log('모든 아키타입의 집단 기억이 성공적으로 업데이트되었습니다!');
@@ -32,3 +43,4 @@ document.addEventListener('DOMContentLoaded', async () => {
     await applyLearnedData();
     StartGame('game-container');
 });
+


### PR DESCRIPTION
## Summary
- replace v1 training data with new `learnedData_v2` weights for ESTJ, ESFJ, INFP and ENFP
- update learning application routine for the new dataset

## Testing
- `for f in tests/*.js; do node $f >/tmp/test.log && tail -n 2 /tmp/test.log; done`
- `python3 -m http.server 8000 & pid=$!; sleep 1; curl http://localhost:8000/debug.html | head -n 20; kill $pid`


------
https://chatgpt.com/codex/tasks/task_e_689358704ce08327a22535627491126e