### PR TITLE
Add crisis fallback scoring and integrate desperate measures

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -39,6 +39,8 @@ import { createESFP_AI } from './behaviors/createESFP_AI.js';
 import { createENFJ_AI } from './behaviors/createENFJ_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
+import SelectorNode from './nodes/SelectorNode.js';
+import ExecuteDesperateMeasureNode from './nodes/ExecuteDesperateMeasureNode.js';
 
 /**
  * 게임 내 모든 AI 유닛을 관리하고, 각 유닛의 행동 트리를 실행합니다.
@@ -142,6 +144,13 @@ class AIManager {
         }
 
         const behaviorTree = behaviorTreeOverride || this._createAIFromArchetype(unitInstance);
+
+        // 모든 AI에 궁여지책을 최후의 수단으로 추가합니다.
+        behaviorTree.root = new SelectorNode([
+            behaviorTree.root,
+            new ExecuteDesperateMeasureNode()
+        ]);
+
         this.unitData.set(unitInstance.uniqueId, {
             instance: unitInstance,
             behaviorTree: behaviorTree,

--- a/src/game/utils/CrisisEngine.js
+++ b/src/game/utils/CrisisEngine.js
@@ -1,10 +1,10 @@
 import { pathfinderEngine } from './PathfinderEngine.js';
 import { skillEngine } from './SkillEngine.js';
 import { combatCalculationEngine } from './CombatCalculationEngine.js';
-import { formationEngine } from './FormationEngine.js';
 import { MBTI_ARCHETYPES } from '../../ai/mbti/MBTIArchetypes.js';
-// ✨ targetManager를 import하여 스킬 대상 탐색에 사용합니다.
 import { targetManager } from './TargetManager.js';
+import { yinYangEngine } from './YinYangEngine.js';
+import { statEngine } from './StatEngine.js';
 
 /**
  * AI가 일반적인 행동 트리로는 유효한 행동을 찾지 못했을 때,
@@ -20,98 +20,116 @@ class CrisisEngine {
         this.name = 'CrisisEngine';
     }
 
-    /**
-     * 현재 유닛에게 가장 적합한 '궁여지책'을 찾아 반환합니다.
-     * @param {object} unit - 행동을 결정할 유닛
-     * @param {object[]} allies - 모든 아군 유닛 배열
-     * @param {object[]} enemies - 모든 적군 유닛 배열
-     * @returns {object|null} - 결정된 최선의 행동 객체 또는 null
-     */
     findBestDesperateMeasure(unit, allies, enemies) {
         console.log(`%c[CrisisEngine] ${unit.instanceName}의 궁여지책 탐색 시작...`, "color: #e11d48; font-weight: bold;");
 
         const possibleActions = this._generateAllPossibleActions(unit, allies, enemies);
         if (possibleActions.length === 0) {
             console.log(`%c[CrisisEngine] 궁여지책으로 실행할 행동을 찾지 못했습니다.`);
-            return null; // 정말 할 수 있는 게 아무것도 없으면 null 반환
+            return null;
         }
 
         const scoredActions = this._evaluateActions(possibleActions, unit, allies, enemies);
         const bestAction = this._selectBestActionByMBTI(unit, scoredActions);
 
-        // bestAction이 null이 아닌지 확인 후 로그 출력
         if (bestAction && bestAction.description) {
-            console.log(`%c[CrisisEngine] 최종 결정: ${bestAction.description}`, "color: #e11d48; font-weight: bold;");
+            console.log(`%c[CrisisEngine] ${unit.instanceName}(${unit.mbti}) 최종 결정: ${bestAction.description} (최종 점수: ${bestAction.finalScore.toFixed(2)})`, "color: #e11d48; font-weight: bold;");
         } else {
             console.log(`%c[CrisisEngine] 최종 행동을 결정하지 못했습니다.`);
             return null;
         }
-        
+
         return bestAction;
     }
 
