### PR TITLE
Clarify adrenaline shot target and refine AI target selection

### DIFF
--- a/src/ai/nodes/FindTargetBySkillTypeNode.js
+++ b/src/ai/nodes/FindTargetBySkillTypeNode.js
@@ -36,7 +36,7 @@ class FindTargetBySkillTypeNode extends Node {
                 const healthRatioB = b.currentHp / b.finalStats.hp;
                 return healthRatioA - healthRatioB;
             })[0];
-        } else if (targetType === 'enemy') {
+        } else if (targetType === 'enemy' || skillData.type === 'DEBUFF' || skillData.type === 'ACTIVE') {
             if (!enemyUnits || enemyUnits.length === 0) {
                 debugAIManager.logNodeResult(NodeState.FAILURE, "공격할 적 유닛 없음");
                 return NodeState.FAILURE;
@@ -76,7 +76,7 @@ class FindTargetBySkillTypeNode extends Node {
                     })[0];
                 }
             } else {
-                // 그 외(ACTIVE, DEBUFF 등)는 기존 로직대로 가장 가까운 적을 공격합니다.
+                // 그 외 스킬은 기존 로직대로 가장 가까운 적을 공격합니다.
                 if (!enemyUnits || enemyUnits.length === 0) {
                     debugAIManager.logNodeResult(NodeState.FAILURE, "공격할 적 유닛 없음");
                     return NodeState.FAILURE;

--- a/src/game/data/skills/active.js
+++ b/src/game/data/skills/active.js
@@ -1363,6 +1363,7 @@ export const activeSkills = {
             type: 'AID', // 지원 스킬이지만 액티브로도 분류 가능
             tags: [SKILL_TAGS.AID, SKILL_TAGS.BUFF],
             cost: 3,
+            // 대상을 '아군'으로 명확히 지정해 AI가 올바른 유닛을 선택하도록 합니다.
             targetType: 'ally',
             description: '아군 하나의 [둔화]와 [속박]을 즉시 해제하고, 2턴간 [아드레날린] 버프를 부여합니다.',
             illustrationPath: null,


### PR DESCRIPTION
## Summary
- Specify adrenaline shot as targeting allies to guide AI
- Improve FindTargetBySkillTypeNode to infer enemy targets for DEBUFF/ACTIVE skills

## Testing
- `node tests/medic_skill_integration_test.js`
- `node tests/status_effect_interaction_test.js`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68964271586883278c565d1a6370f7c2