### PR TITLE
feat: add spinning slash and earth splitter skills

### DIFF
--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -4,6 +4,48 @@ import { SHARED_RESOURCE_TYPES } from '../../utils/SharedResourceEngine.js';
 
 // 액티브 스킬 데이터 정의
 export const activeSkills = {
+    // --- ▼ [신규] 회전 베기 스킬 추가 ▼ ---
+    spinningSlash: {
+        yinYangValue: -3,
+        NORMAL: {
+            id: 'spinningSlash',
+            name: '회전 베기',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.PHYSICAL, SKILL_TAGS.MELEE, SKILL_TAGS.PRODUCTION, SKILL_TAGS.AURA, SKILL_TAGS.WIND],
+            cost: 3,
+            targetType: 'enemy', // 자신 주부의 적을 대상으로 함
+            description: '자신의 주위 4타일(상하좌우)에 있는 모든 적군을 70%의 물리 데미지로 공격하고, [바람] 자원을 1개 생산합니다.',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 0, // 자신을 중심으로 하므로 사거리는 0
+            aoe: { shape: 'CROSS', radius: 1 }, // 십자 형태 범위
+            damageMultiplier: { min: 0.65, max: 0.75 }, // 70% 데미지
+            generatesResource: { type: 'WIND', amount: 1 }
+        }
+    },
+    // --- ▲ [신규] 회전 베기 스킬 추가 ▲ ---
+
+    // --- ▼ [신규] 대지 가르기 스킬 추가 ▼ ---
+    earthSplitter: {
+        yinYangValue: -3,
+        NORMAL: {
+            id: 'earthSplitter',
+            name: '대지 가르기',
+            type: 'ACTIVE',
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.PHYSICAL, SKILL_TAGS.MELEE, SKILL_TAGS.PRODUCTION, SKILL_TAGS.EARTH],
+            cost: 3,
+            targetType: 'enemy',
+            description: '자신으로부터 3타일 일지선상의 모든 적군에게 70%의 물리 데미지를 주고, [대지] 자원을 1개 생산합니다.',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 3, // 스킬 사거리
+            aoe: { shape: 'LINE', length: 3 }, // 직선 형태 범위
+            damageMultiplier: { min: 0.65, max: 0.75 }, // 70% 데미지
+            generatesResource: { type: 'EARTH', amount: 1 }
+        }
+    },
+    // --- ▲ [신규] 대지 가르기 스킬 추가 ▲ ---
+
     // 기본 공격 스킬
     attack: {
         yinYangValue: -1,

--- a/tests/warrior_skill_integration_test.js
+++ b/tests/warrior_skill_integration_test.js
@@ -169,6 +169,36 @@ const doubleStrikeBase = {
 };
 // --- ▲ [신규] 더블 스트라이크 테스트 데이터 추가 ▲ ---
 
+// --- ▼ [신규] 회전 베기 테스트 데이터 추가 ▼ ---
+const spinningSlashBase = {
+    NORMAL: {
+        id: 'spinningSlash',
+        type: 'ACTIVE',
+        cost: 3,
+        cooldown: 3,
+        damageMultiplier: { min: 0.65, max: 0.75 },
+        range: 0,
+        aoe: { shape: 'CROSS', radius: 1 },
+        generatesResource: { type: 'WIND', amount: 1 }
+    }
+};
+// --- ▲ [신규] 회전 베기 테스트 데이터 추가 ▲ ---
+
+// --- ▼ [신규] 대지 가르기 테스트 데이터 추가 ▼ ---
+const earthSplitterBase = {
+    NORMAL: {
+        id: 'earthSplitter',
+        type: 'ACTIVE',
+        cost: 3,
+        cooldown: 3,
+        damageMultiplier: { min: 0.65, max: 0.75 },
+        range: 3,
+        aoe: { shape: 'LINE', length: 3 },
+        generatesResource: { type: 'EARTH', amount: 1 }
+    }
+};
+// --- ▲ [신규] 대지 가르기 테스트 데이터 추가 ▲ ---
+
 const ironWillBase = {
     rankModifiers: [0.39, 0.36, 0.33, 0.30],
     NORMAL: { maxReduction: 0.30, hpRegen: 0 },
@@ -364,6 +394,38 @@ for (const grade of grades) {
     }
 }
 // --- ▲ [신규] 더블 스트라이크 테스트 로직 추가 ▲ ---
+
+// --- ▼ [신규] 회전 베기 테스트 로직 추가 ▼ ---
+{
+    const skill = skillModifierEngine.getModifiedSkill(spinningSlashBase.NORMAL, 'NORMAL');
+    assert.strictEqual(skill.cost, 3, 'Spinning Slash cost failed');
+    assert.strictEqual(skill.cooldown, 3, 'Spinning Slash cooldown failed');
+    assert.strictEqual(skill.range, 0, 'Spinning Slash range failed');
+    assert(skill.aoe && skill.aoe.shape === 'CROSS' && skill.aoe.radius === 1, 'Spinning Slash AOE failed');
+    assert(
+        skill.generatesResource &&
+            skill.generatesResource.type === 'WIND' &&
+            skill.generatesResource.amount === 1,
+        'Spinning Slash resource generation failed'
+    );
+}
+// --- ▲ [신규] 회전 베기 테스트 로직 추가 ▲ ---
+
+// --- ▼ [신규] 대지 가르기 테스트 로직 추가 ▼ ---
+{
+    const skill = skillModifierEngine.getModifiedSkill(earthSplitterBase.NORMAL, 'NORMAL');
+    assert.strictEqual(skill.cost, 3, 'Earth Splitter cost failed');
+    assert.strictEqual(skill.cooldown, 3, 'Earth Splitter cooldown failed');
+    assert.strictEqual(skill.range, 3, 'Earth Splitter range failed');
+    assert(skill.aoe && skill.aoe.shape === 'LINE' && skill.aoe.length === 3, 'Earth Splitter AOE failed');
+    assert(
+        skill.generatesResource &&
+            skill.generatesResource.type === 'EARTH' &&
+            skill.generatesResource.amount === 1,
+        'Earth Splitter resource generation failed'
+    );
+}
+// --- ▲ [신규] 대지 가르기 테스트 로직 추가 ▲ ---
 
 // Throwing Axe
 for (const grade of grades) {


### PR DESCRIPTION
## Summary
- add spinning slash and earth splitter active skills with resource generation
- cover new warrior skills in integration tests

## Testing
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68939176cf388327b0858580b8e91693