### PR TITLE
feat: add aquilifer archetype and aura skills

### DIFF
--- a/src/game/data/archetypes/aquilifer.js
+++ b/src/game/data/archetypes/aquilifer.js
@@ -1,0 +1,54 @@
+import { SKILL_TAGS } from '../../utils/SkillTagManager.js';
+
+/**
+ * 아퀼리퍼 (Aquilifer) 아키타입 정의
+ * * 컨셉: 군단의 깃발을 들고 아군 전체의 사기를 드높이는 지휘관형 지원가.
+ * 자신을 중심으로 한 강력한 오라(Aura)를 통해 아군 전체에 지속적인 버프를 제공하며,
+ * 전투의 흐름을 유리하게 이끕니다.
+ */
+export const aquiliferArchetype = {
+    id: 'Aquilifer',
+    name: '아퀼리퍼',
+
+    // 1. 핵심 코어 태그
+    coreTags: [
+        SKILL_TAGS.AURA,
+        SKILL_TAGS.BUFF,
+        SKILL_TAGS.HOLY
+    ],
+
+    // 2. 선호 스킬 목록
+    preferredSkills: [
+        'sanctuary',            // 성역 (신규)
+        'auraOfRetribution',    // 응징의 오라 (신규)
+        'proofOfValor',         // 용맹의 증거
+        'rallyingHorn',         // 집결의 뿔피리
+        'chargeOrder',          // 돌격 명령
+        'mightyShield'          // 마이티 쉴드
+    ],
+
+    // 3. 선호 장비 옵션
+    preferredEquipment: {
+        prefixes: [
+            { name: '지휘관의', stat: 'auraRadius' },      // (신규) 오라 스킬의 반경 증가
+            { name: '축복받은', stat: 'healingGivenPercentage' }
+        ],
+        suffixes: [
+            { name: '신념의', stat: 'effectDuration' },     // (신규) 자신이 건 버프/디버프 지속시간 증가
+            { name: '용기의', stat: 'valor' }
+        ],
+        mbtiEffects: [
+            'F_AQUILIFER', // (신규) 감정형: 오라 스킬 효과 증폭
+            'J_AQUILIFER'  // (신규) 판단형: 빛 자원을 가지고 전투 시작
+        ]
+    },
+
+    // 4. MBTI 선호도 프로필
+    mbtiProfile: {
+        E: 2, // 외향성 (지휘관)
+        F: 3, // 감정형 (아군 지원)
+        J: 3, // 판단형 (계획, 통솔)
+        S: 1
+    }
+};
+

--- a/src/game/data/archetypes/index.js
+++ b/src/game/data/archetypes/index.js
@@ -1,0 +1,15 @@
+import { dreadnoughtArchetype } from './dreadnought.js';
+import { frostweaverArchetype } from './frostweaver.js';
+import { aquiliferArchetype } from './aquilifer.js';
+
+/**
+ * 모든 아키타입 정의를 하나의 객체로 통합하여 관리합니다.
+ * 새로운 아키타입을 추가할 때마다 이 파일에도 등록해야 합니다.
+ */
+export const archetypes = {
+    Dreadnought: dreadnoughtArchetype,
+    Frostweaver: frostweaverArchetype,
+    Aquilifer: aquiliferArchetype,
+    // ... 향후 추가될 아키타입들
+};
+

--- a/src/game/data/items.js
+++ b/src/game/data/items.js
@@ -64,7 +64,9 @@ export const itemAffixes = {
         { name: '도발하는', stat: 'threat', value: { min: 10, max: 20 } },
         { name: '응보의', stat: 'retaliationDamage', value: { min: 5, max: 10 } },
         // --- ▼ [신규] 프로스트위버용 접두사 추가 ▼ ---
-        { name: '빙결의', stat: 'frostDamage', value: { min: 8, max: 12 } } // 냉기 속성 데미지를 추가하는 신규 스탯
+        { name: '빙결의', stat: 'frostDamage', value: { min: 8, max: 12 } }, // 냉기 속성 데미지를 추가하는 신규 스탯
+        // --- ▼ [신규] 아퀼리퍼용 접두사 추가 ▼ ---
+        { name: '지휘관의', stat: 'auraRadius', value: { min: 1, max: 1 } } // 오라 반경
     ],
 
     // --- 접미사 (주로 방어, 유틸리티 관련) ---
