### PR TITLE
feat: add behavior tree factory and update AI manager

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -1,11 +1,8 @@
-import { createBehaviorTree } from './behaviors/createBehaviorTree';
+import { createBehaviorTree } from './behaviors/createBehaviorTree.js'; // .js 확장자 추가!
 
 /**
  * AI 로직을 총괄하는 관리자입니다.
  * 모든 유닛의 행동을 결정하고 실행을 요청합니다.
- * * [변경점]
- * - 이제 특정 유닛 하나가 아닌, 모든 유닛의 행동을 관리합니다.
- * - GlobalTurnClock의 신호를 받아 동시에 모든 유닛의 행동을 결정합니다.
  */
 export class AIManager {
     constructor(scene, allUnits, gridEngine, battleEngine) {
@@ -25,7 +22,7 @@ export class AIManager {
     }
 
     /**
-     * [신규] 새로운 글로벌 턴이 시작될 때 호출될 메소드입니다.
+     * 새로운 글로벌 턴이 시작될 때 호출될 메소드입니다.
      * 살아있는 모든 유닛의 행동을 결정하고 BattleEngine에 실행을 요청합니다.
      */
     decideAndRequestActions() {
@@ -44,26 +41,22 @@ export class AIManager {
                 const action = behaviorTree.blackboard.get('chosenAction');
 
                 if (action) {
-                    console.log(`[AIManager] ${unit.name}(${unit.id})의 행동:`, action);
                     allActions.push(action);
                 } else {
-                    // 행동이 결정되지 않은 경우, 기본적으로 '대기' 행동을 추가할 수 있습니다.
-                    console.log(`[AIManager] ${unit.name}(${unit.id})는 행동을 결정하지 못했습니다. 대기합니다.`);
+                    // 행동이 결정되지 않은 경우, 기본적으로 '대기' 행동을 추가합니다.
                     allActions.push({ type: 'wait', unit });
                 }
             }
         });
 
         // 결정된 모든 행동을 BattleEngine에 넘겨 동시에 처리하도록 합니다.
-        // 이 부분은 다음 단계에서 BattleEngine을 수정하면서 완성될 것입니다.
+        // 다음 단계에서 이 부분의 주석을 풀고 실제로 작동시킬 것입니다.
         // this.battleEngine.executeMultipleActions(allActions); 
+        console.log('[AIManager] 결정된 행동 목록:', allActions);
     }
 
     // 기존의 requestActionFor 메소드는 이제 사용되지 않습니다.
-    // 하지만 나중에 참고할 수 있도록 일단 남겨둡니다.
     requestActionFor(unit) {
-        // 이 함수는 이전 턴제 시스템에서 사용되었습니다.
         console.warn('[AIManager] requestActionFor는 더 이상 사용되지 않는 함수입니다.');
     }
 }
-

--- a/src/ai/behaviors/createBehaviorTree.js
+++ b/src/ai/behaviors/createBehaviorTree.js
@@ -1,0 +1,53 @@
+import { createISTJ_AI } from './createISTJ_AI.js';
+import { createISFJ_AI } from './createISFJ_AI.js';
+import { createINFJ_AI } from './createINFJ_AI.js';
+import { createINTJ_AI } from './createINTJ_AI.js';
+import { createISTP_AI } from './createISTP_AI.js';
+import { createISFP_AI } from './createISFP_AI.js';
+import { createINFP_AI } from './createINFP_AI.js';
+import { createINTP_AI } from './createINTP_AI.js';
+import { createESTP_AI } from './createESTP_AI.js';
+import { createESFP_AI } from './createESFP_AI.js';
+import { createENFP_AI } from './createENFP_AI.js';
+import { createENTP_AI } from './createENTP_AI.js';
+import { createESTJ_AI } from './createESTJ_AI.js';
+import { createESFJ_AI } from './createESFJ_AI.js';
+import { createENFJ_AI } from './createENFJ_AI.js';
+import { createENTJ_AI } from './createENTJ_AI.js';
+import { createFlyingmanAI } from './createFlyingmanAI.js';
+
+/**
+ * 유닛의 MBTI 유형에 따라 적절한 행동 트리를 생성하고 반환하는 공장 함수입니다.
+ * @param {string} mbti - 유닛의 MBTI 유형 (예: 'ISTJ')
+ * @param {Unit} unit - 행동 트리의 주체가 될 유닛
+ * @param {Phaser.Scene} scene - 현재 씬
+ * @param {AIManager} aiManager - AI 관리자
+ * @returns {BehaviorTree} 생성된 행동 트리
+ */
+export function createBehaviorTree(mbti, unit, scene, aiManager) {
+    // 유닛의 mbti 값에 따라 적절한 AI 생성 함수를 호출합니다.
+    switch (mbti) {
+        case 'ISTJ': return createISTJ_AI(unit, scene, aiManager);
+        case 'ISFJ': return createISFJ_AI(unit, scene, aiManager);
+        case 'INFJ': return createINFJ_AI(unit, scene, aiManager);
+        case 'INTJ': return createINTJ_AI(unit, scene, aiManager);
+        case 'ISTP': return createISTP_AI(unit, scene, aiManager);
+        case 'ISFP': return createISFP_AI(unit, scene, aiManager);
+        case 'INFP': return createINFP_AI(unit, scene, aiManager);
+        case 'INTP': return createINTP_AI(unit, scene, aiManager);
+        case 'ESTP': return createESTP_AI(unit, scene, aiManager);
+        case 'ESFP': return createESFP_AI(unit, scene, aiManager);
+        case 'ENFP': return createENFP_AI(unit, scene, aiManager);
+        case 'ENTP': return createENTP_AI(unit, scene, aiManager);
+        case 'ESTJ': return createESTJ_AI(unit, scene, aiManager);
+        case 'ESFJ': return createESFJ_AI(unit, scene, aiManager);
+        case 'ENFJ': return createENFJ_AI(unit, scene, aiManager);
+        case 'ENTJ': return createENTJ_AI(unit, scene, aiManager);
+        // MBTI가 아닌 특수 유닛 처리
+        case 'Flyingman': return createFlyingmanAI(unit, scene, aiManager);
+        default:
+            console.warn(`[AI Factory] 알 수 없는 MBTI (${mbti}) 입니다. 기본 AI를 사용합니다.`);
+            // 어떤 경우에도 대응할 수 있도록 기본 AI(예: ESTJ)를 반환합니다.
+            return createESTJ_AI(unit, scene, aiManager);
+    }
+}


### PR DESCRIPTION
## Summary
- add MBTI-based behavior tree factory for choosing AI implementations
- update AIManager to import factory with .js extension and log chosen actions

## Testing
- `npm test` (fails: Missing script)
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689b3751aca08327b79d5e74e80bc424