### PR TITLE
Remove aspiration collapse state handling

### DIFF
--- a/src/game/utils/AspirationEngine.js
+++ b/src/game/utils/AspirationEngine.js
@@ -64,13 +64,8 @@ class AspirationEngine {
                 this._applyExaltedBuffs(unit);
                 debugAspirationManager.logStateChange(unit.instanceName, ASPIRATION_STATE.EXALTED);
             }
-        } else if (data.aspiration <= 0) {
-            data.state = ASPIRATION_STATE.COLLAPSED;
-            const unit = this.battleSimulator.turnQueue.find(u => u.uniqueId === unitId);
-            if (unit) {
-                debugAspirationManager.logStateChange(unit.instanceName, ASPIRATION_STATE.COLLAPSED);
-            }
         }
+        // ✨ [수정] 열망 붕괴 로직을 삭제했습니다.
     }
 
     _applyExaltedBuffs(unit) {


### PR DESCRIPTION
## Summary
- stop aspiration from transitioning to COLLAPSED
- keep EXALTED state behavior and logging

## Testing
- `for f in tests/*_test.js; do echo "Running $f"; node $f >/tmp/test.log && tail -n 5 /tmp/test.log; done`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &
  curl http://localhost:8000/debug.html | head -n 20
  kill %1 2>/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_689643221a0883279edbe3b0ce9e8289