@@ -79,7 +81,9 @@ export const itemAffixes = {
         { name: '철벽의', stat: 'damageReduction', value: { min: 2, max: 4 }, isPercentage: true },
         { name: '용기의', stat: 'valor', value: { min: 2, max: 5 } },
         // --- ▼ [신규] 프로스트위버용 접미사 추가 ▼ ---
-        { name: '지연의', stat: 'statusEffectApplication', value: { min: 5, max: 8 } } // 상태이상 적용 확률 증가
+        { name: '지연의', stat: 'statusEffectApplication', value: { min: 5, max: 8 } }, // 상태이상 적용 확률 증가
+        // --- ▼ [신규] 아퀼리퍼용 접미사 추가 ▼ ---
+        { name: '신념의', stat: 'effectDuration', value: { min: 1, max: 1 } } // 효과 지속시간
     ]
 };
 
@@ -101,7 +105,10 @@ export const mbtiGradeEffects = {
     J_DREADNOUGHT: [{ trait: 'J', description: '판단형 장착 시, 피격 시 {value}% 확률로 [철] 자원 1개 생성', stat: 'ironGenerationOnHitChance', value: { min: 15, max: 25 } }],
     // --- ▼ [신규] 프로스트위버용 MBTI 효과 추가 ▼ ---
     I_FROSTWEAVER: [{ trait: 'I', description: '내향형 장착 시, 매 턴 [물] 자원 1개를 가지고 시작', stat: 'startingWaterResource', value: { min: 1, max: 1 } }],
-    N_FROSTWEAVER: [{ trait: 'N', description: '직관형 장착 시, [둔화], [속박] 효과 지속시간 +{value}턴', stat: 'debuffDurationBonus', value: { min: 1, max: 1 } }]
+    N_FROSTWEAVER: [{ trait: 'N', description: '직관형 장착 시, [둔화], [속박] 효과 지속시간 +{value}턴', stat: 'debuffDurationBonus', value: { min: 1, max: 1 } }],
+    // --- ▼ [신규] 아퀼리퍼용 MBTI 효과 추가 ▼ ---
+    F_AQUILIFER: [{ trait: 'F', description: '감정형 장착 시, [오라] 스킬의 효과가 {value}% 증폭됩니다.', stat: 'auraEffectAmplification', value: { min: 10, max: 15 } }],
+    J_AQUILIFER: [{ trait: 'J', description: '판단형 장착 시, 전투 시작 시 [빛] 자원 {value}개를 가지고 시작합니다.', stat: 'startingLightResource', value: { min: 1, max: 2 } }]
 };
 
 // --- ▼ [신규] 장비 시너지 세트 효과 데이터베이스 ▼ ---

--- a/src/game/data/skills/buff.js
+++ b/src/game/data/skills/buff.js
@@ -61,6 +61,61 @@ export const buffSkills = {
     },
     // --- ▲ [신규] 용맹의 증거 스킬 추가 ▲ ---
 
