### PR TITLE
feat: link combat engine to active battle

### DIFF
--- a/src/game/utils/BattleSimulatorEngine.js
+++ b/src/game/utils/BattleSimulatorEngine.js
@@ -149,6 +149,7 @@ export class BattleSimulatorEngine {
         sharedResourceEngine.initialize('ally');
         sharedResourceEngine.initialize('enemy');
         statusEffectManager.setBattleSimulator(this);
+        combatCalculationEngine.battleSimulator = this;
         // ✨ 전투 시작 시 음양 엔진을 초기화합니다.
         yinYangEngine.initializeUnits([...allies, ...enemies]);
 

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -36,6 +36,7 @@ class CombatCalculationEngine {
     // ✨ --- [핵심 버그 수정] 생성자와 name 속성 추가 --- ✨
     constructor() {
         this.name = 'CombatCalculationEngine';
+        this.battleSimulator = null;
         // 다른 엔진들과의 일관성을 위해 debugLogEngine에 등록할 수도 있습니다.
         debugLogEngine.register(this);
     }


### PR DESCRIPTION
## Summary
- store battle simulator reference in `CombatCalculationEngine`
- connect `BattleSimulatorEngine` to `combatCalculationEngine` at battle start

## Testing
- `for f in tests/*_test.js; do node $f; done`
- `node tests/combat_calculation_test.js >/tmp/combat.log && tail -n 20 /tmp/combat.log`
- `python3 -m http.server 8000 &` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689a19605a4483279284e07c238ed1cf