-    /**
-     * 이동, 스킬 사용 등 현재 유닛이 수행할 수 있는 모든 행동의 목록을 생성합니다.
-     * @private
-     */
     _generateAllPossibleActions(unit, allies, enemies) {
         const actions = [];
-
-        // --- 1. 이동 액션 생성 ---
         const reachableTiles = pathfinderEngine.findAllReachableTiles(unit);
         for (const tile of reachableTiles) {
-            // 자기 자신 위치로의 이동은 제외
             if (tile.col === unit.gridX && tile.row === unit.gridY) continue;
-
-            actions.push({
-                type: 'MOVE',
-                target: { col: tile.col, row: tile.row },
-                description: `(${tile.col}, ${tile.row}) 위치로 이동`
-            });
+            actions.push({ type: 'MOVE', target: { col: tile.col, row: tile.row }, description: `(${tile.col}, ${tile.row}) 위치로 이동` });
         }
-
-        // --- 2. 스킬 사용 액션 생성 ---
-        const availableSkills = unit.skills
-            .map(s => s.NORMAL || s) // 등급 객체가 있으면 일반 스킬 데이터를 가져옴
-            .filter(skill => skillEngine.canUseSkill(unit, skill));
-
+        const availableSkills = unit.skills.map(s => s.NORMAL || s).filter(skill => skillEngine.canUseSkill(unit, skill));
         for (const skill of availableSkills) {
-            // 스킬의 대상 규칙에 따라 유효한 대상들을 찾음
             const targets = targetManager.findTargets(unit, skill.targetType, skill.range, allies, enemies);
-
             for (const target of targets) {
-                // 스킬과 대상을 묶어 하나의 행동으로 추가
-                actions.push({
-                    type: 'SKILL',
-                    skill: skill,
-                    target: target,
-                    description: `[${target.instanceName}]에게 [${skill.name}] 스킬 사용`
-                });
+                actions.push({ type: 'SKILL', skill: skill, target: target, description: `[${target.instanceName}]에게 [${skill.name}] 스킬 사용` });
             }
         }
-        
         console.log(`[CrisisEngine] ${unit.instanceName}이(가) 수행 가능한 ${actions.length}가지 행동 발견.`);
         return actions;
     }
 
-    /**
-     * 생성된 행동 목록을 4대 행동 철학에 따라 점수를 매깁니다.
-     * @private
-     */
     _evaluateActions(actions, unit, allies, enemies) {
-        // TODO: 구현 예정
-        // 각 행동에 대해 피해량, 힐량, 위치 이동 거리 등을 계산하여 점수 부여
-        return actions;
+        return actions.map(action => {
+            const scores = { damage: 0, disruption: 0, support: 0, survival: 0 };
+            if (action.type === 'SKILL') {
+                const { skill, target } = action;
+                const { damage } = combatCalculationEngine.calculateDamage(unit, target, skill);
+                if (damage > 0 && target.team !== unit.team) {
+                    scores.damage = Math.min(damage, target.currentHp) * 1.5;
+                }
+                if (skill.healMultiplier) {
+                    const healAmount = statEngine.calculateHeal(unit, skill);
+                    scores.support = healAmount;
+                }
+                if (skill.yinYangChange) {
+                    const currentGauge = yinYangEngine.getGauge();
+                    const futureGauge = currentGauge + skill.yinYangChange;
+                    scores.disruption += Math.abs(50 - futureGauge) - Math.abs(50 - currentGauge);
+                }
+                if (skill.effect && (skill.effect.id === 'push' || skill.effect.id === 'pull')) {
+                    scores.disruption += 20;
+                }
+            } else if (action.type === 'MOVE') {
+                const { target } = action;
+                const currentSafety = this._calculateSafetyScore(unit.gridX, unit.gridY, enemies);
+                const futureSafety = this._calculateSafetyScore(target.col, target.row, enemies);
+                scores.survival = futureSafety - currentSafety;
+            }
+            return { ...action, scores };
+        });
     }
 
