### PR TITLE
feat: add frostweaver archetype and equipment

### DIFF
--- a/src/game/data/archetypes/frostweaver.js
+++ b/src/game/data/archetypes/frostweaver.js
@@ -1,0 +1,52 @@
+import { SKILL_TAGS } from '../../utils/SkillTagManager.js';
+
+/**
+ * 프로스트위버 (Frostweaver) 아키타입 정의
+ * * 컨셉: 냉기 마법으로 적의 움직임을 묶고, 턴 순서를 지연시키며 전장을 얼어붙게 만드는 전장 통제 전문가.
+ * 직접적인 파괴력보다는 적을 무력화시켜 서서히 승리를 가져옵니다.
+ */
+export const frostweaverArchetype = {
+    id: 'Frostweaver',
+    name: '프로스트위버',
+    
+    // 1. 핵심 코어 태그
+    coreTags: [
+        SKILL_TAGS.WATER, 
+        SKILL_TAGS.DELAY, 
+        SKILL_TAGS.PROHIBITION
+    ],
+
+    // 2. 선호 스킬 목록 (빌드의 정답지)
+    preferredSkills: [
+        'iceBolt',       // 아이스 볼트 (신규)
+        'frostNova',     // 프로스트 노바 (신규)
+        'blizzard',      // 블리자드 (신규)
+        'iceball',       // 아이스볼 (기존)
+        'suppressShot',  // 제압 사격 (DELAY 태그 공유)
+        'stigma'         // 낙인 (PROHIBITION 태그 공유)
+    ],
+
+    // 3. 선호 장비 옵션
+    preferredEquipment: {
+        prefixes: [
+            { name: '빙결의', stat: 'frostDamage' }, // (신규) 냉기 속성 데미지
+            { name: '마력의', stat: 'magicAttack' }
+        ],
+        suffixes: [
+            { name: '지연의', stat: 'statusEffectApplication' }, // (신규) 상태이상 적용 확률 증가
+            { name: '끈기의', stat: 'aspirationDecayReduction' }
+        ],
+        mbtiEffects: [
+            'I_FROSTWEAVER', // (신규) 내향형 장착 시, [물] 자원 1개로 턴 시작
+            'N_FROSTWEAVER'  // (신규) 직관형 장착 시, 자신이 부여한 [둔화], [속박] 지속시간 +1턴
+        ]
+    },
+
+    // 4. MBTI 선호도 프로필
+    mbtiProfile: {
+        I: 3, // 내향성 (후방, 제어)
+        N: 3, // 직관형 (변수 창출)
+        T: 1, // 사고형 (효율적 제어)
+        P: 1  // 인식형 (유연한 대처)
+    }
+};

--- a/src/game/data/items.js
+++ b/src/game/data/items.js
@@ -62,7 +62,9 @@ export const itemAffixes = {
         { name: '정밀한', stat: 'accuracy', value: { min: 5, max: 10 } },
         // --- ▼ [신규] 드레드노트용 접두사 추가 ▼ ---
         { name: '도발하는', stat: 'threat', value: { min: 10, max: 20 } },
-        { name: '응보의', stat: 'retaliationDamage', value: { min: 5, max: 10 } }
+        { name: '응보의', stat: 'retaliationDamage', value: { min: 5, max: 10 } },
+        // --- ▼ [신규] 프로스트위버용 접두사 추가 ▼ ---
+        { name: '빙결의', stat: 'frostDamage', value: { min: 8, max: 12 } } // 냉기 속성 데미지를 추가하는 신규 스탯
     ],
 
     // --- 접미사 (주로 방어, 유틸리티 관련) ---
@@ -75,7 +77,9 @@ export const itemAffixes = {
         // --- ▼ [신규] 드레드노트용 접미사 추가 ▼ ---
         { name: '수호의', stat: 'allyDamageReduction', value: { min: 3, max: 5 } },
         { name: '철벽의', stat: 'damageReduction', value: { min: 2, max: 4 }, isPercentage: true },
-        { name: '용기의', stat: 'valor', value: { min: 2, max: 5 } }
+        { name: '용기의', stat: 'valor', value: { min: 2, max: 5 } },
+        // --- ▼ [신규] 프로스트위버용 접미사 추가 ▼ ---
+        { name: '지연의', stat: 'statusEffectApplication', value: { min: 5, max: 8 } } // 상태이상 적용 확률 증가
     ]
 };
 
@@ -94,7 +98,10 @@ export const mbtiGradeEffects = {
     // ISTJ, ISFJ 같은 수호자 타입을 위한 효과들
     I_DREADNOUGHT: [{ trait: 'I', description: '내향형 장착 시, [방어 태세] 발동. 턴 종료 시 방어력 +{value}% (최대 3중첩)', stat: 'defenseStackOnTurnEnd', value: { min: 3, max: 5 } }],
     S_DREADNOUGHT: [{ trait: 'S', description: '감각형 장착 시, [의지 방패] 스킬로 생성되는 스택 +{value}개', stat: 'willGuardStackBonus', value: { min: 1, max: 1 } }],
-    J_DREADNOUGHT: [{ trait: 'J', description: '판단형 장착 시, 피격 시 {value}% 확률로 [철] 자원 1개 생성', stat: 'ironGenerationOnHitChance', value: { min: 15, max: 25 } }]
+    J_DREADNOUGHT: [{ trait: 'J', description: '판단형 장착 시, 피격 시 {value}% 확률로 [철] 자원 1개 생성', stat: 'ironGenerationOnHitChance', value: { min: 15, max: 25 } }],
+    // --- ▼ [신규] 프로스트위버용 MBTI 효과 추가 ▼ ---
+    I_FROSTWEAVER: [{ trait: 'I', description: '내향형 장착 시, 매 턴 [물] 자원 1개를 가지고 시작', stat: 'startingWaterResource', value: { min: 1, max: 1 } }],
+    N_FROSTWEAVER: [{ trait: 'N', description: '직관형 장착 시, [둔화], [속박] 효과 지속시간 +{value}턴', stat: 'debuffDurationBonus', value: { min: 1, max: 1 } }]
 };
 
 // --- ▼ [신규] 장비 시너지 세트 효과 데이터베이스 ▼ ---


### PR DESCRIPTION
## Summary
- add Frostweaver archetype data with core tags and gear preferences
- introduce Frostweaver item affixes and MBTI grade effects

## Testing
- `npm test` (fails: Missing script: "test")
- `for f in tests/*.js; do node $f; done`
- `npm run build`
- `python3 -m http.server 8000 &` / `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6894b5da67a483279d45b85837b81bef