### PR TITLE
refactor: enable battle control buttons

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1296,24 +1296,36 @@ body {
     gap: 8px;
 }
 
-#battle-speed-button {
+/* 전투 UI 버튼들을 감싸는 컨테이너 */
+#battle-controls {
+    display: flex;
+    gap: 8px;
+    pointer-events: auto;
+}
+
+/* 전투 컨트롤 버튼 공통 스타일 */
+.battle-control-button {
     background-color: #2a2a2a;
     border: 1px solid #888;
     color: #f0e68c;
     font-family: 'Cinzel', serif;
     font-size: 16px;
     font-weight: bold;
-    width: 60px;
-    padding: 4px;
+    padding: 4px 8px;
     border-radius: 5px;
     cursor: pointer;
-    pointer-events: auto;
     transition: background-color 0.2s, color 0.2s;
 }
 
-#battle-speed-button:hover {
+.battle-control-button:hover {
     background-color: #f0e68c;
     color: #2a2a2a;
+}
+
+.battle-control-button:disabled {
+    background-color: #444;
+    color: #888;
+    cursor: not-allowed;
 }
 
 .combat-portrait-panel {


### PR DESCRIPTION
## Summary
- Ensure battle speed and result buttons are clickable by wrapping them in a battle controls container
- Consolidate battle control button styling and enable disabled state

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6895ea565db48327a8613d1397511733