-    /**
-     * 점수가 매겨진 행동들 중에서 유닛의 MBTI 아키타입에 가장 적합한 행동을 선택합니다.
-     * @private
-     */
+    _calculateSafetyScore(col, row, enemies) {
+        if (enemies.length === 0) return 100;
+        let totalDistance = 0;
+        for (const enemy of enemies) {
+            totalDistance += pathfinderEngine.getDistance(col, row, enemy.gridX, enemy.gridY);
+        }
+        return totalDistance / enemies.length;
+    }
+
     _selectBestActionByMBTI(unit, scoredActions) {
-        // TODO: 구현 예정
-        // MBTI 가중치를 적용하여 최종 점수가 가장 높은 행동을 선택
-        return scoredActions[0];
+        let mbtiKey = unit.mbti;
+        if (typeof mbtiKey !== 'string' && mbtiKey) {
+            mbtiKey = (mbtiKey.E > mbtiKey.I ? 'E' : 'I') +
+                      (mbtiKey.S > mbtiKey.N ? 'S' : 'N') +
+                      (mbtiKey.T > mbtiKey.F ? 'T' : 'F') +
+                      (mbtiKey.J > mbtiKey.P ? 'J' : 'P');
+        }
+        const archetype = MBTI_ARCHETYPES[mbtiKey] || MBTI_ARCHETYPES['default'];
+        const weights = archetype && archetype.crisisWeights;
+
+        if (!weights) {
+            console.error(`[CrisisEngine] ${mbtiKey}에 대한 crisisWeights가 정의되지 않았습니다.`);
+            return scoredActions.length > 0 ? { ...scoredActions[0], finalScore: 0 } : null;
+        }
+
+        const weightedActions = scoredActions.map(action => {
+            const finalScore =
+                (action.scores.damage * weights.damage) +
+                (action.scores.disruption * weights.disruption) +
+                (action.scores.support * weights.support) +
+                (action.scores.survival * weights.survival);
+            return { ...action, finalScore };
+        });
+
+        if (weightedActions.length === 0) {
+            return null;
+        }
+
+        return weightedActions.reduce((best, current) => (current.finalScore > best.finalScore) ? current : best);
     }
 }
 

--- a/src/game/utils/StatEngine.js
+++ b/src/game/utils/StatEngine.js
@@ -184,6 +184,21 @@ class StatEngine {
     }
 
     /**
+     * 단일 스킬에 의해 회복되는 체력을 계산합니다.
+     * @param {object} unit - 힐을 시전하는 유닛
+     * @param {object} skill - 힐 스킬 데이터
+     * @returns {number} 계산된 힐량
+     */
+    calculateHeal(unit, skill) {
+        if (!skill || !skill.healMultiplier) return 0;
+        let healAmount = Math.round(unit.finalStats.wisdom * skill.healMultiplier);
+        if (unit.finalStats.healingGivenPercentage) {
+            healAmount = Math.round(healAmount * (1 + unit.finalStats.healingGivenPercentage / 100));
+        }
+        return healAmount;
+    }
+
+    /**
      * 기본 스탯, 장비 정보 등을 바탕으로 최종 적용될 스탯 객체를 생성합니다.
      * @param {object} unitData - 유닛의 기본 정보 (예: { name: '전사', baseWeight: 10 })
      * @param {object} baseStats - 순수 스탯 포인트 (예: { hp: 100, strength: 10, valor: 5 })


### PR DESCRIPTION
## Summary
- score desperate actions by damage, disruption, support, and survival values and pick using MBTI archetype weights
- allow AI units to fall back to a crisis move when standard behavior trees fail
- expose `calculateHeal` utility for estimating support action potency

## Testing
- `for f in tests/*_test.js; do node $f >/tmp/test.log && tail -n 20 /tmp/test.log; done`
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68962d7fada08327b131806d3c9ab738