### PR TITLE
refactor: simplify skill movement and self-target evaluation

### DIFF
--- a/src/ai/nodes/MoveToUseSkillNode.js
+++ b/src/ai/nodes/MoveToUseSkillNode.js
@@ -5,35 +5,33 @@ import MoveToTargetNode from './MoveToTargetNode.js';
 class MoveToUseSkillNode extends Node {
     constructor(engines = {}) {
         super();
-        this.pathfinderEngine = engines.pathfinderEngine;
         this.moveNode = new MoveToTargetNode(engines);
     }
 
     async evaluate(unit, blackboard) {
         debugAIManager.logNodeEvaluation(this, unit);
+        const path = blackboard.get('movementPath');
         const skill = blackboard.get('currentSkillData');
-        const target = blackboard.get('skillTarget');
-        if (!skill || !target) {
-            debugAIManager.logNodeResult(NodeState.FAILURE, '스킬 또는 타겟 없음');
-            return NodeState.FAILURE;
-        }
 
-        const path = await this.pathfinderEngine.findBestPathToAttack(unit, skill, target);
-        if (!path) {
-            debugAIManager.logNodeResult(NodeState.FAILURE, `스킬 [${skill.name}] 사용 위치 없음`);
-            return NodeState.FAILURE;
-        }
-
-        blackboard.set('movementPath', path);
-        const result = await this.moveNode.evaluate(unit, blackboard);
-        if (result === NodeState.SUCCESS) {
-            debugAIManager.logNodeResult(NodeState.SUCCESS, `스킬 [${skill.name}] 사용 위치로 이동`);
+        if (!path || path.length === 0) {
+            debugAIManager.logNodeResult(NodeState.SUCCESS, '이동 필요 없음');
             return NodeState.SUCCESS;
         }
 
-        debugAIManager.logNodeResult(NodeState.FAILURE, '경로 탐색 실패');
-        return NodeState.FAILURE;
+        const result = await this.moveNode.evaluate(unit, blackboard);
+
+        if (result === NodeState.SUCCESS) {
+            debugAIManager.logNodeResult(
+                NodeState.SUCCESS,
+                `스킬 [${skill?.name}] 사용 위치로 이동 완료`
+            );
+        } else {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '경로 이동 실패');
+        }
+
+        return result;
     }
 }
 
 export default MoveToUseSkillNode;
+

--- a/src/ai/utils/findBestActionForUnit.js
+++ b/src/ai/utils/findBestActionForUnit.js
@@ -36,9 +36,14 @@ export async function findBestActionForUnit(unit, allies = [], enemies = [], use
             const skillData = skillInventoryManager.getSkillData(instData.skillId, instData.grade);
             if (!skillEngine.canUseSkill(virtualUnit, skillData)) continue;
 
-            const candidates = skillData.targetType === 'ally' ? allies : enemies;
+            const isSelfTarget = skillData.targetType === 'self';
+            const candidates = isSelfTarget ? [virtualUnit] : (skillData.targetType === 'ally' ? allies : enemies);
+
             const targets = candidates.filter(t => {
-                if (skillData.targetType === 'self') return t.uniqueId === virtualUnit.uniqueId;
+                if (isSelfTarget) return t.uniqueId === virtualUnit.uniqueId;
+
+                if (t.uniqueId === virtualUnit.uniqueId) return false;
+
                 const dist = Math.abs(t.gridX - virtualUnit.gridX) + Math.abs(t.gridY - virtualUnit.gridY);
                 return dist <= (skillData.range || 1);
             });


### PR DESCRIPTION
## Summary
- Simplify MoveToUseSkillNode to follow precomputed movement paths
- Fix self-targeting logic in findBestActionForUnit for accurate candidate selection

## Testing
- `npm test` (fails: Missing script "test")
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6895a304132c8327b9baeec8ee8f75dd