### PR TITLE
fix: use singleton status effect manager

### DIFF
--- a/src/game/utils/BattleEngine.js
+++ b/src/game/utils/BattleEngine.js
@@ -1,6 +1,6 @@
 import { SkillEngine } from './SkillEngine.js';
 import { combatCalculationEngine } from './CombatCalculationEngine.js';
-import { StatusEffectManager } from './StatusEffectManager.js';
+import { statusEffectManager } from './StatusEffectManager.js';
 import { SummoningEngine } from './SummoningEngine.js';
 
 /**
@@ -28,7 +28,8 @@ export class BattleEngine {
         // 다른 엔진들에게도 필요한 부품들을 전달하며 생성합니다.
         // CombatCalculationEngine은 싱글턴 인스턴스를 사용합니다.
         this.combatCalculationEngine = combatCalculationEngine;
-        this.statusEffectManager = new StatusEffectManager(this.scene, this.allUnits, this.combatUIManager);
+        // 상태 효과 매니저는 싱글턴을 사용합니다.
+        this.statusEffectManager = statusEffectManager;
         this.summoningEngine = new SummoningEngine(this.scene, this.allUnits, this.spriteEngine, this.combatUIManager, this.aiManager); // [변경점] aiManager 전달
         this.skillEngine = new SkillEngine(this, this.gridEngine, this.combatCalculationEngine, this.statusEffectManager, this.summoningEngine, this.animationEngine, this.combatUIManager);
     }


### PR DESCRIPTION
## Summary
- use exported `statusEffectManager` singleton in `BattleEngine`

## Testing
- `for f in tests/*_test.js; do node $f; done > tests.log && tail -n 20 tests.log`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689b47e8bee08327a2eb3129b2431551