### PR TITLE
feat: enhance offensive scoring and retreat logic

### DIFF
--- a/src/ai/nodes/FindSafeRepositionNode.js
+++ b/src/ai/nodes/FindSafeRepositionNode.js
@@ -17,10 +17,8 @@ class FindSafeRepositionNode extends Node {
         debugAIManager.logNodeEvaluation(this, unit);
         const enemies = blackboard.get('enemyUnits');
 
-        // ✨ [핵심 추가] 현재 위협받고 있는지(isThreatened) 확인하는 로직
+        // ✨ [핵심 수정] 위협받는 상황이 아니면, 전투 중에는 재배치를 수행하지 않도록 로직을 명확화합니다.
         const isThreatened = blackboard.get('isThreatened');
-
-        // 만약 적이 있는데 위협받는 상황이 아니라면, 굳이 후퇴하지 않고 전투를 지속합니다.
         if (enemies && enemies.length > 0 && !isThreatened) {
             debugAIManager.logNodeResult(NodeState.FAILURE, '전투 중 불필요한 재배치는 수행하지 않음');
             return NodeState.FAILURE;
@@ -30,6 +28,7 @@ class FindSafeRepositionNode extends Node {
             if (isThreatened) {
                 this.narrationEngine.show(`${unit.instanceName}이(가) 위협을 피해 안전한 위치로 후퇴합니다.`);
             } else {
+                // ✨ 전투 중이 아닐 때만 이 메시지가 표시됩니다.
                 this.narrationEngine.show(`${unit.instanceName}이(가) 다음 행동을 위해 유리한 위치로 이동합니다.`);
             }
         }

--- a/src/game/utils/SkillScoreEngine.js
+++ b/src/game/utils/SkillScoreEngine.js
@@ -79,6 +79,8 @@ class SkillScoreEngine {
         let yinYangBonus = 0;
         // ✨ [신규] MBTI 성향 점수 변수
         let mbtiScore = 0;
+        // ✨ [신규] 역할군 보너스 점수 변수
+        let roleScore = 0;
         // ✨ 열망 보너스 점수 변수 추가
         let aspirationBonus = 0;
         const situationLogs = [];
@@ -93,8 +95,16 @@ class SkillScoreEngine {
         if (skillData.type === 'ACTIVE') {
             baseScore *= 1.5;
             if (target && target.currentHp < target.finalStats.hp * 0.4) {
-                situationScore += 20;
-                situationLogs.push('마무리:+20');
+                situationScore += 45; // ✨ 마무리 점수 상향 (20 -> 45)
+                situationLogs.push('마무리:+45');
+            }
+        }
+
+        // ✨ [신규] 공격 역할군 보너스
+        const offensiveClasses = ['warrior', 'gunner', 'flyingmen', 'ghost', 'darkKnight', 'hacker'];
+        if (offensiveClasses.includes(unit.id)) {
+            if (skillData.type === 'ACTIVE' || skillData.type === 'DEBUFF') {
+                roleScore += 20;
             }
         }
 
@@ -268,7 +278,8 @@ class SkillScoreEngine {
             }
         }
 
-        const calculatedScore = baseScore + tagScore + situationScore + yinYangBonus + mbtiScore + aspirationBonus + customScore;
+        // ✨ 최종 점수 계산에 역할군 보너스 합산
+        const calculatedScore = baseScore + tagScore + situationScore + yinYangBonus + mbtiScore + aspirationBonus + customScore + roleScore;
 
         // ✨ AI 기억 가중치 적용 로직을 수정합니다.
         let finalScore = calculatedScore;
@@ -312,7 +323,7 @@ class SkillScoreEngine {
 
         debugYinYangManager.logScoreModification(
             skillData.name,
-            baseScore + tagScore + situationScore + mbtiScore + aspirationBonus + customScore,
+            baseScore + tagScore + situationScore + mbtiScore + roleScore + aspirationBonus + customScore,
             yinYangBonus,
             finalScore
         );
@@ -320,7 +331,7 @@ class SkillScoreEngine {
         debugLogEngine.log(
             this.name,
             `[${unit.instanceName}] 스킬 [${skillData.name}] 점수: ` +
-                `기본(${baseScore}) + 태그(${tagScore}) + 상황(${situationScore}) + 음양(${yinYangBonus.toFixed(2)}) + MBTI(${mbtiScore}) + 열망(${aspirationBonus.toFixed(2)}) + 커스텀(${customScore.toFixed(2)}) = 최종 ${finalScore.toFixed(2)}` +
+                `기본(${baseScore}) + 태그(${tagScore}) + 상황(${situationScore}) + 음양(${yinYangBonus.toFixed(2)}) + MBTI(${mbtiScore}) + 역할(${roleScore}) + 열망(${aspirationBonus.toFixed(2)}) + 커스텀(${customScore.toFixed(2)}) = 최종 ${finalScore.toFixed(2)}` +
                 (situationLogs.length > 0 ? ` (${situationLogs.join(', ')})` : '')
         );
 


### PR DESCRIPTION
## Summary
- boost finishing attack bonus and add offensive role bonus in SkillScoreEngine
- prevent unnecessary repositioning unless unit is threatened in FindSafeRepositionNode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6895f3012e8c8327b66c6dd0b0ba2ac5