### PR TITLE
fix: export SkillEngine class

### DIFF
--- a/src/game/utils/SkillEngine.js
+++ b/src/game/utils/SkillEngine.js
@@ -23,7 +23,7 @@ export const SKILL_TYPES = {
 /**
  * 용병의 스킬 사용, 우선순위 결정 등 스킬 관련 로직을 총괄하는 엔진
  */
-class SkillEngine {
+export class SkillEngine {
     constructor() {
         this.skillTypes = Object.keys(SKILL_TYPES);
         // ✨ 한 턴 동안 유닛별로 사용한 스킬을 추적합니다


### PR DESCRIPTION
## Summary
- export `SkillEngine` class so BattleEngine can import it

## Testing
- `node tests/class_passive_integration_test.js`
- `node tests/warrior_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689b451939b88327b87f18490243de0d