### PR TITLE
feat: add crisis engine fallback to behavior tree

### DIFF
--- a/src/ai/BehaviorTree.js
+++ b/src/ai/BehaviorTree.js
@@ -1,5 +1,7 @@
 import Blackboard from './Blackboard.js';
 import { debugLogEngine } from '../game/utils/DebugLogEngine.js';
+import { NodeState } from './nodes/Node.js';
+import ExecuteDesperateMeasureNode from './nodes/ExecuteDesperateMeasureNode.js';
 
 /**
  * 행동 트리와 블랙보드를 함께 캡슐화하는 클래스입니다.
@@ -31,7 +33,13 @@ class BehaviorTree {
         // --- ▲ [버그 수정] ▲ ---
 
         // 루트 노드부터 평가를 시작합니다.
-        await this.root.evaluate(unit, this.blackboard);
+        const result = await this.root.evaluate(unit, this.blackboard);
+
+        // 다른 모든 노드가 실패했을 경우 크라이시스 엔진에 의존합니다.
+        if (result === NodeState.FAILURE) {
+            const desperateNode = new ExecuteDesperateMeasureNode();
+            await desperateNode.evaluate(unit, this.blackboard);
+        }
     }
 }
 

--- a/src/ai/nodes/ExecuteDesperateMeasureNode.js
+++ b/src/ai/nodes/ExecuteDesperateMeasureNode.js
@@ -1,0 +1,50 @@
+import Node, { NodeState } from './Node.js';
+import { crisisEngine } from '../../game/utils/CrisisEngine.js';
+import { skillEngine } from '../../game/utils/SkillEngine.js';
+import { pathfinderEngine } from '../../game/utils/PathfinderEngine.js';
+
+/**
+ * 행동 트리의 다른 모든 노드가 실패했을 때 최후의 수단을 실행하는 노드.
+ * CrisisEngine을 호출하여 현재 상황에 가장 적합한 행동을 받아와 실행합니다.
+ */
+class ExecuteDesperateMeasureNode extends Node {
+    constructor() {
+        super();
+    }
+
+    async evaluate(unit, blackboard) {
+        const allies = blackboard.get('allyUnits') || [];
+        const enemies = blackboard.get('enemyUnits') || [];
+        const bestAction = crisisEngine.findBestDesperateMeasure(unit, allies, enemies);
+
+        if (!bestAction) {
+            // 크라이시스 엔진조차 할 일을 찾지 못하면 최종적으로 실패(대기) 처리
+            return NodeState.FAILURE;
+        }
+
+        // 크라이시스 엔진이 제안한 행동 실행
+        try {
+            switch (bestAction.type) {
+                case 'MOVE':
+                    await pathfinderEngine.moveUnitTo(unit, bestAction.target.col, bestAction.target.row);
+                    break;
+                case 'SKILL':
+                    console.log(`${unit.instanceName}이(가) ${bestAction.target.instanceName}에게 ${bestAction.skill.name} 스킬 사용!`);
+                    skillEngine.recordSkillUse(unit, bestAction.skill);
+                    // 임시로 이펙트만 표시
+                    const vfxManager = blackboard.get('vfxManager');
+                    if (vfxManager) {
+                        vfxManager.showSkillName(unit.sprite, bestAction.skill.name);
+                    }
+                    break;
+                // 추후 다른 타입의 행동 추가 가능
+            }
+            return NodeState.SUCCESS;
+        } catch (error) {
+            console.error('[ExecuteDesperateMeasureNode] 행동 실행 중 오류:', error);
+            return NodeState.FAILURE;
+        }
+    }
+}
+
+export default ExecuteDesperateMeasureNode;

