### PR TITLE
fix: handle missing skill name in logs

### DIFF
--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -120,7 +120,11 @@ class SkillEngine {
             cooldownManager.setCooldown(unit.uniqueId, skill.id, finalCooldown);
         }
 
-        debugLogEngine.log('SkillEngine', `${unit.instanceName}이(가) 스킬 [${skill.name}] 사용 (토큰 ${skill.cost} 소모).`);
+        const skillLabel = skill.name || skill.id || 'Unknown';
+        debugLogEngine.log(
+            'SkillEngine',
+            `${unit.instanceName}이(가) 스킬 [${skillLabel}] 사용 (토큰 ${skill.cost} 소모).`
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid `undefined` in skill usage logs by falling back to skill id

## Testing
- `for f in tests/*_test.js; do node $f >/tmp/test.log && tail -n 2 /tmp/test.log; done`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68964970a0e883278e7550e2990abf9e