### PR TITLE
feat: track support skill use and aspiration after attacks

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -236,12 +236,12 @@ class AIManager {
             }
         }
 
-        // \u2728 --- [핵심 추가] 턴 종료 후 공격 행동 여부 확인 --- \u2728
-        if (unit.currentHp > 0 && !unit.offensiveActionTakenThisTurn) {
-            // 공격 행동을 하지 않았다면 열망을 5 감소시킵니다.
+        // \u2728 --- [핵심 수정] 턴 종료 후 비행동 여부 확인 --- \u2728
+        // 공격/지원 스킬을 사용하지 않았고, 이번 턴에 피격당하지도 않았다면 열망 감소
+        if (unit.currentHp > 0 && !unit.offensiveActionTakenThisTurn && !unit.wasAttackedBy) {
             aspirationEngine.addAspiration(unit.uniqueId, -5, '비전투');
         }
-        // \u2728 --- 추가 완료 --- \u2728
+        // \u2728 --- 수정 완료 --- \u2728
 
         console.groupEnd();
     }


### PR DESCRIPTION
## Summary
- flag offensive or support-tagged skills to mark AI unit as having acted
- decrease aspiration only if unit neither attacked nor was attacked that turn

## Testing
- `for f in tests/*_test.js; do node $f >>test.log 2>&1; done && tail -n 20 test.log`
- `grep -n "test passed" test.log | head -n 20`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689457e1d7f483278a0db66776e262bc