### PR TITLE
refactor dynamic passive application

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,39 +1,43 @@
 import StartGame from './game/main.js';
 import { archetypeMemoryEngine } from './game/utils/ArchetypeMemoryEngine.js';
 
-// [2차 강화학습 데이터] - 2025-08-06 로그 기반
-const learnedData_v2 = {
-    // ESTJ: 메딕/거너 선호도는 유지하되, 자신을 공격하는 전사/다크나이트에 대한 대응 가중치 소폭 상향
+// [3차 강화학습 데이터] - 2025-08-06 로그 기반
+const learnedData_v3 = {
+    // 기존 강화학습 데이터 유지
     'ESTJ': {
         'target_medic': { 'melee_weight': 1.4 },
         'target_gunner': { 'melee_weight': 1.3 },
-        'target_warrior': { 'melee_weight': 1.1 }, // 근접 위협 대응력 +10%
+        'target_warrior': { 'melee_weight': 1.1 },
         'target_darkKnight': { 'melee_weight': 1.1 }
     },
-    // ESFJ: 탱커(센티넬, 전사) 공격 선호도를 낮추고, 지원가(메딕, 역병의사) 공격 선호도 상향
     'ESFJ': {
-        'target_sentinel': { 'melee_weight': 0.7 }, // 탱커 공격 가중치 -30%
+        'target_sentinel': { 'melee_weight': 0.7 },
         'target_warrior': { 'melee_weight': 0.75 },
-        'target_medic': { 'melee_weight': 1.2 }, // 지원가 공격 가중치 +20%
+        'target_medic': { 'melee_weight': 1.2 },
         'target_plagueDoctor': { 'melee_weight': 1.2 }
     },
-    // INFP: 적 메딕과 팔라딘을 상대로 마법(디버프, 특히 '치료 금지') 사용 선호도 대폭 상향
     'INFP': {
         'target_warrior': { 'magic_weight': 1.25 },
-        'target_medic': { 'magic_weight': 1.5 }, // 메딕 대상 마법(치료 금지) 가중치 +50%
-        'target_paladin': { 'magic_weight': 1.4 }  // 팔라딘 대상 마법 가중치 +40%
+        'target_medic': { 'magic_weight': 1.5 },
+        'target_paladin': { 'magic_weight': 1.4 }
     },
-    // ENFP(거너): 원거리에서 이미 멀리 있는 적에 대한 공격 선호도를 낮춰, 불필요한 KINETIC 스킬 낭비 방지
-    'ENFP': {
-        'target_nanomancer': { 'ranged_weight': 0.8 }, // 원거리 딜러 대상 원거리 공격 가중치 -20%
-        'target_esper': { 'ranged_weight': 0.8 }
+
+    // 신규 아키타입 학습 데이터
+    'INTP': {
+        'target_warrior': { 'magic_weight': 0.85 },
+        'target_zombie': { 'melee_weight': 1.15 }
+    },
+    'INFJ': {
+        'target_gunner': { 'melee_weight': 1.3 },
+        'target_nanomancer': { 'melee_weight': 1.3 },
+        'target_sentinel': { 'melee_weight': 0.8 }
     }
 };
 
 // 학습 데이터 적용 함수 (기존과 동일)
 async function applyLearnedData() {
-    console.log('AI 강화학습 v2 데이터를 적용합니다...');
-    for (const [mbti, memory] of Object.entries(learnedData_v2)) {
+    console.log('AI 강화학습 v3 데이터를 적용합니다...');
+    for (const [mbti, memory] of Object.entries(learnedData_v3)) {
         await archetypeMemoryEngine.updateMemory(mbti, memory);
     }
     console.log('모든 아키타입의 집단 기억이 성공적으로 업데이트되었습니다!');


### PR DESCRIPTION
## Summary
- buffer passive stat bonuses before applying to final stats to avoid mid-calculation side effects
- load v3 reinforcement learning data including new INTP and INFJ behavior tweaks

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6893827b59548327aa0c820add75770d