### PR TITLE
feat: integrate world map scene

### DIFF
--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -35,6 +35,7 @@ export class TerritoryDOMEngine {
         // ✨ [신규] 장비 관리 아이콘을 추가합니다.
         this.addEquipmentManagementButton(1, 2); // 비어있는 (1, 2) 슬롯에 추가
         this.addArenaButton(0, 2); // 아레나 아이콘 추가
+        this.addWorldMapButton(2, 2); // 월드맵 아이콘 추가 (비어있는 2,2 위치)
     }
 
     createGrid() {
@@ -182,6 +183,22 @@ export class TerritoryDOMEngine {
         button.addEventListener('click', () => {
             this.container.style.display = 'none';
             this.scene.scene.start('ArenaScene');
+        });
+        this.grid.appendChild(button);
+    }
+
+    addWorldMapButton(col, row) {
+        const button = document.createElement('div');
+        button.className = 'building-icon';
+        // 월드맵 아이콘 이미지가 필요합니다. 여기서는 임시로 dungeon-icon을 재사용합니다.
+        button.style.backgroundImage = 'url(assets/images/territory/dungeon-icon.png)';
+        button.style.gridColumnStart = col + 1;
+        button.style.gridRowStart = row + 1;
+        button.addEventListener('mouseover', (event) => this.domEngine.showTooltip(event.clientX, event.clientY, '[월드맵]'));
+        button.addEventListener('mouseout', () => this.domEngine.hideTooltip());
+        button.addEventListener('click', () => {
+            this.container.style.display = 'none';
+            this.scene.scene.start('WorldMapScene');
         });
         this.grid.appendChild(button);
     }

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -19,6 +19,7 @@ import { SummonManagementScene } from './SummonManagementScene.js';
 import { EquipmentManagementScene } from './EquipmentManagementScene.js';
 import { ArenaScene } from './ArenaScene.js';
 import { ArenaBattleScene } from './ArenaBattleScene.js';
+import { WorldMapScene } from './WorldMapScene.js'; // 월드맵 씬 import 추가
 
 export class Boot extends Scene
 {
@@ -54,6 +55,7 @@ export class Boot extends Scene
         this.scene.add('EquipmentManagementScene', EquipmentManagementScene);
         this.scene.add('ArenaScene', ArenaScene);
         this.scene.add('ArenaBattleScene', ArenaBattleScene);
+        this.scene.add('WorldMapScene', WorldMapScene); // 월드맵 씬 추가
 
         this.scene.start('Preloader');
     }

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -118,6 +118,15 @@ export class Preloader extends Scene
         this.load.image('cursed-forest', 'images/territory/cursed-forest.png');
         this.load.image('formation-icon', 'images/territory/formation-icon.png');
         this.load.image('arena-icon', 'images/territory/arena-icon.png');
+        // --- ▼ [신규] 월드맵 애셋 로드 ▼ ---
+        // 리더 스프라이트
+        this.load.image('leader-infp', 'images/leaders/infp.png');
+
+        // 월드맵 타일 (15개)
+        for (let i = 1; i <= 15; i++) {
+            this.load.image(`mab-tile-${i}`, `images/world-mab/mab-tile-${i}.png`);
+        }
+        // --- ▲ [신규] 월드맵 애셋 로드 ▲ ---
         // --- 스킬 관리 아이콘 및 씬 배경 로드 ---
         this.load.image('skills-icon', 'images/territory/skills-icon.png');
         this.load.image('skills-scene-background', 'images/territory/skills-scene.png');

--- a/src/game/scenes/WorldMapScene.js
+++ b/src/game/scenes/WorldMapScene.js
@@ -1,0 +1,45 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { WorldMapEngine } from '../utils/WorldMapEngine.js';
+import { LeaderEngine } from '../utils/LeaderEngine.js';
+import { WorldMapTurnEngine } from '../utils/WorldMapTurnEngine.js';
+import { CameraControlEngine } from '../utils/CameraControlEngine.js';
+
+export class WorldMapScene extends Scene {
+    constructor() {
+        super('WorldMapScene');
+    }
+
+    create() {
+        // 다른 DOM 컨테이너 숨기기
+        const territoryContainer = document.getElementById('territory-container');
+        if (territoryContainer) {
+            territoryContainer.style.display = 'none';
+        }
+
+        // 1. 월드맵 엔진을 생성하고 맵을 만듭니다.
+        const mapEngine = new WorldMapEngine(this);
+        mapEngine.create();
+
+        // 2. 리더 엔진을 생성하고 플레이어 캐릭터를 만듭니다.
+        const leaderEngine = new LeaderEngine(this, mapEngine);
+        leaderEngine.create();
+        
+        // 3. 턴 엔진을 생성하여 키보드 입력을 처리합니다.
+        new WorldMapTurnEngine(this, leaderEngine);
+
+        // 4. 카메라 드래그 및 줌 기능을 활성화합니다.
+        new CameraControlEngine(this);
+
+        // 'T' 키를 누르면 영지 씬으로 돌아가는 기능을 추가합니다.
+        this.input.keyboard.on('keydown-T', () => {
+            this.scene.start('TerritoryScene');
+        });
+        
+        // 씬이 종료될 때 DOM 요소를 정리하도록 이벤트를 설정합니다.
+        this.events.on('shutdown', () => {
+            if (territoryContainer) {
+                territoryContainer.style.display = 'block';
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Add WorldMapScene to combine map, leader and camera engines
- Load world map tiles and leader sprite in Preloader
- Register world map scene and DOM entry button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689a41a7b9648327b13889cace8e777c