### PR TITLE
Use shared combat calculation engine in BattleEngine

### DIFF
--- a/src/game/utils/BattleEngine.js
+++ b/src/game/utils/BattleEngine.js
@@ -1,5 +1,5 @@
 import { SkillEngine } from './SkillEngine.js';
-import { CombatCalculationEngine } from './CombatCalculationEngine.js';
+import { combatCalculationEngine } from './CombatCalculationEngine.js';
 import { StatusEffectManager } from './StatusEffectManager.js';
 import { SummoningEngine } from './SummoningEngine.js';
 
@@ -26,7 +26,8 @@ export class BattleEngine {
         this.aiManager = aiManager; // [변경점] aiManager 저장
 
         // 다른 엔진들에게도 필요한 부품들을 전달하며 생성합니다.
-        this.combatCalculationEngine = new CombatCalculationEngine(this.gridEngine);
+        // CombatCalculationEngine은 싱글턴 인스턴스를 사용합니다.
+        this.combatCalculationEngine = combatCalculationEngine;
         this.statusEffectManager = new StatusEffectManager(this.scene, this.allUnits, this.combatUIManager);
         this.summoningEngine = new SummoningEngine(this.scene, this.allUnits, this.spriteEngine, this.combatUIManager, this.aiManager); // [변경점] aiManager 전달
         this.skillEngine = new SkillEngine(this, this.gridEngine, this.combatCalculationEngine, this.statusEffectManager, this.summoningEngine, this.animationEngine, this.combatUIManager);


### PR DESCRIPTION
## Summary
- Fix BattleEngine to import the shared `combatCalculationEngine` instance
- Avoid creating a new CombatCalculationEngine and reuse the singleton

## Testing
- `for f in tests/*_test.js; do echo Running $f; node $f; done`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689b41b4ed288327b35a7408164a4b6f