### PR TITLE
feat: add buff fallback on path failure

### DIFF
--- a/src/ai/behaviors/MeleeAI.js
+++ b/src/ai/behaviors/MeleeAI.js
@@ -15,6 +15,7 @@ import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 import { NodeState } from '../nodes/Node.js';
 import MoveToUseSkillNode from '../nodes/MoveToUseSkillNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
+import UseBuffSkillOrWaitNode from '../nodes/UseBuffSkillOrWaitNode.js';
 
 /**
  * MeleeAI: 근접 공격형 AI 행동 트리 (개선 버전)
@@ -93,7 +94,9 @@ function createMeleeAI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
-        ])
+        ]),
+        // 7순위: 경로를 찾지 못한 경우 버프 스킬 사용 또는 대기
+        new UseBuffSkillOrWaitNode(engines)
     ]);
 
     return new BehaviorTree(rootNode);

--- a/src/ai/behaviors/RangedAI.js
+++ b/src/ai/behaviors/RangedAI.js
@@ -14,6 +14,7 @@ import FindSafeRepositionNode from '../nodes/FindSafeRepositionNode.js';
 import MoveToUseSkillNode from '../nodes/MoveToUseSkillNode.js';
 import FindTargetNode from '../nodes/FindTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
+import UseBuffSkillOrWaitNode from '../nodes/UseBuffSkillOrWaitNode.js';
 
 function createRangedAI(engines = {}) {
     // --- 공통 사용 브랜치 ---
@@ -43,7 +44,9 @@ function createRangedAI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
-        ])
+        ]),
+        // 경로를 찾지 못했다면 버프 스킬 사용 또는 대기
+        new UseBuffSkillOrWaitNode(engines)
     ]);
 
     // --- MBTI 기반 특수 행동들 ---

--- a/src/ai/nodes/UseBuffSkillOrWaitNode.js
+++ b/src/ai/nodes/UseBuffSkillOrWaitNode.js
@@ -1,0 +1,47 @@
+import Node, { NodeState } from './Node.js';
+import { debugAIManager } from '../../game/debug/DebugAIManager.js';
+import { ownedSkillsManager } from '../../game/utils/OwnedSkillsManager.js';
+import { skillInventoryManager } from '../../game/utils/SkillInventoryManager.js';
+import { skillEngine } from '../../game/utils/SkillEngine.js';
+import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
+import UseSkillNode from './UseSkillNode.js';
+
+/**
+ * 경로 탐색 실패 시 사용할 버프 스킬을 찾거나,
+ * 사용할 버프 스킬이 없다면 대기합니다.
+ */
+class UseBuffSkillOrWaitNode extends Node {
+    constructor(engines = {}) {
+        super();
+        this.useSkillNode = new UseSkillNode(engines);
+    }
+
+    async evaluate(unit, blackboard) {
+        debugAIManager.logNodeEvaluation(this, unit);
+
+        const equipped = ownedSkillsManager.getEquippedSkills(unit.uniqueId) || [];
+        const usedSkills = blackboard.get('usedSkillsThisTurn') || new Set();
+
+        for (const instanceId of equipped) {
+            if (!instanceId || usedSkills.has(instanceId)) continue;
+
+            const instData = skillInventoryManager.getInstanceData(instanceId);
+            const skillData = skillInventoryManager.getSkillData(instData.skillId, instData.grade);
+
+            if (skillData.tags?.includes(SKILL_TAGS.BUFF) && skillEngine.canUseSkill(unit, skillData)) {
+                blackboard.set('currentSkillData', skillData);
+                blackboard.set('currentSkillInstanceId', instanceId);
+                blackboard.set('skillTarget', unit);
+                const result = await this.useSkillNode.evaluate(unit, blackboard);
+                debugAIManager.logNodeResult(result, `버프 스킬 [${skillData.name}] 사용 시도`);
+                return result;
+            }
+        }
+
+        // 사용할 수 있는 버프 스킬이 없다면 대기
+        debugAIManager.logNodeResult(NodeState.SUCCESS, '버프 스킬 없음 - 대기');
+        return NodeState.SUCCESS;
+    }
+}
+
+export default UseBuffSkillOrWaitNode;


### PR DESCRIPTION
## Summary
- add `UseBuffSkillOrWaitNode` to handle pathfinding failure by using a buff skill or waiting
- plug fallback node into melee and ranged AI trees

## Testing
- `for f in tests/*_test.js; do node $f; done`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6895ee3c9728832798e1a6163499df6c