### PR TITLE
Implement DebugLogEngine log saving

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -438,7 +438,7 @@ export const battleSimulatorEngine = {
 
         const winner = simAllies.some(u => u.currentHp > 0) ? 'ally' : 'enemy';
         debugLogEngine.log('System', `전투 종료! 결과: ${winner}`);
-        debugLogEngine.stopRecording();
+        debugLogEngine.saveLog();
         return debugLogEngine.getHistory();
     }
 };

--- a/src/game/utils/DebugLogEngine.js
+++ b/src/game/utils/DebugLogEngine.js
@@ -74,6 +74,37 @@ class DebugLogEngine {
         this.reset();
     }
 
+    getHistory() {
+        return [...this.logHistory];
+    }
+
+    /**
+     * 기록된 로그를 JSON 파일로 저장합니다.
+     * 브라우저 환경에서만 동작하며, 로그가 비어 있으면 아무 작업도 하지 않습니다.
+     * @param {string} [filename] 저장할 파일 이름
+     */
+    saveLog(filename = `debug-log-${Date.now()}.json`) {
+        if (!this.enabled || this.logHistory.length === 0) {
+            return;
+        }
+
+        if (typeof document === 'undefined') {
+            this.warn('Engine', 'saveLog는 브라우저 환경에서만 사용할 수 있습니다.');
+            return;
+        }
+
+        const blob = new Blob(
+            [JSON.stringify(this.logHistory, null, 2)],
+            { type: 'application/json' }
+        );
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
     _getSourceColor(source) {
         let hash = 0;
         for (let i = 0; i < source.length; i++) {


### PR DESCRIPTION
## Summary
- Replace nonexistent `stopRecording` call with `saveLog` when simulation ends
- Add `getHistory` and `saveLog` methods to `DebugLogEngine` to expose and persist structured debug logs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895f19325208327be48a80a117f04ac