### PR TITLE
refactor: switch world map to image tiles

### DIFF
--- a/src/game/utils/LeaderEngine.js
+++ b/src/game/utils/LeaderEngine.js
@@ -1,5 +1,9 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
+/**
+ * 월드 맵에서 플레이어 리더를 제어하는 엔진.
+ * WorldMapEngine이 타일맵을 사용하지 않으므로 좌표 계산도 직접 수행합니다.
+ */
 export class LeaderEngine {
     /**
      * @param {Phaser.Scene} scene 리더가 생성될 씬
@@ -10,17 +14,18 @@ export class LeaderEngine {
         this.mapEngine = mapEngine;
         this.sprite = null;
 
-        // 리더의 현재 타일 좌표
-        this.tileX = 25;
-        this.tileY = 25;
+        // 맵의 중앙에서 시작합니다.
+        this.tileX = Math.floor(mapEngine.MAP_WIDTH_IN_TILES / 2);
+        this.tileY = Math.floor(mapEngine.MAP_HEIGHT_IN_TILES / 2);
     }
 
     /**
      * 리더 스프라이트를 생성하고 초기 위치를 설정합니다.
      */
     create() {
-        const startX = this.mapEngine.map.tileToWorldX(this.tileX);
-        const startY = this.mapEngine.map.tileToWorldY(this.tileY);
+        // 타일 좌표를 월드 좌표로 직접 계산합니다.
+        const startX = this.tileX * this.mapEngine.TILE_WIDTH + this.mapEngine.TILE_WIDTH / 2;
+        const startY = this.tileY * this.mapEngine.TILE_HEIGHT + this.mapEngine.TILE_HEIGHT / 2;
 
         this.sprite = this.scene.physics.add.sprite(startX, startY, 'leader-infp');
         this.sprite.setDisplaySize(512, 512);
@@ -50,6 +55,8 @@ export class LeaderEngine {
             case 'right':
                 targetX += 1;
                 break;
+            default:
+                break;
         }
 
         if (targetX >= 0 && targetX < this.mapEngine.MAP_WIDTH_IN_TILES &&
@@ -57,15 +64,16 @@ export class LeaderEngine {
             this.tileX = targetX;
             this.tileY = targetY;
 
-            const worldX = this.mapEngine.map.tileToWorldX(this.tileX);
-            const worldY = this.mapEngine.map.tileToWorldY(this.tileY);
+            // 이동할 월드 좌표를 계산합니다.
+            const worldX = this.tileX * this.mapEngine.TILE_WIDTH + this.mapEngine.TILE_WIDTH / 2;
+            const worldY = this.tileY * this.mapEngine.TILE_HEIGHT + this.mapEngine.TILE_HEIGHT / 2;
 
             this.scene.tweens.add({
                 targets: this.sprite,
                 x: worldX,
                 y: worldY,
                 ease: 'Sine.easeInOut',
-                duration: 200
+                duration: 200,
             });
         }
     }

--- a/src/game/utils/WorldMapEngine.js
+++ b/src/game/utils/WorldMapEngine.js
@@ -1,58 +1,49 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
+/**
+ * 간단한 월드 맵 엔진. Tilemap API 대신 각 타일을 이미지로 직접 배치합니다.
+ */
 export class WorldMapEngine {
     /**
      * @param {Phaser.Scene} scene 월드맵이 생성될 씬
      */
     constructor(scene) {
         this.scene = scene;
-        this.map = null;
-        this.layer = null;
+        this.tiles = []; // 배치된 타일 스프라이트를 저장할 배열
 
-        // 월드맵의 크기와 타일 크기를 정의합니다.
-        this.MAP_WIDTH_IN_TILES = 50;
-        this.MAP_HEIGHT_IN_TILES = 50;
+        // 사용자 요청에 따라 맵 크기를 20x20으로 조정합니다.
+        this.MAP_WIDTH_IN_TILES = 20;
+        this.MAP_HEIGHT_IN_TILES = 20;
         this.TILE_WIDTH = 512;
         this.TILE_HEIGHT = 512;
+
+        this.widthInPixels = this.MAP_WIDTH_IN_TILES * this.TILE_WIDTH;
+        this.heightInPixels = this.MAP_HEIGHT_IN_TILES * this.TILE_HEIGHT;
     }
 
     /**
      * 월드맵을 생성하고 랜덤 타일로 채웁니다.
      */
     create() {
-        this.map = this.scene.make.tilemap({
-            tileWidth: this.TILE_WIDTH,
-            tileHeight: this.TILE_HEIGHT,
-            width: this.MAP_WIDTH_IN_TILES,
-            height: this.MAP_HEIGHT_IN_TILES
-        });
-
-        // --- ▼ [핵심 수정] 타일셋 추가 및 타일 배치 로직 변경 ▼ ---
-
-        // 1. 사용할 모든 타일 이미지 키를 기반으로 타일셋들을 생성합니다.
-        const tilesets = [];
+        const tileImageKeys = [];
         for (let i = 1; i <= 15; i++) {
-            const key = `mab-tile-${i}`;
-            // 각 이미지를 별도의 타일셋으로 추가합니다.
-            tilesets.push(this.map.addTilesetImage(key, key, this.TILE_WIDTH, this.TILE_HEIGHT, 0, 0));
+            tileImageKeys.push(`mab-tile-${i}`);
         }
 
-        // 2. 'layer1'이라는 이름으로 빈 레이어를 생성합니다.
-        this.layer = this.map.createBlankLayer('layer1', tilesets, 0, 0);
+        for (let y = 0; y < this.MAP_HEIGHT_IN_TILES; y++) {
+            for (let x = 0; x < this.MAP_WIDTH_IN_TILES; x++) {
+                const randomKey = Phaser.Math.RND.pick(tileImageKeys);
+                const tileX = x * this.TILE_WIDTH;
+                const tileY = y * this.TILE_HEIGHT;
 
-        // 3. randomize 대신 putTileAt을 사용하여 각 칸에 직접 타일을 채웁니다.
-        //    이것이 여러 개의 개별 타일셋을 사용할 때 더 안정적인 방법입니다.
-        for (let y = 0; y < this.map.height; y++) {
-            for (let x = 0; x < this.map.width; x++) {
-                // 1번부터 15번까지의 타일 인덱스 중 하나를 무작위로 선택합니다.
-                const randomTileIndex = Phaser.Math.Between(1, 15);
-                this.map.putTileAt(randomTileIndex, x, y, true, this.layer);
+                // 각 타일을 Scene에 직접 이미지로 추가하고 원점에 맞게 배치합니다.
+                const tile = this.scene.add.image(tileX, tileY, randomKey).setOrigin(0, 0);
+                this.tiles.push(tile);
             }
         }
 
-        // --- ▲ [핵심 수정] 완료 ▲ ---
-
-        this.scene.cameras.main.setBounds(0, 0, this.map.widthInPixels, this.map.heightInPixels);
+        // 카메라 경계를 설정합니다.
+        this.scene.cameras.main.setBounds(0, 0, this.widthInPixels, this.heightInPixels);
     }
 }
 


### PR DESCRIPTION
## Summary
- replace tilemap-based world map with direct image placement
- update leader engine to compute positions without tilemap

## Testing
- `for f in tests/*test.js; do node "$f" >/tmp/test.log && tail -n 5 /tmp/test.log; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_689af23189d4832789716395de616dd2