### PR TITLE
fix: remove nonexistent Unit import in SummoningEngine

### DIFF
--- a/src/game/utils/SummoningEngine.js
+++ b/src/game/utils/SummoningEngine.js
@@ -1,5 +1,11 @@
-import { Unit } from '../data/Unit';
 import { createBehaviorTree } from '../../ai/behaviors/createBehaviorTree.js';
+
+/**
+ * @typedef {Object} Unit
+ * @property {string} id - 유닛의 고유 식별자
+ * @property {string} name - 유닛 이름
+ * @property {string} mbti - AI 행동 트리를 결정하는 MBTI
+ */
 
 /**
  * 소환수 관련 로직을 처리하는 엔진입니다.


### PR DESCRIPTION
## Summary
- remove missing Unit import from `SummoningEngine.js`
- define lightweight Unit typedef to document required fields

## Testing
- `node tests/class_passive_integration_test.js` *(fails: The requested module '../src/ai/AIManager.js' does not provide an export named 'aiManager')*
- `for f in tests/*.js; do node "$f"; done`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689b3bee811883279010cc9612ce5e3a