### PR TITLE
Add world map and leader movement engines

### DIFF
--- a/src/game/utils/LeaderEngine.js
+++ b/src/game/utils/LeaderEngine.js
@@ -1,0 +1,73 @@
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
+export class LeaderEngine {
+    /**
+     * @param {Phaser.Scene} scene 리더가 생성될 씬
+     * @param {WorldMapEngine} mapEngine 리더가 상호작용할 맵 엔진
+     */
+    constructor(scene, mapEngine) {
+        this.scene = scene;
+        this.mapEngine = mapEngine;
+        this.sprite = null;
+
+        // 리더의 현재 타일 좌표
+        this.tileX = 25;
+        this.tileY = 25;
+    }
+
+    /**
+     * 리더 스프라이트를 생성하고 초기 위치를 설정합니다.
+     */
+    create() {
+        const startX = this.mapEngine.map.tileToWorldX(this.tileX);
+        const startY = this.mapEngine.map.tileToWorldY(this.tileY);
+
+        this.sprite = this.scene.physics.add.sprite(startX, startY, 'leader-infp');
+        this.sprite.setDisplaySize(512, 512);
+
+        this.scene.cameras.main.startFollow(this.sprite, true, 0.08, 0.08);
+        this.scene.cameras.main.setZoom(0.3);
+    }
+
+    /**
+     * 지정된 방향으로 한 칸 이동합니다.
+     * @param {'up' | 'down' | 'left' | 'right'} direction
+     */
+    move(direction) {
+        let targetX = this.tileX;
+        let targetY = this.tileY;
+
+        switch (direction) {
+            case 'up':
+                targetY -= 1;
+                break;
+            case 'down':
+                targetY += 1;
+                break;
+            case 'left':
+                targetX -= 1;
+                break;
+            case 'right':
+                targetX += 1;
+                break;
+        }
+
+        if (targetX >= 0 && targetX < this.mapEngine.MAP_WIDTH_IN_TILES &&
+            targetY >= 0 && targetY < this.mapEngine.MAP_HEIGHT_IN_TILES) {
+            this.tileX = targetX;
+            this.tileY = targetY;
+
+            const worldX = this.mapEngine.map.tileToWorldX(this.tileX);
+            const worldY = this.mapEngine.map.tileToWorldY(this.tileY);
+
+            this.scene.tweens.add({
+                targets: this.sprite,
+                x: worldX,
+                y: worldY,
+                ease: 'Sine.easeInOut',
+                duration: 200
+            });
+        }
+    }
+}
+

--- a/src/game/utils/WorldMapEngine.js
+++ b/src/game/utils/WorldMapEngine.js
@@ -1,0 +1,56 @@
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
+export class WorldMapEngine {
+    /**
+     * @param {Phaser.Scene} scene 월드맵이 생성될 씬
+     */
+    constructor(scene) {
+        this.scene = scene;
+        this.map = null;
+        this.layer = null;
+
+        // 월드맵의 크기와 타일 크기 정의
+        this.MAP_WIDTH_IN_TILES = 50;
+        this.MAP_HEIGHT_IN_TILES = 50;
+        this.TILE_WIDTH = 512;
+        this.TILE_HEIGHT = 512;
+    }
+
+    /**
+     * 월드맵을 생성하고 랜덤 타일로 채웁니다.
+     */
+    create() {
+        // 비어있는 타일맵 객체 생성
+        this.map = this.scene.make.tilemap({
+            tileWidth: this.TILE_WIDTH,
+            tileHeight: this.TILE_HEIGHT,
+            width: this.MAP_WIDTH_IN_TILES,
+            height: this.MAP_HEIGHT_IN_TILES
+        });
+
+        // 사용할 타일셋 이미지 불러오기
+        const tileset = this.map.addTilesetImage(
+            'mab-tiles',
+            'mab-tile-1',
+            this.TILE_WIDTH,
+            this.TILE_HEIGHT,
+            0,
+            0
+        );
+
+        // 추가 타일 이미지를 타일셋에 등록
+        for (let i = 2; i <= 15; i++) {
+            tileset.addImage(this.scene.textures.get(`mab-tile-${i}`));
+        }
+
+        // 레이어 생성
+        this.layer = this.map.createBlankLayer('layer1', tileset, 0, 0);
+
+        // 맵 전체를 랜덤 타일로 채움
+        this.layer.randomize(0, 0, this.map.width, this.map.height, Array.from(Array(15).keys()));
+
+        // 카메라 경계 설정
+        this.scene.cameras.main.setBounds(0, 0, this.map.widthInPixels, this.map.heightInPixels);
+    }
+}
+

--- a/src/game/utils/WorldMapTurnEngine.js
+++ b/src/game/utils/WorldMapTurnEngine.js
@@ -1,0 +1,41 @@
+export class WorldMapTurnEngine {
+    /**
+     * @param {Phaser.Scene} scene
+     * @param {LeaderEngine} leaderEngine
+     */
+    constructor(scene, leaderEngine) {
+        this.scene = scene;
+        this.leader = leaderEngine;
+        this.isPlayerTurn = true;
+
+        this.setupKeyboardControls();
+    }
+
+    /**
+     * 키보드 방향키 입력을 설정합니다.
+     */
+    setupKeyboardControls() {
+        this.scene.input.keyboard.on('keydown-UP', () => this.handleMove('up'));
+        this.scene.input.keyboard.on('keydown-DOWN', () => this.handleMove('down'));
+        this.scene.input.keyboard.on('keydown-LEFT', () => this.handleMove('left'));
+        this.scene.input.keyboard.on('keydown-RIGHT', () => this.handleMove('right'));
+    }
+
+    /**
+     * 이동을 처리하고 턴을 넘깁니다.
+     * @param {'up' | 'down' | 'left' | 'right'} direction
+     */
+    handleMove(direction) {
+        if (!this.isPlayerTurn) return;
+
+        this.isPlayerTurn = false;
+        this.leader.move(direction);
+
+        this.scene.events.emit('turnTaken');
+
+        this.scene.time.delayedCall(200, () => {
+            this.isPlayerTurn = true;
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- build a WorldMapEngine to generate a random 50x50 tile map
- introduce LeaderEngine for map navigation and camera follow
- handle turn-based leader movement via WorldMapTurnEngine

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689a36b68eac8327a9774d658fa93ad7