+    // --- ▼ [신규] 아퀼리퍼 전용 오라 스킬 2종 추가 ▼ ---
+    sanctuary: {
+        yinYangValue: +4, // 아군을 보호하는 강력한 양(Yang)의 기술
+        NORMAL: {
+            id: 'sanctuary',
+            name: '성역',
+            type: 'BUFF',
+            requiredClass: ['paladin', 'medic'],
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.AURA, SKILL_TAGS.WILL_GUARD, SKILL_TAGS.HOLY],
+            cost: 3,
+            targetType: 'self',
+            description: '자신을 중심으로 성역을 펼칩니다. 3턴간 자신과 주위 2칸 내 모든 아군의 물리 및 마법 방어력을 15% 증가시킵니다.',
+            illustrationPath: null,
+            cooldown: 4,
+            range: 0,
+            effect: {
+                id: 'sanctuaryAura',
+                type: EFFECT_TYPES.BUFF,
+                duration: 3,
+                isAura: true,
+                radius: 2,
+                modifiers: [
+                    { stat: 'physicalDefense', type: 'percentage', value: 0.15 },
+                    { stat: 'magicDefense', type: 'percentage', value: 0.15 }
+                ]
+            }
+        }
+    },
+
+    auraOfRetribution: {
+        yinYangValue: +3,
+        NORMAL: {
+            id: 'auraOfRetribution',
+            name: '응징의 오라',
+            type: 'BUFF',
+            requiredClass: ['paladin', 'commander'],
+            tags: [SKILL_TAGS.BUFF, SKILL_TAGS.AURA, SKILL_TAGS.HOLY, SKILL_TAGS.LIGHT],
+            cost: 2,
+            targetType: 'self',
+            description: '주위 2칸 내 모든 아군에게 응징의 오라를 부여합니다. 3턴간 오라 안의 아군이 공격 시, 대상에게 시전자 지혜의 30%만큼 추가 [신성] 피해를 입힙니다.',
+            illustrationPath: null,
+            cooldown: 4,
+            range: 0,
+            effect: {
+                id: 'retributionAuraBuff',
+                type: EFFECT_TYPES.BUFF,
+                duration: 3,
+                isAura: true,
+                radius: 2
+                // 실제 추가 데미지 로직은 CombatCalculationEngine에서 이 버프 유무를 체크하여 처리해야 합니다.
+            }
+        }
+    },
+    // --- ▲ [신규] 아퀼리퍼 전용 오라 스킬 2종 추가 ▲ ---
+
     stoneSkin: {
         yinYangValue: +2,
         // NORMAL 등급: 기본 효과

--- a/src/game/utils/MercenaryEquipmentSelector.js
+++ b/src/game/utils/MercenaryEquipmentSelector.js
@@ -122,6 +122,21 @@ class MercenaryEquipmentSelector {
                 });
             }
             score += archetypeScore;
+        } else if (mercenary.archetype === 'Aquilifer') {
+            let archetypeScore = 0;
+            const aquiliferStats = ['auraRadius', 'effectDuration'];
+            aquiliferStats.forEach(stat => {
+                if (stats[stat]) archetypeScore += 50;
+            });
+
+            if (item.mbtiEffects) {
+                item.mbtiEffects.forEach(effect => {
+                    if (effect.trait.includes('_AQUILIFER')) {
+                        archetypeScore += 100;
+                    }
+                });
+            }
+            score += archetypeScore;
         }
         // --- ▲ [핵심 수정] 아키타입 보너스 점수 계산 ▲ ---
 

