### PR TITLE
fix: guard against units without skills in CrisisEngine

### DIFF
--- a/src/game/utils/CrisisEngine.js
+++ b/src/game/utils/CrisisEngine.js
@@ -49,7 +49,11 @@ class CrisisEngine {
             if (tile.col === unit.gridX && tile.row === unit.gridY) continue;
             actions.push({ type: 'MOVE', target: { col: tile.col, row: tile.row }, description: `(${tile.col}, ${tile.row}) 위치로 이동` });
         }
-        const availableSkills = unit.skills.map(s => s.NORMAL || s).filter(skill => skillEngine.canUseSkill(unit, skill));
+        // 일부 유닛은 스킬 목록이 정의되지 않을 수 있으므로 안전하게 처리합니다.
+        const skills = Array.isArray(unit.skills) ? unit.skills : [];
+        const availableSkills = skills
+            .map(s => s && (s.NORMAL || s))
+            .filter(skill => skill && skillEngine.canUseSkill(unit, skill));
         for (const skill of availableSkills) {
             const targets = targetManager.findTargets(unit, skill.targetType, skill.range, allies, enemies);
             for (const target of targets) {


### PR DESCRIPTION
## Summary
- prevent CrisisEngine from crashing when a unit has no skills
- safely map and filter skills before generating actions

## Testing
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689638aebcdc8327baebae7db43f2e8c