### PR TITLE
feat: introduce trap manager and danger memory

### DIFF
--- a/src/ai/nodes/FindAllyClusterCenterNode.js
+++ b/src/ai/nodes/FindAllyClusterCenterNode.js
@@ -45,7 +45,7 @@ class FindAllyClusterCenterNode extends Node {
         });
         const bestCell = availableCells[0];
 
-        const path = this.pathfinderEngine.findPath(unit, { col: unit.gridX, row: unit.gridY }, { col: bestCell.col, row: bestCell.row });
+        const path = await this.pathfinderEngine.findPath(unit, { col: unit.gridX, row: unit.gridY }, { col: bestCell.col, row: bestCell.row });
         if (path && path.length > 0) {
             blackboard.set('movementPath', path);
             debugAIManager.logNodeResult(NodeState.SUCCESS, `아군 중심(${bestCell.col}, ${bestCell.row})으로 경로 설정`);

--- a/src/ai/nodes/FindAllyMagicClusterNode.js
+++ b/src/ai/nodes/FindAllyMagicClusterNode.js
@@ -57,7 +57,7 @@ class FindAllyMagicClusterNode extends Node {
         const bestCell = availableCells[0];
 
         // 4. 해당 위치로의 경로 탐색 및 블랙보드에 저장
-        const path = this.pathfinderEngine.findPath(unit, { col: unit.gridX, row: unit.gridY }, { col: bestCell.col, row: bestCell.row });
+        const path = await this.pathfinderEngine.findPath(unit, { col: unit.gridX, row: unit.gridY }, { col: bestCell.col, row: bestCell.row });
 
         if (path && path.length > 0) {
             blackboard.set('movementPath', path);

--- a/src/ai/nodes/FindEnemyClusterCenterNode.js
+++ b/src/ai/nodes/FindEnemyClusterCenterNode.js
@@ -47,7 +47,7 @@ class FindEnemyClusterCenterNode extends Node {
         });
         const bestCell = availableCells[0];
 
-        const path = this.pathfinderEngine.findPath(
+        const path = await this.pathfinderEngine.findPath(
             unit,
             { col: unit.gridX, row: unit.gridY },
             { col: bestCell.col, row: bestCell.row }

--- a/src/ai/nodes/FindKitingPositionNode.js
+++ b/src/ai/nodes/FindKitingPositionNode.js
@@ -77,7 +77,7 @@ class FindKitingPositionNode extends Node {
         });
 
         if (bestCell) {
-            const path = this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
+            const path = await this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
             if (path && path.length > 0) {
                 blackboard.set('movementPath', path);
                 debugAIManager.logNodeResult(NodeState.SUCCESS, `최적 카이팅 위치 (${bestCell.col}, ${bestCell.row})로 경로 설정`);

--- a/src/ai/nodes/FindMeleeStrategicTargetNode.js
+++ b/src/ai/nodes/FindMeleeStrategicTargetNode.js
@@ -10,7 +10,7 @@ class FindMeleeStrategicTargetNode extends Node {
     }
 
     // 유닛을 공격할 수 있는 가장 가까운 위치로의 경로를 찾는 헬퍼 메서드
-    _findPathToUnit(unit, target) {
+    async _findPathToUnit(unit, target) {
         const attackRange = unit.finalStats.attackRange || 1;
         const start = { col: unit.gridX, row: unit.gridY };
         const targetPos = { col: target.gridX, row: target.gridY };
@@ -42,7 +42,7 @@ class FindMeleeStrategicTargetNode extends Node {
         });
 
         for (const bestCell of potentialAttackCells) {
-            const path = this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
+            const path = await this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
             if (path && path.length > 0) return path;
         }
         return null;
@@ -65,7 +65,7 @@ class FindMeleeStrategicTargetNode extends Node {
             .sort((a, b) => a.currentHp - b.currentHp);
 
         for (const lowHpEnemy of lowHpEnemies) {
-            const path = this._findPathToUnit(unit, lowHpEnemy);
+            const path = await this._findPathToUnit(unit, lowHpEnemy);
             if (path && path.length <= movementRange) {
                 blackboard.set('movementTarget', lowHpEnemy);
                 debugAIManager.logNodeResult(NodeState.SUCCESS, `체력이 적고 도달 가능한 타겟 [${lowHpEnemy.instanceName}] 설정`);

--- a/src/ai/nodes/FindPathToAllyNode.js
+++ b/src/ai/nodes/FindPathToAllyNode.js
@@ -18,7 +18,7 @@ class FindPathToAllyNode extends Node {
             return NodeState.FAILURE;
         }
 
-        const path = this.pathfinderEngine.findPath(unit, { col: unit.gridX, row: unit.gridY }, { col: target.gridX, row: target.gridY });
+        const path = await this.pathfinderEngine.findPath(unit, { col: unit.gridX, row: unit.gridY }, { col: target.gridX, row: target.gridY });
         if (path && path.length > 0) {
             const finalPath = path.slice(0, path.length - 1);
             blackboard.set('movementPath', finalPath);

--- a/src/ai/nodes/FindPathToTargetNode.js
+++ b/src/ai/nodes/FindPathToTargetNode.js
@@ -17,7 +17,7 @@ class FindPathToTargetNode extends Node {
             return NodeState.FAILURE;
         }
 
-        const path = this._findPathToUnit(unit, target);
+        const path = await this._findPathToUnit(unit, target);
         if (path) {
             blackboard.set('movementPath', path);
             debugAIManager.logNodeResult(NodeState.SUCCESS, `목표(${target.instanceName})에게 경로 설정`);
@@ -28,7 +28,7 @@ class FindPathToTargetNode extends Node {
         return NodeState.FAILURE;
     }
 
-    _findPathToUnit(unit, target) {
+    async _findPathToUnit(unit, target) {
         const attackRange = unit.finalStats.attackRange || 1;
         const start = { col: unit.gridX, row: unit.gridY };
         const targetPos = { col: target.gridX, row: target.gridY };
@@ -60,7 +60,7 @@ class FindPathToTargetNode extends Node {
         });
 
         for (const bestCell of potentialCells) {
-            const path = this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
+            const path = await this.pathfinderEngine.findPath(unit, start, { col: bestCell.col, row: bestCell.row });
             if (path && path.length > 0) return path;
         }
         return null;

--- a/src/ai/nodes/FindPullPositionNode.js
+++ b/src/ai/nodes/FindPullPositionNode.js
@@ -50,7 +50,7 @@ class FindPullPositionNode extends Node {
         });
 
         if (bestCell) {
-            const path = this.pathfinderEngine.findPath(
+            const path = await this.pathfinderEngine.findPath(
                 unit,
                 { col: unit.gridX, row: unit.gridY },
                 { col: bestCell.col, row: bestCell.row }

--- a/src/ai/nodes/FindSafeHealingPositionNode.js
+++ b/src/ai/nodes/FindSafeHealingPositionNode.js
@@ -56,7 +56,7 @@ class FindSafeHealingPositionNode extends Node {
         });
 
         if (bestCell) {
-            const path = this.pathfinderEngine.findPath(
+            const path = await this.pathfinderEngine.findPath(
                 unit,
                 { col: unit.gridX, row: unit.gridY },
                 { col: bestCell.col, row: bestCell.row }

--- a/src/ai/nodes/FindSafeRepositionNode.js
+++ b/src/ai/nodes/FindSafeRepositionNode.js
@@ -68,7 +68,7 @@ class FindSafeRepositionNode extends Node {
         });
 
         if (bestCell) {
-            const path = this.pathfinderEngine.findPath(
+            const path = await this.pathfinderEngine.findPath(
                 unit,
                 { col: unit.gridX, row: unit.gridY },
                 { col: bestCell.col, row: bestCell.row }

--- a/src/ai/nodes/FleeNode.js
+++ b/src/ai/nodes/FleeNode.js
@@ -43,7 +43,7 @@ class FleeNode extends Node {
 
         const start = { col: unit.gridX, row: unit.gridY };
         const end = { col: bestCell.col, row: bestCell.row };
-        const path = this.pathfinderEngine.findPath(unit, start, end);
+        const path = await this.pathfinderEngine.findPath(unit, start, end);
         if (path && path.length > 0) {
             blackboard.set('movementPath', path);
             debugAIManager.logNodeResult(NodeState.SUCCESS, `도주 경로 설정 (${end.col}, ${end.row})`);

--- a/src/ai/nodes/MoveToUseSkillNode.js
+++ b/src/ai/nodes/MoveToUseSkillNode.js
@@ -18,7 +18,7 @@ class MoveToUseSkillNode extends Node {
             return NodeState.FAILURE;
         }
 
-        const path = this.pathfinderEngine.findBestPathToAttack(unit, skill, target);
+        const path = await this.pathfinderEngine.findBestPathToAttack(unit, skill, target);
         if (!path) {
             debugAIManager.logNodeResult(NodeState.FAILURE, `스킬 [${skill.name}] 사용 위치 없음`);
             return NodeState.FAILURE;

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -1441,6 +1441,32 @@ export const activeSkills = {
     // --- ▲ [신규] 화염병 투척 스킬 추가 ▲ ---
 
     // --- ▼ [신규] 나노레일건 스킬 추가 ▼ ---
+    // --- ▼ [신규] 트랩마스터용 함정 스킬 추가 ▼ ---
+    steelTrap: {
+        yinYangValue: +3,
+        NORMAL: {
+            id: 'steelTrap',
+            name: '강철 덫',
+            type: 'ACTIVE',
+            requiredClass: ['gunner', 'hacker'],
+            tags: [SKILL_TAGS.ACTIVE, SKILL_TAGS.TRAP, SKILL_TAGS.PROHIBITION],
+            cost: 2,
+            targetType: 'tile',
+            description: '지정한 타일에 3턴 동안 유지되는 강철 덫을 설치합니다. 덫을 밟은 적은 1턴간 [속박] 상태가 됩니다.',
+            illustrationPath: null,
+            cooldown: 2,
+            range: 3,
+            trapData: {
+                duration: 3,
+                effect: {
+                    id: 'bind',
+                    type: EFFECT_TYPES.STATUS_EFFECT,
+                    duration: 1
+                }
+            }
+        }
+    },
+    // --- ▲ [신규] 트랩마스터용 함정 스킬 추가 ▲ ---
     nanoRailgun: {
         yinYangValue: -4,
         NORMAL: {

--- a/src/game/utils/AIMemoryEngine.js
+++ b/src/game/utils/AIMemoryEngine.js
@@ -110,6 +110,36 @@ class AIMemoryEngine {
         const store = transaction.objectStore(this.storeName);
         store.put({ id: attackerId, memory: memory });
     }
+
+    /**
+     * 특정 유닛의 '위험 타일' 기억을 갱신합니다.
+     * @param {number} unitId - 기억을 갱신할 유닛 ID
+     * @param {number} col - 위험한 타일의 열
+     * @param {number} row - 위험한 타일의 행
+     * @param {number} dangerIncrease - 증가시킬 위험도
+     */
+    async updateTileMemory(unitId, col, row, dangerIncrease) {
+        await this.initPromise;
+        if (!this.db) return;
+
+        const memory = await this.getMemory(unitId);
+        if (!memory.dangerousTiles) {
+            memory.dangerousTiles = {};
+        }
+
+        const tileKey = `${col},${row}`;
+        const oldDanger = memory.dangerousTiles[tileKey] || 0;
+        memory.dangerousTiles[tileKey] = oldDanger + dangerIncrease;
+
+        const transaction = this.db.transaction([this.storeName], 'readwrite');
+        const store = transaction.objectStore(this.storeName);
+        store.put({ id: unitId, memory: memory });
+
+        console.log(
+            `%c[AIMemoryEngine] 유닛 ${unitId}가 (${tileKey}) 타일을 위험 지역으로 기억합니다. (위험도: ${memory.dangerousTiles[tileKey]})`,
+            'color: #8b5cf6;'
+        );
+    }
 }
 
 export const aiMemoryEngine = new AIMemoryEngine();

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -6,6 +6,8 @@ import { AnimationEngine } from './AnimationEngine.js';
 import { TerminationManager } from './TerminationManager.js';
 // ✨ SummoningEngine을 새로 import 합니다.
 import { SummoningEngine } from './SummoningEngine.js';
+import SkillEffectProcessor from './SkillEffectProcessor.js';
+import { trapManager } from './TrapManager.js';
 
 import { aiManager } from '../../ai/AIManager.js';
 
@@ -56,6 +58,14 @@ export class BattleSimulatorEngine {
         this.summoningEngine = new SummoningEngine(scene, this);
         // 소환 엔진을 참조하는 종료 매니저를 초기화합니다.
         this.terminationManager = new TerminationManager(scene, this.summoningEngine, this);
+        this.skillEffectProcessor = new SkillEffectProcessor({
+            vfxManager: this.vfxManager,
+            animationEngine: this.animationEngine,
+            terminationManager: this.terminationManager,
+            summoningEngine: this.summoningEngine,
+            battleSimulator: this,
+            delayEngine
+        });
         // 전투 속도 매니저
         this.battleSpeedManager = new BattleSpeedManager();
         // 전투 중 유닛 정보를 표시할 UI 매니저
@@ -81,6 +91,7 @@ export class BattleSimulatorEngine {
             summoningEngine: this.summoningEngine,
             battleSimulator: this,
             narrationEngine: this.narrationUI,
+            skillEffectProcessor: this.skillEffectProcessor,
         };
 
         // ✨ AspirationEngine에 battleSimulator 참조 설정
@@ -131,6 +142,7 @@ export class BattleSimulatorEngine {
         this.battleSpeedManager.reset();
         cooldownManager.reset();
         this.summoningEngine.reset();
+        trapManager.reset();
         // ✨ [수정] 각 팀의 자원을 개별적으로 초기화
         sharedResourceEngine.initialize('ally');
         sharedResourceEngine.initialize('enemy');

--- a/src/game/utils/TrapManager.js
+++ b/src/game/utils/TrapManager.js
@@ -1,0 +1,92 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+class TrapManager {
+    constructor() {
+        this.name = 'TrapManager';
+        // key: "col,row", value: { ownerId, skillData, sprite }
+        this.activeTraps = new Map();
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 전투 시작 시 모든 함정 데이터를 초기화합니다.
+     */
+    reset() {
+        this.activeTraps.forEach(trap => trap.sprite?.destroy());
+        this.activeTraps.clear();
+        debugLogEngine.log(this.name, '모든 함정 데이터를 초기화했습니다.');
+    }
+
+    /**
+     * 특정 타일에 함정을 설치합니다.
+     * @param {number} col - 설치할 타일의 열
+     * @param {number} row - 설치할 타일의 행
+     * @param {object} trapData - { owner, skillData }
+     * @param {Phaser.Scene} scene - 시각 효과를 표시할 씬
+     */
+    addTrap(col, row, trapData, scene) {
+        const key = `${col},${row}`;
+        if (this.activeTraps.has(key)) {
+            debugLogEngine.warn(this.name, `[${key}] 타일에는 이미 함정이 존재하여 덮어썼습니다.`);
+            this.activeTraps.get(key).sprite?.destroy();
+        }
+
+        // 함정의 시각적 표현 (VFX) - 지금은 간단한 아이콘으로 대체
+        const cell = scene.gridEngine.getCell(col, row);
+        const trapSprite = scene.add
+            .image(cell.x, cell.y, 'placeholder')
+            .setScale(0.1)
+            .setAlpha(0.5);
+
+        this.activeTraps.set(key, { ...trapData, sprite: trapSprite });
+        debugLogEngine.log(this.name, `[${key}] 타일에 [${trapData.skillData.name}] 함정을 설치했습니다.`);
+    }
+
+    /**
+     * 특정 타일에 함정이 있는지 확인합니다.
+     * @returns {object|null} 함정 데이터 또는 null
+     */
+    getTrapAt(col, row) {
+        return this.activeTraps.get(`${col},${row}`) || null;
+    }
+
+    /**
+     * 유닛이 함정을 밟았을 때 효과를 발동시킵니다.
+     * @param {object} unit - 함정을 밟은 유닛
+     * @param {SkillEffectProcessor} skillEffectProcessor - 효과 처리를 위임할 프로세서
+     */
+    async triggerTrap(unit, skillEffectProcessor) {
+        const key = `${unit.gridX},${unit.gridY}`;
+        const trap = this.activeTraps.get(key);
+
+        if (!trap) return;
+
+        console.log(
+            `%c[TrapManager] ${unit.instanceName}이(가) [${trap.skillData.name}] 함정을 발동시켰습니다!`,
+            'color: #f97316; font-weight: bold;'
+        );
+
+        await skillEffectProcessor.process({
+            unit: trap.owner,
+            target: unit,
+            skill: trap.skillData
+        });
+
+        this.removeTrap(unit.gridX, unit.gridY);
+    }
+
+    /**
+     * 특정 타일의 함정을 제거합니다.
+     */
+    removeTrap(col, row) {
+        const key = `${col},${row}`;
+        const trap = this.activeTraps.get(key);
+        if (trap) {
+            trap.sprite?.destroy();
+            this.activeTraps.delete(key);
+            debugLogEngine.log(this.name, `[${key}] 타일의 함정을 제거했습니다.`);
+        }
+    }
+}
+
+export const trapManager = new TrapManager();

--- a/tests/gunner_skill_integration_test.js
+++ b/tests/gunner_skill_integration_test.js
@@ -265,4 +265,24 @@ for (const grade of grades) {
 }
 // --- ▲ [신규] 집중 포화 테스트 로직 추가 ▲ ---
 
+// --- ▼ [신규] 강철 덫 테스트 로직 추가 ▼ ---
+const steelTrapBase = {
+    NORMAL: {
+        id: 'steelTrap',
+        cost: 2,
+        cooldown: 2,
+        range: 3,
+        trapData: {
+            duration: 3,
+            effect: { id: 'bind', type: 'STATUS_EFFECT', duration: 1 }
+        }
+    }
+};
+const steelTrap = skillModifierEngine.getModifiedSkill(steelTrapBase.NORMAL, 'NORMAL');
+assert.strictEqual(steelTrap.cost, 2, 'Steel Trap cost failed');
+assert.strictEqual(steelTrap.cooldown, 2, 'Steel Trap cooldown failed');
+assert(steelTrap.trapData && steelTrap.trapData.duration === 3, 'Steel Trap duration failed');
+assert.strictEqual(steelTrap.trapData.effect.id, 'bind', 'Steel Trap effect id failed');
+// --- ▲ [신규] 강철 덫 테스트 로직 추가 ▲ ---
+
 console.log('Gunner skills integration test passed.');

--- a/tests/pathfinder_flyingmen_bug_test.js
+++ b/tests/pathfinder_flyingmen_bug_test.js
@@ -1,5 +1,9 @@
 import assert from 'assert';
+import './setup-indexeddb.js';
 import { pathfinderEngine } from '../src/game/utils/PathfinderEngine.js';
+import { aiMemoryEngine } from '../src/game/utils/AIMemoryEngine.js';
+aiMemoryEngine.initPromise = Promise.resolve();
+aiMemoryEngine.getMemory = async () => ({});
 
 // --- 테스트를 위한 Mock 객체 설정 ---
 // 실제 게임 엔진 대신 테스트용 가짜 객체를 만들어 사용합니다.
@@ -44,17 +48,17 @@ mockFormationEngine.grid.getCell(2, 0).isOccupied = true;
 
 // 2. 테스트 케이스 실행
 // 테스트 1: 플라잉맨이 장애물이 있는 (1,2) 칸을 '목표'로 경로를 찾을 수 없는지 확인
-const path1 = pathfinderEngine.findPath(flyingman, { col: 1, row: 1 }, { col: 1, row: 2 });
+const path1 = await pathfinderEngine.findPath(flyingman, { col: 1, row: 1 }, { col: 1, row: 2 });
 assert.strictEqual(path1, null, '테스트 1 실패: 플라잉맨이 점유된 칸으로의 경로를 생성했습니다.');
 console.log('✅ 테스트 1 통과: 플라잉맨은 점유된 칸에 도착할 수 없습니다.');
 
 // 테스트 2: 플라잉맨이 장애물이 있는 (1,2) 칸을 '통과'하여 (1,3)으로 갈 수 없는지 확인
-const path2 = pathfinderEngine.findPath(flyingman, { col: 1, row: 1 }, { col: 1, row: 3 });
+const path2 = await pathfinderEngine.findPath(flyingman, { col: 1, row: 1 }, { col: 1, row: 3 });
 assert.strictEqual(path2, null, '테스트 2 실패: 플라잉맨이 점유된 칸을 통과하는 경로를 생성했습니다.');
 console.log('✅ 테스트 2 통과: 플라잉맨은 점유된 칸을 통과할 수 없습니다.');
 
 // 테스트 3: 일반 유닛(전사)이 장애물이 있는 (1,2) 칸을 '통과'할 수 없는지 확인
-const path3 = pathfinderEngine.findPath(warrior, { col: 1, row: 1 }, { col: 1, row: 3 });
+const path3 = await pathfinderEngine.findPath(warrior, { col: 1, row: 1 }, { col: 1, row: 3 });
 assert.strictEqual(path3, null, '테스트 3 실패: 일반 유닛이 점유된 칸을 통과하는 경로를 생성했습니다.');
 console.log('✅ 테스트 3 통과: 일반 유닛은 점유된 칸을 통과할 수 없습니다.');
 


### PR DESCRIPTION
## Summary
- add TrapManager to handle trap placement, triggering and cleanup
- store dangerous tile memories in AIMemoryEngine and avoid them in PathfinderEngine
- create steelTrap skill and integrate trap handling in movement and skill processing

## Testing
- `node tests/gunner_skill_integration_test.js`
- `node tests/pathfinder_flyingmen_bug_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6894c17647c08327a7e6e6eb985d7560