--- a/tests/archetype_aquilifer_test.js
+++ b/tests/archetype_aquilifer_test.js
@@ -1,0 +1,54 @@
+import assert from 'assert';
+import { archetypeAssignmentEngine } from '../src/game/utils/ArchetypeAssignmentEngine.js';
+import { mercenaryEquipmentSelector } from '../src/game/utils/MercenaryEquipmentSelector.js';
+
+console.log('--- 🏳️ 아퀼리퍼 아키타입 통합 테스트 시작 ---');
+
+// 아키타입 할당을 결정론적으로 만들기 위해 Math.random 고정
+const originalRandom = Math.random;
+Math.random = () => 0.6; // 아퀼리퍼 구간으로 설정
+
+// 1. 아퀼리퍼에 어울리는 MBTI를 가진 가상 용병 생성
+const mockAquiliferMerc = {
+    id: 'paladin',
+    instanceName: '빛의 전령',
+    mbti: { E: 80, F: 80, J: 80, I: 0, S: 0, N: 0, T: 0, P: 0 }
+};
+
+// 2. 아키타입 할당 엔진 실행
+archetypeAssignmentEngine.assignArchetype(mockAquiliferMerc);
+
+// Math.random 복원
+Math.random = originalRandom;
+
+// 3. 아키타입 할당 검증
+assert.strictEqual(
+    mockAquiliferMerc.archetype,
+    'Aquilifer',
+    '테스트 1 실패: 아퀼리퍼 아키타입이 올바르게 할당되지 않았습니다.'
+);
+console.log('✅ 테스트 1 통과: MBTI 성향에 따라 아퀼리퍼 아키타입이 정확히 할당되었습니다.');
+
+// 4. 장비 선호도 테스트
+const genericArmor = { name: '일반 갑옷', stats: { physicalDefense: 5 } };
+const aquiliferArmor = { name: '지휘관의 갑옷', stats: { auraRadius: 1 } };
+const aquiliferMbtiArmor = {
+    name: '지휘관의 신념 갑옷',
+    stats: {},
+    mbtiEffects: [{ trait: 'F_AQUILIFER' }]
+};
+
+const genericScore = mercenaryEquipmentSelector._calculateItemScore(mockAquiliferMerc, genericArmor);
+const aquiliferScore = mercenaryEquipmentSelector._calculateItemScore(mockAquiliferMerc, aquiliferArmor);
+const aquiliferMbtiScore = mercenaryEquipmentSelector._calculateItemScore(mockAquiliferMerc, aquiliferMbtiArmor);
+
+console.log(`  - 일반 장비 점수: ${genericScore.toFixed(0)}`);
+console.log(`  - 아퀼리퍼 전용 옵션 장비 점수: ${aquiliferScore.toFixed(0)}`);
+console.log(`  - 아퀼리퍼 전용 MBTI 장비 점수: ${aquiliferMbtiScore.toFixed(0)}`);
+
+assert(aquiliferScore > genericScore, '테스트 2 실패: 아퀼리퍼가 전용 옵션 장비를 더 선호해야 합니다.');
+assert(aquiliferMbtiScore > aquiliferScore, '테스트 3 실패: 아퀼리퍼가 전용 MBTI 장비를 가장 선호해야 합니다.');
+
+console.log('✅ 테스트 2 & 3 통과: 아퀼리퍼가 자신의 아키타입에 맞는 장비를 더 높게 평가합니다.');
+console.log('--- ✅ 모든 아퀼리퍼 테스트 완료 ---');
+

--- a/tests/medic_skill_integration_test.js
+++ b/tests/medic_skill_integration_test.js
@@ -59,4 +59,28 @@ for (const grade of grades) {
 }
 // --- ▲ [신규] 윌 가드 테스트 로직 추가 ▲ ---
 
+// --- ▼ [신규] 성역 스킬 테스트 추가 ▼ ---
+const sanctuaryBase = {
+    NORMAL: {
+        id: 'sanctuary',
+        type: 'BUFF',
+        cost: 3,
+        cooldown: 4,
+        effect: {
+            radius: 2,
+            modifiers: [
+                { stat: 'physicalDefense', type: 'percentage', value: 0.15 },
+                { stat: 'magicDefense', type: 'percentage', value: 0.15 }
+            ]
+        }
+    }
+};
+
+{
+    const skill = skillModifierEngine.getModifiedSkill(sanctuaryBase.NORMAL, 'NORMAL');
+    assert.strictEqual(skill.effect.radius, 2, 'Sanctuary aura radius mismatch');
+    assert(Array.isArray(skill.effect.modifiers) && skill.effect.modifiers.length === 2, 'Sanctuary modifiers missing');
+}
+// --- ▲ [신규] 성역 스킬 테스트 추가 ▲ ---
+
 console.log('Medic skill integration test passed.');


### PR DESCRIPTION
## Summary
- add Sanctuary and Aura of Retribution aura buffs for paladin allies
- introduce Aquilifer archetype with equipment options and MBTI traits
- extend item affixes and equipment selector to support new aura-focused gear

## Testing
- `node tests/medic_skill_integration_test.js`
- `node tests/item_factory_test.js`
- `node tests/archetype_aquilifer_test.js`
- `node tests/archetype_dreadnought_test.js`
- `node tests/archetype_frostweaver_test.js`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6894be81036083279438a73995bbb78b