### PR TITLE
Refine movement path logic for skill usage

### DIFF
--- a/src/ai/utils/findBestActionForUnit.js
+++ b/src/ai/utils/findBestActionForUnit.js
@@ -36,9 +36,15 @@ export async function findBestActionForUnit(unit, allies = [], enemies = [], use
             const skillData = skillInventoryManager.getSkillData(instData.skillId, instData.grade);
             if (!skillEngine.canUseSkill(virtualUnit, skillData)) continue;
 
-            const candidates = skillData.targetType === 'ally' ? allies : enemies;
+            const isSelfTarget = skillData.targetType === 'self';
+            const candidates = isSelfTarget
+                ? [virtualUnit]
+                : skillData.targetType === 'ally'
+                    ? allies
+                    : enemies;
             const targets = candidates.filter(t => {
-                if (skillData.targetType === 'self') return t.uniqueId === virtualUnit.uniqueId;
+                if (isSelfTarget) return t.uniqueId === virtualUnit.uniqueId;
+                if (t.uniqueId === virtualUnit.uniqueId) return false;
                 const dist = Math.abs(t.gridX - virtualUnit.gridX) + Math.abs(t.gridY - virtualUnit.gridY);
                 return dist <= (skillData.range || 1);
             });


### PR DESCRIPTION
## Summary
- Reuse existing movement paths when executing a skill and skip unnecessary movement
- Handle self-targeting skills when evaluating best unit actions

## Testing
- `find tests -name '*_test.js' -print0 | xargs -0 -n1 node`
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6895d0f47ec883279bca7b3d2f3692ab