### PR TITLE
fix: import FindBestSkillByScoreNode in ISTP AI

### DIFF
--- a/src/ai/behaviors/createISTP_AI.js
+++ b/src/ai/behaviors/createISTP_AI.js
@@ -14,6 +14,7 @@ import WasAttackedRecentlyNode from '../nodes/WasAttackedRecentlyNode.js';
 import FindAttackerNode from '../nodes/FindAttackerNode.js';
 import FindTargetNode from '../nodes/FindTargetNode.js';
 import FindPathToTargetNode from '../nodes/FindPathToTargetNode.js';
+import FindBestSkillByScoreNode from '../nodes/FindBestSkillByScoreNode.js';
 
 /**
  * ISTP: 만능 재주꾼 아키타입 행동 트리


### PR DESCRIPTION
## Summary
- import FindBestSkillByScoreNode in ISTP AI behavior

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68963de5a6ac832785755fec5b46056d