### PR TITLE
Fix debug log reset in battle simulator

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -397,7 +397,7 @@ export class BattleSimulatorEngine {
 
 export const battleSimulatorEngine = {
     async runFullSimulation(initialAllies, initialEnemies) {
-        debugLogEngine.clear();
+        debugLogEngine.reset();
         debugLogEngine.startRecording();
 
         const simAllies = JSON.parse(JSON.stringify(initialAllies));

--- a/src/game/utils/DebugLogEngine.js
+++ b/src/game/utils/DebugLogEngine.js
@@ -66,6 +66,14 @@ class DebugLogEngine {
         this._recordLog('error', source, args);
     }
 
+    reset() {
+        this.logHistory = [];
+    }
+
+    startRecording() {
+        this.reset();
+    }
+
     _getSourceColor(source) {
         let hash = 0;
         for (let i = 0; i < source.length; i++) {


### PR DESCRIPTION
## Summary
- use `debugLogEngine.reset()` before running simulation
- add minimal `reset` and `startRecording` helpers to DebugLogEngine

## Testing
- `npm test` (fails: Missing script: "test")
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6895ee74667c832788c8be726d9a2b32