### PR TITLE
feat: expand skill tags and AI scoring

### DIFF
--- a/src/game/data/skillScores.js
+++ b/src/game/data/skillScores.js
@@ -23,6 +23,15 @@ export const SCORE_BY_TAG = {
     HEAL: 8,         // 치유 (점수 상향)
     CHARGE: 4,       // 돌진
     KINETIC: 4,      // 넉백
-    SACRIFICE: 9     // ✨ 희생 태그 추가
+    SACRIFICE: 9,     // ✨ 희생 태그 추가
+    EXECUTE: 15,      // 처형 (마무리 능력은 매우 가치 있음)
+    AREA_DENIAL: 11,  // 지역 장악 (전략적으로 매우 유용함)
+    COUNTER: 10,      // 반격 (조건부지만 강력함)
+    CHAIN: 7,         // 연쇄 (다중 타겟 가능성)
+    STACKABLE: 6,     // 중첩 (지속적인 압박)
+    SUMMON_BUFF: 8,   // 소환수 강화 (소환사에게 매우 중요)
+    ON_HIT: 5,        // 타격시 발동 (부가적인 이득)
+    BLOOD_MAGIC: 4,   // 혈마법 (리스크가 따름)
+    STEALTH: 7        // 은신 (생존 및 기습에 유리)
     // 기타 태그는 필요에 따라 추가할 수 있습니다.
 };

--- a/src/game/utils/MercenaryCardSelector.js
+++ b/src/game/utils/MercenaryCardSelector.js
@@ -102,6 +102,31 @@ class MercenaryCardSelector {
                 if (isConventional) score += mercenary.mbti.J;
                 if (!isConventional) score += mercenary.mbti.P;
 
+                // ✨ --- [신규] 추가된 태그에 대한 MBTI 선호도 점수 --- ✨
+                // INTJ, ENTJ (전략가, 통솔관)는 전장 통제 스킬을 선호
+                if (tags.includes(SKILL_TAGS.AREA_DENIAL)) score += (mercenary.mbti.N + mercenary.mbti.T) / 2;
+
+                // INTP, ESTJ (논리술사, 관리자)는 중첩을 통한 꾸준한 이득을 선호
+                if (tags.includes(SKILL_TAGS.STACKABLE)) score += (mercenary.mbti.I + mercenary.mbti.T) / 2;
+
+                // ENFP, ENTP (활동가, 변론가)는 변수를 창출하는 연쇄 효과를 선호
+                if (tags.includes(SKILL_TAGS.CHAIN)) score += (mercenary.mbti.E + mercenary.mbti.P) / 2;
+
+                // ISTP (재주꾼)와 S타입은 타격 시 발동하는 확실한 효과를 선호
+                if (tags.includes(SKILL_TAGS.ON_HIT)) score += (mercenary.mbti.S + mercenary.mbti.T) / 2;
+
+                // ENFJ (선도자)는 자신의 소환수를 강화하는 것을 선호
+                if (tags.includes(SKILL_TAGS.SUMMON_BUFF)) score += mercenary.mbti.E + mercenary.mbti.F;
+
+                // F타입은 '신성' 태그에, T타입은 '산성' 태그에 높은 가중치
+                if (tags.includes(SKILL_TAGS.HOLY)) score += mercenary.mbti.F;
+                if (tags.includes(SKILL_TAGS.ACID)) score += mercenary.mbti.T;
+
+                // ISFP, I타입은 '은신'에, ESTP, INFJ는 '혈마법'에 높은 가중치
+                if (tags.includes(SKILL_TAGS.STEALTH)) score += mercenary.mbti.I + mercenary.mbti.P;
+                if (tags.includes(SKILL_TAGS.BLOOD_MAGIC)) score += mercenary.mbti.E + mercenary.mbti.N; // 리스크와 변수 창출
+                // ✨ --- 추가 완료 --- ✨
+
                 return { instance: inst, score };
             });
 

--- a/src/game/utils/SkillTagManager.js
+++ b/src/game/utils/SkillTagManager.js
@@ -28,6 +28,11 @@ export const SKILL_TAGS = {
     DELAY: '지연',      // 대상의 턴 순서를 미루는 메커니즘
     PROHIBITION: '금지',// 특정 행동(치유 등)을 막는 메커니즘
     WILL_GUARD: '의지 방패', // 스택 기반 방어 효과를 부여하는 메커니즘
+    STACKABLE: '중첩',    // 중첩 가능 효과
+    CHAIN: '연쇄',       // 주변 적에게 튕기는 효과
+    ON_HIT: '타격시 발동', // 공격 성공 시 부가 효과
+    AREA_DENIAL: '지역 장악', // 장판기 스킬
+    SUMMON_BUFF: '소환수 강화', // 소환수 직접 강화
 
     // --- 6. 테마 및 자원 (Theme & Resource) ---
     WILL: '의지',       // '정신력', '용기' 테마 스킬 그룹
@@ -39,6 +44,11 @@ export const SKILL_TAGS = {
     WATER: '물',
     WIND: '바람',
     DARK: '어둠',
+    POISON: '독',
+    HOLY: '신성',
+    ACID: '산성',
+    STEALTH: '은신',
+    BLOOD_MAGIC: '혈마법',
     PRODUCTION: '생산', // 공유 자원을 생성하는 스킬
     THROWING: '투척',   // 무기나 물체를 던지는 컨셉
     SPECIAL: '특수 스킬',// 특수 슬롯 전용 스킬


### PR DESCRIPTION
## Summary
- add new mechanism and theme tags to `SKILL_TAGS`
- assign default AI scores for new tags
- weight MBTI skill selection toward new tags

## Testing
- `node tests/summon_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68946cf28c6c8327aee82a02e6f5bed2