### PR TITLE
feat: add taunt and shield bash skills

### DIFF
--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -4,6 +4,63 @@ import { SHARED_RESOURCE_TYPES } from '../../utils/SharedResourceEngine.js';
 
 // 액티브 스킬 데이터 정의
 export const activeSkills = {
+    // --- ▼ [신규] 드레드노트 전용 스킬 2종 추가 ▼ ---
+    taunt: {
+        yinYangValue: -3,
+        NORMAL: {
+            id: 'taunt',
+            name: '도발',
+            type: 'ACTIVE',
+            requiredClass: ['sentinel', 'warrior'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.DEBUFF, SKILL_TAGS.AURA, SKILL_TAGS.GUARDIAN],
+            cost: 2,
+            targetType: 'self',
+            description:
+                '주위 3타일 내의 모든 적을 2턴간 [도발]하여 자신을 공격하게 만듭니다. 효과가 지속되는 동안 자신의 물리 방어력이 20% 증가합니다.',
+            illustrationPath: null,
+            cooldown: 3,
+            range: 0,
+            aoe: { shape: 'SQUARE', radius: 3 },
+            effect: {
+                id: 'tauntDebuff',
+                type: EFFECT_TYPES.DEBUFF,
+                duration: 2,
+            },
+            selfEffect: {
+                id: 'tauntBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 2,
+                modifiers: { stat: 'physicalDefense', type: 'percentage', value: 0.2 },
+            },
+        },
+    },
+
+    shieldBash: {
+        yinYangValue: -2,
+        NORMAL: {
+            id: 'shieldBash',
+            name: '방패 치기',
+            type: 'ACTIVE',
+            requiredClass: ['sentinel', 'warrior', 'paladin'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.PHYSICAL, SKILL_TAGS.MELEE, SKILL_TAGS.GUARDIAN],
+            cost: 2,
+            targetType: 'enemy',
+            description:
+                '자신의 최대 체력의 15%에 해당하는 물리 피해를 입히고, 30% 확률로 1턴간 [기절]시킵니다.',
+            illustrationPath: null,
+            cooldown: 1,
+            range: 1,
+            damageBasedOn: { stat: 'hp', percentage: 0.15 },
+            effect: {
+                id: 'stun',
+                type: EFFECT_TYPES.STATUS_EFFECT,
+                duration: 1,
+                chance: 0.3,
+            },
+        },
+    },
+    // --- ▲ [신규] 드레드노트 전용 스킬 2종 추가 ▲ ---
+
     // --- ▼ [신규] 회전 베기 스킬 추가 ▼ ---
     spinningSlash: {
         yinYangValue: -3,

--- a/tests/sentinel_skill_integration_test.js
+++ b/tests/sentinel_skill_integration_test.js
@@ -6,6 +6,7 @@ const { mercenaryData } = await import('../src/game/data/mercenaries.js');
 const { statEngine } = await import('../src/game/utils/StatEngine.js');
 const { statusEffectManager } = await import('../src/game/utils/StatusEffectManager.js');
 const { combatCalculationEngine } = await import('../src/game/utils/CombatCalculationEngine.js');
+const { activeSkills } = await import('../src/game/data/skills/active.js');
 
 console.log('--- 센티넬 클래스 통합 테스트 시작 ---');
 
@@ -67,4 +68,15 @@ const reducedDamage = combatCalculationEngine.calculateDamage(attacker, sentinel
 assert.strictEqual(reducedDamage, Math.round(baseDamage * 0.85), '3스택 시 데미지가 15% 감소해야 합니다.');
 
 console.log('✅ 클래스 패시브 테스트 통과');
+
+// 3. 신규 스킬 데이터 검증
+const tauntSkill = activeSkills.taunt.NORMAL;
+assert(tauntSkill && tauntSkill.cooldown === 3, '도발 스킬의 기본 쿨타임이 3이어야 합니다.');
+assert(tauntSkill.selfEffect && tauntSkill.selfEffect.modifiers.stat === 'physicalDefense', '도발 스킬은 방어력 증가 효과를 가져야 합니다.');
+
+const shieldBashSkill = activeSkills.shieldBash.NORMAL;
+assert(shieldBashSkill && shieldBashSkill.range === 1, '방패 치기 스킬의 사거리는 1이어야 합니다.');
+assert(shieldBashSkill.effect && shieldBashSkill.effect.chance === 0.3, '방패 치기 스킬은 30% 확률로 기절시켜야 합니다.');
+
+console.log('✅ 신규 센티넬 스킬 테스트 통과');
 console.log('--- 모든 센티넬 테스트 완료 ---');

--- a/tests/warrior_skill_integration_test.js
+++ b/tests/warrior_skill_integration_test.js
@@ -199,6 +199,38 @@ const earthSplitterBase = {
 };
 // --- ▲ [신규] 대지 가르기 테스트 데이터 추가 ▲ ---
 
+// --- ▼ [신규] 도발 & 방패 치기 테스트 데이터 추가 ▼ ---
+const tauntBase = {
+    NORMAL: {
+        id: 'taunt',
+        type: 'ACTIVE',
+        cost: 2,
+        cooldown: 3,
+        range: 0,
+        aoe: { shape: 'SQUARE', radius: 3 },
+        effect: { id: 'tauntDebuff', type: 'DEBUFF', duration: 2 },
+        selfEffect: {
+            id: 'tauntBuff',
+            type: 'BUFF',
+            duration: 2,
+            modifiers: { stat: 'physicalDefense', type: 'percentage', value: 0.2 }
+        }
+    }
+};
+
+const shieldBashBase = {
+    NORMAL: {
+        id: 'shieldBash',
+        type: 'ACTIVE',
+        cost: 2,
+        cooldown: 1,
+        range: 1,
+        damageBasedOn: { stat: 'hp', percentage: 0.15 },
+        effect: { id: 'stun', type: 'STATUS_EFFECT', duration: 1, chance: 0.3 }
+    }
+};
+// --- ▲ [신규] 도발 & 방패 치기 테스트 데이터 추가 ▲ ---
+
 const ironWillBase = {
     rankModifiers: [0.39, 0.36, 0.33, 0.30],
     NORMAL: { maxReduction: 0.30, hpRegen: 0 },
@@ -426,6 +458,19 @@ for (const grade of grades) {
     );
 }
 // --- ▲ [신규] 대지 가르기 테스트 로직 추가 ▲ ---
+
+// --- ▼ [신규] 도발 & 방패 치기 테스트 로직 추가 ▼ ---
+{
+    const skill = skillModifierEngine.getModifiedSkill(tauntBase.NORMAL, 'NORMAL');
+    assert.strictEqual(skill.cooldown, 3, 'Taunt cooldown failed');
+    assert(skill.selfEffect && skill.selfEffect.modifiers.stat === 'physicalDefense', 'Taunt selfEffect failed');
+}
+{
+    const skill = skillModifierEngine.getModifiedSkill(shieldBashBase.NORMAL, 'NORMAL');
+    assert.strictEqual(skill.range, 1, 'Shield Bash range failed');
+    assert(skill.effect && skill.effect.chance === 0.3, 'Shield Bash effect failed');
+}
+// --- ▲ [신규] 도발 & 방패 치기 테스트 로직 추가 ▲ ---
 
 // Throwing Axe
 for (const grade of grades) {


### PR DESCRIPTION
## Summary
- add Taunt and Shield Bash active skills for frontline classes
- cover new skills in Sentinel and Warrior integration tests

## Testing
- `node tests/sentinel_skill_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &` / `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6894a6b08dac8327bad2d6b849b8bebc