### PR TITLE
fix: adapt AI manager instantiation

### DIFF
--- a/tests/class_passive_integration_test.js
+++ b/tests/class_passive_integration_test.js
@@ -18,7 +18,6 @@ import SkillEffectProcessor from '../src/game/utils/SkillEffectProcessor.js';
 import { SummoningEngine } from '../src/game/utils/SummoningEngine.js';
 import { formationEngine } from '../src/game/utils/FormationEngine.js';
 import { monsterEngine } from '../src/game/utils/MonsterEngine.js';
-import { aiManager } from '../src/ai/AIManager.js';
 import { TerminationManager } from '../src/game/utils/TerminationManager.js';
 console.log('--- 클래스 전용 패시브 통합 테스트 시작 ---');
 


### PR DESCRIPTION
## Summary
- refactor `AIManager` with unit registration, clearing, and turn execution helpers
- instantiate `AIManager` inside `BattleSimulatorEngine` instead of importing missing singleton
- drop unused AI manager import from integration test

## Testing
- `node tests/class_passive_integration_test.js`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689b3f4c44648327acd33ba04b3429cb