### PR TITLE
feat: support multiple random elements

### DIFF
--- a/src/game/utils/DiceEngine.js
+++ b/src/game/utils/DiceEngine.js
@@ -9,16 +9,26 @@ class DiceEngine {
     }
 
     /**
-     * 주어진 배열에서 무작위 요소를 하나 선택하여 반환합니다.
+     * 주어진 배열에서 무작위 요소를 하나 또는 여러 개 선택하여 반환합니다.
      * @param {Array<*>} array - 요소를 선택할 배열
-     * @returns {*|undefined} - 무작위로 선택된 요소
+     * @param {number} [count=1] - 선택할 요소의 개수
+     * @returns {*|Array<*>|undefined} - 선택된 요소 또는 요소들의 배열
      */
-    getRandomElement(array) {
+    getRandomElement(array, count = 1) {
         if (!array || array.length === 0) {
-            return undefined;
+            // count가 1이면 undefined, 아니면 빈 배열을 반환하여 일관성을 유지합니다.
+            return count === 1 ? undefined : [];
         }
-        const index = Math.floor(Math.random() * array.length);
-        return array[index];
+
+        // count가 1이면 기존 로직대로 단일 요소를 반환합니다.
+        if (count === 1) {
+            const index = Math.floor(Math.random() * array.length);
+            return array[index];
+        }
+
+        // count가 1보다 크면, 배열을 섞은 뒤 원하는 개수만큼 잘라서 반환합니다.
+        const shuffled = [...array].sort(() => 0.5 - Math.random());
+        return shuffled.slice(0, Math.min(count, array.length));
     }
 
     /**

--- a/src/game/utils/SkillEffectProcessor.js
+++ b/src/game/utils/SkillEffectProcessor.js
@@ -416,22 +416,25 @@ class SkillEffectProcessor {
             // 최대 2명에게 튕김
             const ricochetTargets = diceEngine.getRandomElement(candidates, 2);
 
-            for (const ricochetTarget of ricochetTargets) {
-                await this.delayEngine.hold(200);
+            // ✨ [버그 수정] ricochetTargets가 배열이고 비어있지 않은지 확인합니다.
+            if (Array.isArray(ricochetTargets) && ricochetTargets.length > 0) {
+                for (const ricochetTarget of ricochetTargets) {
+                    await this.delayEngine.hold(200);
 
-                // 도탄 시각 효과 (임시)
-                this.vfxManager.createMagicImpact(ricochetTarget.sprite.x, ricochetTarget.sprite.y, 'placeholder');
+                    // 도탄 시각 효과 (임시)
+                    this.vfxManager.createMagicImpact(ricochetTarget.sprite.x, ricochetTarget.sprite.y, 'placeholder');
 
-                const ricochetSkill = {
-                    ...skill,
-                    damageMultiplier:
-                        ((skill.damageMultiplier.min + skill.damageMultiplier.max) / 2) * 0.5
-                };
-                const { damage: ricochetDamage, hitType: ricochetHitType } =
-                    combatCalculationEngine.calculateDamage(unit, ricochetTarget, ricochetSkill, instanceId, grade);
+                    const ricochetSkill = {
+                        ...skill,
+                        damageMultiplier:
+                            ((skill.damageMultiplier.min + skill.damageMultiplier.max) / 2) * 0.5
+                    };
+                    const { damage: ricochetDamage, hitType: ricochetHitType } =
+                        combatCalculationEngine.calculateDamage(unit, ricochetTarget, ricochetSkill, instanceId, grade);
 
-                this._applyDamage(ricochetTarget, ricochetDamage, ricochetHitType);
-                if (ricochetTarget.currentHp <= 0) this.terminationManager.handleUnitDeath(ricochetTarget, unit);
+                    this._applyDamage(ricochetTarget, ricochetDamage, ricochetHitType);
+                    if (ricochetTarget.currentHp <= 0) this.terminationManager.handleUnitDeath(ricochetTarget, unit);
+                }
             }
         }
         // ▲▲▲ [신규] 추가 완료 ▲▲▲


### PR DESCRIPTION
## Summary
- allow DiceEngine.getRandomElement to return multiple values when a count is provided
- guard ricochet shot processing against empty target lists

## Testing
- `for f in tests/*.js; do node "$f"; done`
- `node tests/warrior_skill_integration_test.js | tail -n 5`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6895de09c3d083279558b9e76cd82420