### PR TITLE
Remove auto-save for battle logs

### DIFF
--- a/src/game/dom/CombatUIManager.js
+++ b/src/game/dom/CombatUIManager.js
@@ -132,9 +132,9 @@ export class CombatUIManager {
             const allies = partyEngine.getDeployedMercenaries();
             const enemies = monsterEngine.getAllMonsters('enemy');
 
-            const battleLog = await battleSimulatorEngine.runFullSimulation(allies, enemies);
+            await battleSimulatorEngine.runFullSimulation(allies, enemies);
 
-            logDownloader.download(battleLog, 'battle-simulation-log.json');
+            logDownloader.download();
 
             this.instantResultButton.textContent = '시뮬레이션 완료';
             console.log('전투 시뮬레이션이 완료되었습니다. 로그 파일을 확인하세요.');

--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -493,7 +493,6 @@ export const battleSimulatorEngine = {
 
         const winner = simAllies.some(u => u.currentHp > 0) ? 'ally' : 'enemy';
         debugLogEngine.log('System', `전투 종료! 결과: ${winner}`);
-        debugLogEngine.saveLog();
         return debugLogEngine.getHistory();
     }
 };


### PR DESCRIPTION
## Summary
- stop `BattleSimulatorEngine` from automatically saving logs after simulations
- let the instant result button handle log download via `logDownloader.download`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build-nolog`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6895f75ecf888327b247d276d249beac