### PR TITLE
Ensure skill targetType directs valid targets

### DIFF
--- a/src/ai/nodes/FindTargetBySkillTypeNode.js
+++ b/src/ai/nodes/FindTargetBySkillTypeNode.js
@@ -19,20 +19,32 @@ class FindTargetBySkillTypeNode extends Node {
             return NodeState.FAILURE;
         }
 
-        // ✨ [수정] 스킬의 targetType을 먼저 확인하여 'self'인 경우 자신을 즉시 타겟으로 설정합니다.
-        if (skillData.targetType === 'self' || skillData.type === 'STRATEGY') {
-            blackboard.set('skillTarget', unit);
-            debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skillData.name}]의 대상 (자신/전략) 설정`);
-            return NodeState.SUCCESS;
-        }
-
         let target = null;
-        // 특별 타겟팅 로직: '낙인'은 가장 멀리 있으며 체력이 가장 낮은 적을 노립니다.
-        if (skillData.id === 'stigma') {
-            if (enemyUnits && enemyUnits.length > 0) {
+        const targetType = skillData.targetType;
+
+        // 1. targetType을 최우선으로 확인하여 대상 그룹을 명확히 설정합니다.
+        if (targetType === 'self' || skillData.type === 'STRATEGY') {
+            target = unit;
+        } else if (targetType === 'ally') {
+            if (!alliedUnits || alliedUnits.length === 0) {
+                debugAIManager.logNodeResult(NodeState.FAILURE, "지원할 아군 유닛 없음");
+                return NodeState.FAILURE;
+            }
+            // 지원 스킬은 체력이 가장 낮은 아군을 우선 대상으로 합니다.
+            target = [...alliedUnits].sort((a, b) => {
+                const healthRatioA = a.currentHp / a.finalStats.hp;
+                const healthRatioB = b.currentHp / b.finalStats.hp;
+                return healthRatioA - healthRatioB;
+            })[0];
+        } else if (targetType === 'enemy') {
+            if (!enemyUnits || enemyUnits.length === 0) {
+                debugAIManager.logNodeResult(NodeState.FAILURE, "공격할 적 유닛 없음");
+                return NodeState.FAILURE;
+            }
+            // '낙인' 스킬을 위한 특별 타겟팅 로직
+            if (skillData.id === 'stigma') {
                 let farthestEnemies = [];
                 let maxDist = -1;
-
                 enemyUnits.forEach(enemy => {
                     const dist = Math.abs(unit.gridX - enemy.gridX) + Math.abs(unit.gridY - enemy.gridY);
                     if (dist > maxDist) {
@@ -42,59 +54,18 @@ class FindTargetBySkillTypeNode extends Node {
                         farthestEnemies.push(enemy);
                     }
                 });
-
                 if (farthestEnemies.length > 0) {
                     target = farthestEnemies.sort((a, b) => a.currentHp - b.currentHp)[0];
                 }
+            } else {
+                // 기본 적 대상 스킬은 체력이 가장 높은 적을 우선합니다.
+                target = this.targetManager.findHighestHealthEnemy(enemyUnits);
             }
         } else {
-        switch (skillData.type) {
-            case 'ACTIVE':
-                if (!enemyUnits || enemyUnits.length === 0) {
-                    debugAIManager.logNodeResult(NodeState.FAILURE, "적 유닛 없음");
-                    return NodeState.FAILURE;
-                }
-                const skillRange = skillData.range || unit.finalStats.attackRange || 1;
-                const inRangeEnemies = enemyUnits.filter(e =>
-                    Math.abs(unit.gridX - e.gridX) + Math.abs(unit.gridY - e.gridY) <= skillRange
-                );
+            // targetType이 명시되지 않은 경우, 기존 로직으로 대체 작동
+            target = this.targetManager.findNearestEnemy(unit, enemyUnits);
+        }
 
-                if (inRangeEnemies.length > 0) {
-                    target = inRangeEnemies.sort((a, b) => a.currentHp - b.currentHp)[0];
-                } else {
-                    target = this.targetManager.findNearestEnemy(unit, enemyUnits);
-                }
-                break;
-            case 'DEBUFF':
-                if (!enemyUnits || enemyUnits.length === 0) {
-                    debugAIManager.logNodeResult(NodeState.FAILURE, "적 유닛 없음");
-                    return NodeState.FAILURE;
-                }
-                target = this.targetManager.findHighestHealthEnemy(enemyUnits);
-                break;
-            // ✨ [수정] 'BUFF' 타입을 별도로 처리하고, 'self'가 아닌 경우에만 아군을 찾도록 남겨둡니다.
-            case 'BUFF':
-            case 'AID':
-                if (!alliedUnits || alliedUnits.length === 0) {
-                    debugAIManager.logNodeResult(NodeState.FAILURE, "아군 유닛 없음");
-                    return NodeState.FAILURE;
-                }
-                // 체력 비율이 가장 낮은 아군을 찾습니다 (자신 포함).
-                target = [...alliedUnits].sort((a, b) => {
-                    const healthRatioA = a.currentHp / a.finalStats.hp;
-                    const healthRatioB = b.currentHp / b.finalStats.hp;
-                    return healthRatioA - healthRatioB;
-                })[0];
-                break;
-            // ✨ [신규] 소환 스킬은 임시로 시전자 자신을 대상으로 합니다.
-            case 'SUMMON':
-                target = unit;
-                break;
-            default:
-                target = this.targetManager.findNearestEnemy(unit, enemyUnits);
-                break;
-        }
-        }
         if (target) {
             blackboard.set('skillTarget', target);
             debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skillData.name}]의 대상 (${target.instanceName}) 설정`);


### PR DESCRIPTION
## Summary
- honor each skill's explicit `targetType` before applying other target selection logic
- prevent ally-targeting skills from mistakenly choosing enemies

## Testing
- `for f in tests/*.js; do node $f; done`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68938f7b8c7c8327865e2b1de8fa4405