### PR TITLE
Add constructor with debug logging to combat engine

### DIFF
--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -33,6 +33,14 @@ import { statusEffects } from '../data/status-effects.js';
  * 실제 전투 데미지 계산을 담당하는 엔진
  */
 class CombatCalculationEngine {
+    // ✨ --- [핵심 버그 수정] 생성자와 name 속성 추가 --- ✨
+    constructor() {
+        this.name = 'CombatCalculationEngine';
+        // 다른 엔진들과의 일관성을 위해 debugLogEngine에 등록할 수도 있습니다.
+        debugLogEngine.register(this);
+    }
+    // ✨ --- 수정 완료 --- ✨
+
     /**
      * 스킬 또는 기본 공격 데미지 계산
      * @param {object} attacker


### PR DESCRIPTION
## Summary
- give CombatCalculationEngine a constructor with `name` property
- register engine with `debugLogEngine` for consistent debugging

## Testing
- `node tests/combat_calculation_test.js`
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68949789e00483279282a006e0b8a276