### PR TITLE
feat: integrate world map scene and navigation

### DIFF
--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -35,6 +35,7 @@ export class TerritoryDOMEngine {
         // ✨ [신규] 장비 관리 아이콘을 추가합니다.
         this.addEquipmentManagementButton(1, 2); // 비어있는 (1, 2) 슬롯에 추가
         this.addArenaButton(0, 2); // 아레나 아이콘 추가
+        this.addWorldMapButton(2, 2); // 월드맵 아이콘 추가 (비어있는 2,2 위치)
     }
 
     createGrid() {
@@ -182,6 +183,22 @@ export class TerritoryDOMEngine {
         button.addEventListener('click', () => {
             this.container.style.display = 'none';
             this.scene.scene.start('ArenaScene');
+        });
+        this.grid.appendChild(button);
+    }
+
+    addWorldMapButton(col, row) {
+        const button = document.createElement('div');
+        button.className = 'building-icon';
+        // 월드맵 아이콘 이미지가 필요합니다. 여기서는 임시로 dungeon-icon을 재사용합니다.
+        button.style.backgroundImage = 'url(assets/images/territory/dungeon-icon.png)';
+        button.style.gridColumnStart = col + 1;
+        button.style.gridRowStart = row + 1;
+        button.addEventListener('mouseover', (event) => this.domEngine.showTooltip(event.clientX, event.clientY, '[월드맵]'));
+        button.addEventListener('mouseout', () => this.domEngine.hideTooltip());
+        button.addEventListener('click', () => {
+            this.container.style.display = 'none';
+            this.scene.scene.start('WorldMapScene');
         });
         this.grid.appendChild(button);
     }

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -19,6 +19,7 @@ import { SummonManagementScene } from './SummonManagementScene.js';
 import { EquipmentManagementScene } from './EquipmentManagementScene.js';
 import { ArenaScene } from './ArenaScene.js';
 import { ArenaBattleScene } from './ArenaBattleScene.js';
+import { WorldMapScene } from './WorldMapScene.js'; // 월드맵 씬 import 추가
 
 export class Boot extends Scene
 {
@@ -54,6 +55,7 @@ export class Boot extends Scene
         this.scene.add('EquipmentManagementScene', EquipmentManagementScene);
         this.scene.add('ArenaScene', ArenaScene);
         this.scene.add('ArenaBattleScene', ArenaBattleScene);
+        this.scene.add('WorldMapScene', WorldMapScene); // 월드맵 씬 추가
 
         this.scene.start('Preloader');
     }

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -172,6 +172,16 @@ export class Preloader extends Scene
         this.load.image('battle-stage-arena', 'images/battle/battle-stage-arena.png');
         this.load.image('battle-stage-cursed-forest', 'images/battle/battle-stage-cursed-forest.png');
 
+        // --- ▼ [신규] 월드맵 애셋 로드 ▼ ---
+        // 리더 스프라이트
+        this.load.image('leader-infp', 'images/leaders/infp.png');
+
+        // 월드맵 타일 (15개)
+        for (let i = 1; i <= 15; i++) {
+            this.load.image(`mab-tile-${i}`, `images/world-mab/mab-tile-${i}.png`);
+        }
+        // --- ▲ [신규] 월드맵 애셋 로드 ▲ ---
+
         // 몬스터 스프라이트 로드
         this.load.image('zombie', 'images/unit/zombie.png');
         // 소환수 스프라이트 로드

--- a/src/game/scenes/WorldMapScene.js
+++ b/src/game/scenes/WorldMapScene.js
@@ -1,0 +1,45 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { WorldMapEngine } from '../utils/WorldMapEngine.js';
+import { LeaderEngine } from '../utils/LeaderEngine.js';
+import { WorldMapTurnEngine } from '../utils/WorldMapTurnEngine.js';
+import { CameraControlEngine } from '../utils/CameraControlEngine.js';
+
+export class WorldMapScene extends Scene {
+    constructor() {
+        super('WorldMapScene');
+    }
+
+    create() {
+        // 다른 DOM 컨테이너 숨기기
+        const territoryContainer = document.getElementById('territory-container');
+        if (territoryContainer) {
+            territoryContainer.style.display = 'none';
+        }
+
+        // 1. 월드맵 엔진을 생성하고 맵을 만듭니다.
+        const mapEngine = new WorldMapEngine(this);
+        mapEngine.create();
+
+        // 2. 리더 엔진을 생성하고 플레이어 캐릭터를 만듭니다.
+        const leaderEngine = new LeaderEngine(this, mapEngine);
+        leaderEngine.create();
+        
+        // 3. 턴 엔진을 생성하여 키보드 입력을 처리합니다.
+        const turnEngine = new WorldMapTurnEngine(this, leaderEngine);
+
+        // 4. 카메라 드래그 및 줌 기능을 활성화합니다.
+        new CameraControlEngine(this);
+
+        // 'T' 키를 누르면 영지 씬으로 돌아가는 기능을 추가합니다.
+        this.input.keyboard.on('keydown-T', () => {
+            this.scene.start('TerritoryScene');
+        });
+        
+        // 씬이 종료될 때 DOM 요소를 정리하도록 이벤트를 설정합니다.
+        this.events.on('shutdown', () => {
+            if (territoryContainer) {
+                territoryContainer.style.display = 'block';
+            }
+        });
+    }
+}

--- a/src/game/utils/LeaderEngine.js
+++ b/src/game/utils/LeaderEngine.js
@@ -1,0 +1,28 @@
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
+/**
+ * 월드맵에서 플레이어 리더를 제어하는 엔진
+ */
+export class LeaderEngine {
+    constructor(scene, mapEngine) {
+        this.scene = scene;
+        this.mapEngine = mapEngine;
+        this.sprite = null;
+        this.position = { x: 0, y: 0 };
+    }
+
+    create() {
+        const { tileWidth, tileHeight } = this.mapEngine;
+        this.sprite = this.scene.add.sprite(tileWidth / 2, tileHeight / 2, 'leader-infp');
+        this.sprite.setDepth(100);
+    }
+
+    move(dx, dy) {
+        this.position.x += dx;
+        this.position.y += dy;
+        const { tileWidth, tileHeight } = this.mapEngine;
+        const x = this.position.x * tileWidth + tileWidth / 2;
+        const y = this.position.y * tileHeight + tileHeight / 2;
+        this.sprite.setPosition(x, y);
+    }
+}

--- a/src/game/utils/WorldMapEngine.js
+++ b/src/game/utils/WorldMapEngine.js
@@ -1,0 +1,39 @@
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
+/**
+ * 월드맵 타일을 배치하는 간단한 엔진
+ */
+export class WorldMapEngine {
+    /**
+     * @param {Phaser.Scene} scene
+     */
+    constructor(scene) {
+        this.scene = scene;
+        this.tileWidth = 0;
+        this.tileHeight = 0;
+    }
+
+    create() {
+        // 첫 번째 타일의 크기를 기반으로 타일 크기를 결정합니다.
+        const texture = this.scene.textures.get('mab-tile-1');
+        if (texture) {
+            const image = texture.getSourceImage();
+            this.tileWidth = image.width;
+            this.tileHeight = image.height;
+        } else {
+            this.tileWidth = 256;
+            this.tileHeight = 256;
+        }
+
+        let index = 1;
+        for (let y = 0; y < 3; y++) {
+            for (let x = 0; x < 5; x++) {
+                const key = `mab-tile-${index}`;
+                if (this.scene.textures.exists(key)) {
+                    this.scene.add.image(x * this.tileWidth, y * this.tileHeight, key).setOrigin(0);
+                }
+                index++;
+            }
+        }
+    }
+}

--- a/src/game/utils/WorldMapTurnEngine.js
+++ b/src/game/utils/WorldMapTurnEngine.js
@@ -1,0 +1,16 @@
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
+/**
+ * 월드맵에서 키보드 입력을 처리하는 간단한 턴 엔진
+ */
+export class WorldMapTurnEngine {
+    constructor(scene, leaderEngine) {
+        this.scene = scene;
+        this.leaderEngine = leaderEngine;
+
+        scene.input.keyboard.on('keydown-UP', () => this.leaderEngine.move(0, -1));
+        scene.input.keyboard.on('keydown-DOWN', () => this.leaderEngine.move(0, 1));
+        scene.input.keyboard.on('keydown-LEFT', () => this.leaderEngine.move(-1, 0));
+        scene.input.keyboard.on('keydown-RIGHT', () => this.leaderEngine.move(1, 0));
+    }
+}


### PR DESCRIPTION
## Summary
- load world map tiles and leader sprites in Preloader
- register WorldMapScene and launchable button from territory UI
- add basic world map scene with map, leader and keyboard movement engines

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689a372959708327975333fef197f0a0