--- a/src/game/utils/CrisisEngine.js
+++ b/src/game/utils/CrisisEngine.js
@@ -1,0 +1,81 @@
+import { pathfinderEngine } from './PathfinderEngine.js';
+import { skillEngine } from './SkillEngine.js';
+import { combatCalculationEngine } from './CombatCalculationEngine.js';
+import { formationEngine } from './FormationEngine.js';
+// TODO: MBTI 가중치 적용을 위한 아키타입 데이터는 추후 추가 예정
+// import { MBTI_ARCHETYPES } from '../../ai/mbti/MBTIArchetypes.js';
+
+/**
+ * AI가 일반적인 행동 트리로는 유효한 행동을 찾지 못했을 때,
+ * 최후의 수단(궁여지책)을 결정하는 엔진.
+ *
+ * 이 엔진은 현재 상황에서 가능한 모든 행동 조합(이동, 스킬)을 탐색하고,
+ * 4가지 핵심 철학(피해, 교란, 지원, 생존)에 따라 각 행동의 가치를 평가합니다.
+ * 마지막으로, 유닛의 MBTI 아키타입에 기반한 가중치를 적용하여
+ * 자신의 성향에 가장 잘 맞는 단 하나의 '최선의 수'를 결정합니다.
+ */
+class CrisisEngine {
+    constructor() {
+        this.name = 'CrisisEngine';
+    }
+
+    /**
+     * 현재 유닛에게 가장 적합한 '궁여지책'을 찾아 반환합니다.
+     * @param {object} unit - 행동을 결정할 유닛
+     * @param {object[]} allies - 모든 아군 유닛 배열
+     * @param {object[]} enemies - 모든 적군 유닛 배열
+     * @returns {object|null} - 결정된 최선의 행동 객체 또는 null
+     */
+    findBestDesperateMeasure(unit, allies, enemies) {
+        console.log(`%c[CrisisEngine] ${unit.instanceName}의 궁여지책 탐색 시작...`, "color: #e11d48; font-weight: bold;");
+
+        // 1. 가능한 모든 행동 생성 (이동, 스킬 사용 등)
+        const possibleActions = this._generateAllPossibleActions(unit, allies, enemies);
+        if (possibleActions.length === 0) {
+            console.log(`%c[CrisisEngine] 궁여지책으로 실행할 행동을 찾지 못했습니다.`, "color: #e11d48;");
+            return null;
+        }
+
+        // 2. 각 행동을 4대 철학에 따라 평가
+        const scoredActions = this._evaluateActions(possibleActions, unit, allies, enemies);
+
+        // 3. 유닛의 MBTI에 따라 최종 행동 결정
+        const bestAction = this._selectBestActionByMBTI(unit, scoredActions);
+        
+        console.log(`%c[CrisisEngine] 최종 결정: ${bestAction.description}`, "color: #e11d48; font-weight: bold;");
+
+        return bestAction;
+    }
+
+    /**
+     * 이동, 스킬 사용 등 현재 유닛이 수행할 수 있는 모든 행동의 목록을 생성합니다.
+     * @private
+     */
+    _generateAllPossibleActions(unit, allies, enemies) {
+        // TODO: 구현 예정
+        // 예: 이동 가능한 모든 타일, 사용 가능한 모든 스킬과 대상의 조합
+        return []; 
+    }
+
+    /**
+     * 생성된 행동 목록을 4대 행동 철학에 따라 점수를 매깁니다.
+     * @private
+     */
+    _evaluateActions(actions, unit, allies, enemies) {
+        // TODO: 구현 예정
+        // 각 행동에 대해 피해량, 힐량, 위치 이동 거리 등을 계산하여 점수 부여
+        return actions;
+    }
+
+    /**
+     * 점수가 매겨진 행동들 중에서 유닛의 MBTI 아키타입에 가장 적합한 행동을 선택합니다.
+     * @private
+     */
+    _selectBestActionByMBTI(unit, scoredActions) {
+        // TODO: 구현 예정
+        // MBTI 가중치를 적용하여 최종 점수가 가장 높은 행동을 선택
+        return scoredActions[0];
+    }
+}
+
+export const crisisEngine = new CrisisEngine();


### PR DESCRIPTION
## Summary
- add CrisisEngine utility for evaluating desperate actions
- introduce ExecuteDesperateMeasureNode to trigger CrisisEngine
- invoke fallback node from BehaviorTree when standard actions fail

## Testing
- `for f in tests/*_test.js; do echo "Running $f"; node $f; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68960234c60c832780ed65ac70163398