### PR TITLE
Boost AI aggression with revised skill scores and fallbacks

### DIFF
--- a/src/ai/behaviors/createENFJ_AI.js
+++ b/src/ai/behaviors/createENFJ_AI.js
@@ -11,6 +11,7 @@ import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import FindPriorityTargetNode from '../nodes/FindPriorityTargetNode.js';
 import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
 import { SKILL_TAGS } from '../../game/utils/SkillTagManager.js';
 
 /**
@@ -53,6 +54,12 @@ function createENFJ_AI(engines = {}) {
         new SequenceNode([
             new FindBestSkillByScoreNode(engines),
             new FindTargetBySkillTypeNode(engines),
+            executeSkillBranch
+        ]),
+        // 4순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
             executeSkillBranch
         ])
     ]);

--- a/src/ai/behaviors/createENFP_AI.js
+++ b/src/ai/behaviors/createENFP_AI.js
@@ -65,6 +65,12 @@ function createENFP_AI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
+        ]),
+        // 5순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createENTJ_AI.js
+++ b/src/ai/behaviors/createENTJ_AI.js
@@ -11,6 +11,7 @@ import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import IsEarlyBattleNode from '../nodes/IsEarlyBattleNode.js';
 import FindStrategySkillNode from '../nodes/FindStrategySkillNode.js';
 import FindAllyClusterCenterNode from '../nodes/FindAllyClusterCenterNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
 
 /**
  * ENTJ: 통솔관 아키타입 행동 트리
@@ -53,6 +54,12 @@ function createENTJ_AI(engines = {}) {
             new FindTargetBySkillTypeNode(engines),
             executeSkillBranch
         ]),
+        // 4순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
+        ])
     ]);
 
     return new BehaviorTree(rootNode);

--- a/src/ai/behaviors/createENTP_AI.js
+++ b/src/ai/behaviors/createENTP_AI.js
@@ -70,6 +70,12 @@ function createENTP_AI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
+        ]),
+        // 6순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createESFP_AI.js
+++ b/src/ai/behaviors/createESFP_AI.js
@@ -9,6 +9,7 @@ import UseSkillNode from '../nodes/UseSkillNode.js';
 import HasNotMovedNode from '../nodes/HasNotMovedNode.js';
 import FindPathToSkillRangeNode from '../nodes/FindPathToSkillRangeNode.js';
 import FindEnemyClusterCenterNode from '../nodes/FindEnemyClusterCenterNode.js';
+import FindTargetNode from '../nodes/FindTargetNode.js';
 
 /**
  * ESFP: 자유로운 영혼의 연예인 아키타입 행동 트리 (다크나이트)
@@ -22,6 +23,17 @@ function createESFP_AI(engines = {}) {
     const useSkillImmediately = new SequenceNode([
         new IsSkillInRangeNode(engines),
         new UseSkillNode(engines)
+    ]);
+
+    const executeSkillBranch = new SelectorNode([
+        useSkillImmediately,
+        new SequenceNode([
+            new HasNotMovedNode(),
+            new FindPathToSkillRangeNode(engines),
+            new MoveToTargetNode(engines),
+            new IsSkillInRangeNode(engines),
+            new UseSkillNode(engines)
+        ])
     ]);
 
     const rootNode = new SelectorNode([
@@ -43,16 +55,13 @@ function createESFP_AI(engines = {}) {
         new SequenceNode([
             new FindBestSkillByScoreNode(engines),
             new FindTargetBySkillTypeNode(engines),
-            new SelectorNode([
-                useSkillImmediately, // 바로 공격 가능하면 공격
-                new SequenceNode([ // 아니면 이동 후 공격
-                    new HasNotMovedNode(),
-                    new FindPathToSkillRangeNode(engines),
-                    new MoveToTargetNode(engines),
-                    new IsSkillInRangeNode(engines),
-                    new UseSkillNode(engines)
-                ])
-            ])
+            executeSkillBranch
+        ]),
+        // 4순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createESTJ_AI.js
+++ b/src/ai/behaviors/createESTJ_AI.js
@@ -77,6 +77,12 @@ function createESTJ_AI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
+        ]),
+        // 4순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createESTP_AI.js
+++ b/src/ai/behaviors/createESTP_AI.js
@@ -63,6 +63,12 @@ function createESTP_AI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
+        ]),
+        // 5순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createINFJ_AI.js
+++ b/src/ai/behaviors/createINFJ_AI.js
@@ -75,6 +75,12 @@ function createINFJ_AI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
+        ]),
+        // 6순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createINFP_AI.js
+++ b/src/ai/behaviors/createINFP_AI.js
@@ -97,6 +97,12 @@ function createINFP_AI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
+        ]),
+        // 7순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createINTJ_AI.js
+++ b/src/ai/behaviors/createINTJ_AI.js
@@ -78,6 +78,12 @@ function createINTJ_AI(engines = {}) {
                 new FindSafeRepositionNode(engines),
                 new MoveToTargetNode(engines)
             ])
+        ]),
+        // 5순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createINTP_AI.js
+++ b/src/ai/behaviors/createINTP_AI.js
@@ -60,6 +60,12 @@ function createINTP_AI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
+        ]),
+        // 5순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createISFJ_AI.js
+++ b/src/ai/behaviors/createISFJ_AI.js
@@ -63,6 +63,12 @@ function createISFJ_AI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
+        ]),
+        // 5순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createISFP_AI.js
+++ b/src/ai/behaviors/createISFP_AI.js
@@ -84,6 +84,12 @@ function createISFP_AI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
+        ]),
+        // 6순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/ai/behaviors/createISTJ_AI.js
+++ b/src/ai/behaviors/createISTJ_AI.js
@@ -75,6 +75,12 @@ function createISTJ_AI(engines = {}) {
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
         ]),
+        // 6순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
+        ])
     ]);
 
     return new BehaviorTree(rootNode);

--- a/src/ai/behaviors/createISTP_AI.js
+++ b/src/ai/behaviors/createISTP_AI.js
@@ -65,6 +65,12 @@ function createISTP_AI(engines = {}) {
             new HasNotMovedNode(),
             new FindSafeRepositionNode(engines),
             new MoveToTargetNode(engines)
+        ]),
+        // 5순위: 모든 행동이 실패했다면 가까운 적에게 공격 시도
+        new SequenceNode([
+            new FindBestSkillByScoreNode(engines),
+            new FindTargetNode(engines),
+            executeSkillBranch
         ])
     ]);
 

--- a/src/game/data/skillScores.js
+++ b/src/game/data/skillScores.js
@@ -5,12 +5,13 @@
 
 // 스킬 타입별 기본 점수
 export const SCORE_BY_TYPE = {
-    ACTIVE: 2,
-    BUFF: 3,
-    DEBUFF: 2,
-    AID: 4,
-    SUMMON: 3,
-    STRATEGY: 3
+    // ACTIVE 점수를 다른 스킬과 비슷하거나 더 높게 설정하여 공격을 장려합니다.
+    ACTIVE: 5, // 기존 2점에서 5점으로 상향
+    BUFF: 4,   // 기존 3점에서 4점으로 상향
+    DEBUFF: 3, // 기존 2점에서 3점으로 상향
+    AID: 5,    // 기존 4점에서 5점으로 상향
+    SUMMON: 4, // 기존 3점에서 4점으로 상향
+    STRATEGY: 5 // 기존 3점에서 5점으로 상향
     // PASSIVE는 AI가 직접 사용하는 스킬이 아니므로 점수 계산에서 제외됩니다.
 };
 


### PR DESCRIPTION
## Summary
- Increase base scores for active, buff, debuff, aid, summon and strategy skill types to encourage offensive play
- Add a final attack fallback sequence to all MBTI behavior trees so units try one last strike when other actions fail

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689632ac930c8327a621dc7d5ffbed47