### PR TITLE
feat: assign mercenary archetypes and bias dreadnought gear

### DIFF
--- a/src/game/utils/ArchetypeAssignmentEngine.js
+++ b/src/game/utils/ArchetypeAssignmentEngine.js
@@ -1,0 +1,58 @@
+import { mercenaryData } from '../data/mercenaries.js';
+
+/**
+ * 용병의 MBTI 성향에 따라 아키타입(하위 클래스)을 **확률적으로** 결정하는 엔진
+ */
+class ArchetypeAssignmentEngine {
+    constructor() {
+        // 각 아키타입별로 선호하는 MBTI 특성과 가중치를 정의합니다.
+        this.archetypeProfiles = {
+            Dreadnought: { I: 3, S: 2, J: 2, F: 1 },
+            Frostweaver: { I: 3, N: 3, T: 1 },
+            Aquilifer: { E: 1, F: 3, J: 1 },
+            Trapmaster: { N: 3, P: 2, T: 1 },
+            Executioner: { I: 2, S: 1, P: 3 },
+            Dreadbringer: { I: 2, N: 2, T: 2, F: 1 }
+        };
+    }
+
+    /**
+     * 용병의 MBTI 데이터를 분석하여 가장 적합한 아키타입을 결정하고 할당합니다.
+     * @param {object} mercenary - 아키타입을 할당할 용병 객체
+     */
+    assignArchetype(mercenary) {
+        const scoredArchetypes = [];
+        let totalScore = 0;
+
+        for (const [archetype, profile] of Object.entries(this.archetypeProfiles)) {
+            let currentScore = 0;
+            for (const [trait, weight] of Object.entries(profile)) {
+                currentScore += (mercenary.mbti[trait] || 0) * weight;
+            }
+
+            if (currentScore > 0) {
+                scoredArchetypes.push({ archetype, score: currentScore });
+                totalScore += currentScore;
+            }
+        }
+
+        // --- ▼ [핵심 로직] 가중치 기반 랜덤 선택 ▼ ---
+        let random = Math.random() * totalScore;
+        let finalArchetype = scoredArchetypes[scoredArchetypes.length - 1].archetype; // Fallback
+
+        for (const scored of scoredArchetypes) {
+            if (random < scored.score) {
+                finalArchetype = scored.archetype;
+                break;
+            }
+            random -= scored.score;
+        }
+        // --- ▲ [핵심 로직] 가중치 기반 랜덤 선택 ▲ ---
+
+        // 용병 객체에 아키타입을 직접 기록합니다.
+        mercenary.archetype = finalArchetype;
+        console.log(`[ArchetypeEngine] ${mercenary.instanceName}(${mercenary.id})의 아키타입이 [${finalArchetype}]으로 결정되었습니다.`);
+    }
+}
+
+export const archetypeAssignmentEngine = new ArchetypeAssignmentEngine();

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -7,6 +7,8 @@ import { uniqueIDManager } from './UniqueIDManager.js';
 // ✨ 1. 속성 특화 데이터와 주사위 엔진을 가져옵니다.
 import { attributeSpecializations } from '../data/attributeSpecializations.js';
 import { diceEngine } from './DiceEngine.js';
+// ✨ [추가] 아키타입 결정 엔진을 가져옵니다.
+import { archetypeAssignmentEngine } from './ArchetypeAssignmentEngine.js';
 
 /**
  * 용병의 생성, 저장, 관리를 전담하는 엔진 (싱글턴)
@@ -56,6 +58,9 @@ class MercenaryEngine {
             // ✨ 각 용병은 고유한 MBTI 성향을 가집니다.
             mbti: this._generateMBTI()
         };
+
+        // ✨ [핵심 추가] 용병 생성 직후 아키타입을 결정합니다.
+        archetypeAssignmentEngine.assignArchetype(newInstance);
 
         // ✨ 2. [신규] 용병 생성 시 무작위 속성 특화 태그를 부여합니다.
         const randomAttribute = diceEngine.getRandomElement(attributeSpecializations);

--- a/src/game/utils/MercenaryEquipmentSelector.js
+++ b/src/game/utils/MercenaryEquipmentSelector.js
@@ -80,7 +80,7 @@ class MercenaryEquipmentSelector {
     }
 
     /**
-     * 용병의 MBTI 성향에 따라 아이템의 점수를 계산합니다.
+     * 용병의 MBTI 성향과 아키타입에 따라 아이템의 점수를 계산합니다.
      * @param {object} mercenary
      * @param {object} item
      * @returns {number}
@@ -90,6 +90,25 @@ class MercenaryEquipmentSelector {
         let score = 100; // 기본 점수
         const mbti = mercenary.mbti;
         const stats = item.stats;
+
+        // --- ▼ [핵심 수정] 아키타입 보너스 점수 계산 ▼ ---
+        if (mercenary.archetype === 'Dreadnought') {
+            let archetypeScore = 0;
+            const dreadnoughtStats = ['threat', 'retaliationDamage', 'allyDamageReduction', 'damageReduction', 'valor'];
+            dreadnoughtStats.forEach(stat => {
+                if (stats[stat]) archetypeScore += 50;
+            });
+
+            if (item.mbtiEffects) {
+                item.mbtiEffects.forEach(effect => {
+                    if (effect.trait.includes('_DREADNOUGHT')) {
+                        archetypeScore += 100;
+                    }
+                });
+            }
+            score += archetypeScore;
+        }
+        // --- ▲ [핵심 수정] 아키타입 보너스 점수 계산 ▲ ---
 
         // E vs I: 공격/지속력 vs 방어/효율
         if (stats.physicalAttack || stats.valor || stats.strength) score += (mbti.E / 100) * 20;
@@ -104,7 +123,6 @@ class MercenaryEquipmentSelector {
         if (stats.hp || stats.healingGivenPercentage) score += (mbti.F / 100) * 15;
 
         // J vs P: 계획(세트 완성) vs 즉흥(특수 효과)
-        // (세트 완성 로직은 더 복잡하므로 여기서는 MBTI 효과에만 집중)
         if (item.mbtiEffects && item.mbtiEffects.length > 0) {
              score += (mbti.P / 100) * 30; // P는 특이한 MBTI 효과를 선호
         }


### PR DESCRIPTION
## Summary
- add ArchetypeAssignmentEngine to probabilistically assign MBTI-based archetypes
- assign archetypes when hiring mercenaries
- favor Dreadnought stats and MBTI effects during equipment scoring

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6894abda07f8832787524ba5a5300bb3