### PR TITLE
feat: recover from invalid pathing results

### DIFF
--- a/tests/find_path_to_target_node_test.js
+++ b/tests/find_path_to_target_node_test.js
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import './setup-indexeddb.js';
+import FindPathToTargetNode from '../src/ai/nodes/FindPathToTargetNode.js';
+import Blackboard from '../src/ai/Blackboard.js';
+
+const mockPathfinderEngine = {
+    async findPath() {
+        return {}; // 잘못된 경로 형식 시뮬레이션
+    }
+};
+
+const mockFormationEngine = {
+    grid: {
+        rows: 3,
+        cols: 3,
+        getCell(col, row) {
+            return { col, row, isOccupied: false };
+        }
+    }
+};
+
+const node = new FindPathToTargetNode({ pathfinderEngine: mockPathfinderEngine, formationEngine: mockFormationEngine });
+
+const unit = { gridX: 0, gridY: 1, finalStats: { attackRange: 1 }, instanceName: '테스트유닛' };
+const target = { gridX: 2, gridY: 1, instanceName: '목표유닛' };
+
+const blackboard = new Blackboard();
+blackboard.set('currentTargetUnit', target);
+
+const result = await node.evaluate(unit, blackboard);
+const path = blackboard.get('movementPath');
+
+assert.strictEqual(result, 'SUCCESS');
+assert.ok(Array.isArray(path) && path.length === 1 && path[0].col === 1 && path[0].row === 1);
+
+console.log('✅ FindPathToTargetNode fallback path test passed');


### PR DESCRIPTION
## Summary
- fix FindPathToTargetNode to validate pathfinder output and step toward target when path is invalid
- add regression test for fallback path handling

## Testing
- `node tests/find_path_to_target_node_test.js`
- `node tests/pathfinder_flyingmen_bug_test.js`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6896473231d0832793408e286b06f23e